### PR TITLE
Miscellaneous fixes around qvm-ls

### DIFF
--- a/qubesadmin/tests/tools/qvm_ls.py
+++ b/qubesadmin/tests/tools/qvm_ls.py
@@ -82,9 +82,9 @@ class TC_50_List(qubesadmin.tests.QubesTestCase):
         with qubesadmin.tests.tools.StdoutBuffer() as stdout:
             qubesadmin.tools.qvm_ls.main([], app=app)
         self.assertEqual(stdout.getvalue(),
-            'NAME     STATUS    LABEL  TEMPLATE  NETVM\n'
-            'dom0     -r------  black  -         -\n'
-            'test-vm  -r------  green  template  sys-net\n')
+            'NAME     STATE    CLASS   LABEL  TEMPLATE  NETVM\n'
+            'dom0     Running  TestVM  black  -         -\n'
+            'test-vm  Running  TestVM  green  template  sys-net\n')
 
 
 class TC_90_List_with_qubesd_calls(qubesadmin.tests.QubesTestCase):
@@ -110,13 +110,7 @@ class TC_90_List_with_qubesd_calls(qubesadmin.tests.QubesTestCase):
             'label': b'type=label green',
             'template': b'type=vm template1',
             'netvm': b'type=vm sys-net',
-            'updateable': b'type=bool False',
-            'provides_network': b'type=bool False',
-            'hvm': b'type=bool False',
-            'installed_by_rpm': b'type=bool False',
-            'internal': b'type=bool False',
-            'debug': b'type=bool False',
-            'autostart': b'type=bool False',
+#           'hvm': b'type=bool False',
         }
         for key, value in props.items():
             self.app.expected_calls[
@@ -125,7 +119,6 @@ class TC_90_List_with_qubesd_calls(qubesadmin.tests.QubesTestCase):
 
         # setup template1
         props['label'] = b'type=label black'
-        props['updateable'] = b'type=bool True'
         for key, value in props.items():
             self.app.expected_calls[
                 ('template1', 'admin.vm.property.Get', key, None)] = \
@@ -136,8 +129,6 @@ class TC_90_List_with_qubesd_calls(qubesadmin.tests.QubesTestCase):
 
         # setup sys-net
         props['label'] = b'type=label red'
-        props['provides_network'] = b'type=bool True'
-        props['updateable'] = b'type=bool False'
         for key, value in props.items():
             self.app.expected_calls[
                 ('sys-net', 'admin.vm.property.Get', key, None)] = \
@@ -146,8 +137,8 @@ class TC_90_List_with_qubesd_calls(qubesadmin.tests.QubesTestCase):
         with qubesadmin.tests.tools.StdoutBuffer() as stdout:
             qubesadmin.tools.qvm_ls.main([], app=self.app)
         self.assertEqual(stdout.getvalue(),
-            'NAME       STATUS    LABEL  TEMPLATE   NETVM\n'
-            'sys-net    ar-N----  red    template1  sys-net\n'
-            'template1  t-U-----  black  -          sys-net\n'
-            'vm1        ar------  green  template1  sys-net\n')
+            'NAME       STATE    CLASS       LABEL  TEMPLATE   NETVM\n'
+            'sys-net    Running  AppVM       red    template1  sys-net\n'
+            'template1  Halted   TemplateVM  black  -          sys-net\n'
+            'vm1        Running  AppVM       green  template1  sys-net\n')
         self.assertAllCalled()

--- a/qubesadmin/tools/qvm_ls.py
+++ b/qubesadmin/tools/qvm_ls.py
@@ -563,7 +563,7 @@ def main(args=None, app=None):
     # assume unknown columns are VM properties
     for col in columns:
         if col.upper() not in Column.columns:
-            PropertyColumn(col)
+            PropertyColumn(col.lower())
 
     if args.spinner:
         # we need Enterprise Edition™, since it's the only one that detects TTY

--- a/qubesadmin/tools/qvm_ls.py
+++ b/qubesadmin/tools/qvm_ls.py
@@ -191,13 +191,13 @@ def simple_flag(field, letter, attr, doc=None):
     return helper
 
 
-class StatusColumn(Column):
+class FlagsColumn(Column):
     '''Some fancy flags that describe general status of the domain.'''
     # pylint: disable=no-self-use
 
     def __init__(self):
-        super(StatusColumn, self).__init__(
-            head='STATUS',
+        super(FlagsColumn, self).__init__(
+            head='FLAGS',
             doc=self.__class__.__doc__)
 
 
@@ -333,6 +333,15 @@ def calc_used(vm, volume_name):
 
 # todo maxmem
 
+Column('STATE',
+    attr=(lambda vm: vm.get_power_state()),
+    doc='Current power state.')
+
+Column('CLASS',
+    attr=(lambda vm: type(vm).__name__),
+    doc='Class of the qube.')
+
+
 Column('GATEWAY',
     attr='netvm.gateway',
     doc='Network gateway.')
@@ -372,7 +381,7 @@ Column('ROOT-USED',
     doc='Disk utilisation by root image as a percentage of available space.')
 
 
-StatusColumn()
+FlagsColumn()
 
 
 class Table(object):
@@ -421,11 +430,11 @@ class Table(object):
 
 #: Available formats. Feel free to plug your own one.
 formats = {
-    'simple': ('name', 'status', 'label', 'template', 'netvm'),
-    'network': ('name', 'status', 'netvm', 'ip', 'ipback', 'gateway'),
-    'full': ('name', 'status', 'label', 'qid', 'xid', 'uuid'),
-#   'perf': ('name', 'status', 'cpu', 'memory'),
-    'disk': ('name', 'status', 'disk',
+    'simple': ('name', 'state', 'class', 'label', 'template', 'netvm'),
+    'network': ('name', 'state', 'netvm', 'ip', 'ipback', 'gateway'),
+    'full': ('name', 'state', 'class', 'label', 'qid', 'xid', 'uuid'),
+#   'perf': ('name', 'state', 'cpu', 'memory'),
+    'disk': ('name', 'state', 'disk',
         'priv-curr', 'priv-max', 'priv-used',
         'root-curr', 'root-max', 'root-used'),
 }

--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -180,10 +180,15 @@ class QubesVM(qubesadmin.base.PropertyHolder):
 
         '''
 
-        vm_list_info = self.qubesd_call(
-            self._method_dest, 'admin.vm.List', None, None).decode('ascii')
+        vm_list_info = [line
+            for line in self.qubesd_call(
+                self._method_dest, 'admin.vm.List', None, None
+            ).decode('ascii').split('\n')
+            if line.startswith(self._method_dest+' ')]
+        assert len(vm_list_info) == 1
         #  name class=... state=... other=...
-        vm_state = vm_list_info.strip().partition('state=')[2].split(' ')[0]
+        # NOTE: when querying dom0, we get whole list
+        vm_state = vm_list_info[0].strip().partition('state=')[2].split(' ')[0]
         return vm_state
 
 


### PR DESCRIPTION
There is not a mention about PV/HVM setting (other than `FLAGS` aka `STATUS`). Should that remain that way?

The old field `STATUS` got renamed to `FLAGS` not to confuse that with `STATE`, which is `get_power_state()`.