### PR TITLE
Incremental development update

### DIFF
--- a/qubesadmin/features.py
+++ b/qubesadmin/features.py
@@ -67,6 +67,15 @@ class Features(object):
 
     _NO_DEFAULT = object()
 
+    def get(self, item, default=_NO_DEFAULT):
+        '''Get a feature, return default value if missing.'''
+        try:
+            return self[item]
+        except KeyError:
+            if default is self._NO_DEFAULT:
+                raise
+            return default
+
     def check_with_template(self, feature, default=_NO_DEFAULT):
         ''' Check if the vm's template has the specified feature. '''
         try:

--- a/qubesadmin/tests/features.py
+++ b/qubesadmin/tests/features.py
@@ -1,0 +1,91 @@
+# -*- encoding: utf8 -*-
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2017 Marek Marczykowski-Górecki
+#                               <marmarek@invisiblethingslab.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+import qubesadmin.features
+import qubesadmin.tests
+
+
+class TC_00_Features(qubesadmin.tests.QubesTestCase):
+    def setUp(self):
+        super(TC_00_Features, self).setUp()
+        self.app.expected_calls[('dom0', 'admin.vm.List', None, None)] = \
+            b'0\0test-vm class=AppVM state=Running\n' \
+            b'test-vm2 class=AppVM state=Running\n' \
+            b'test-vm3 class=AppVM state=Running\n'
+        self.vm = self.app.domains['test-vm']
+        self.features = qubesadmin.features.Features(self.vm)
+
+    def test_000_list(self):
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.feature.List', None, None)] = \
+            b'0\0feature1\nfeature2\n'
+        self.assertEqual(sorted(self.vm.features.keys()),
+            ['feature1', 'feature2'])
+        self.assertAllCalled()
+
+    def test_010_get(self):
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.feature.Get', 'feature1', None)] = \
+            b'0\0value1'
+        self.assertEqual(self.vm.features['feature1'], 'value1')
+        self.assertAllCalled()
+
+    def test_011_get_none(self):
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.feature.Get', 'feature1', None)] = \
+            b'2\x00QubesFeatureNotFoundError\x00\x00feature1\x00'
+        with self.assertRaises(KeyError):
+            value = self.vm.features['feature1']
+        self.assertAllCalled()
+
+    def test_012_get_none(self):
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.feature.Get', 'feature1', None)] = \
+            b'2\x00QubesFeatureNotFoundError\x00\x00feature1\x00'
+        with self.assertRaises(KeyError):
+            self.vm.features.get('feature1')
+        self.assertAllCalled()
+
+    def test_013_get_default(self):
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.feature.Get', 'feature1', None)] = \
+            b'2\x00QubesFeatureNotFoundError\x00\x00feature1\x00'
+        self.assertEqual(self.vm.features.get('feature1', 'other'), 'other')
+        self.assertAllCalled()
+
+    def test_020_set(self):
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.feature.Set', 'feature1', b'value')] = \
+            b'0\0'
+        self.vm.features['feature1'] = 'value'
+        self.assertAllCalled()
+
+    def test_021_set_bool(self):
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.feature.Set', 'feature1', b'True')] = \
+            b'0\0'
+        self.vm.features['feature1'] = True
+        self.assertAllCalled()
+
+    def test_022_set_bool_false(self):
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.feature.Set', 'feature1', b'')] = \
+            b'0\0'
+        self.vm.features['feature1'] = False
+        self.assertAllCalled()

--- a/qubesadmin/tests/tools/qvm_template_postprocess.py
+++ b/qubesadmin/tests/tools/qvm_template_postprocess.py
@@ -239,6 +239,8 @@ class TC_00_qvm_template_postprocess(qubesadmin.tests.QubesTestCase):
         self.app.expected_calls[
             ('test-vm', 'admin.vm.property.Reset', 'netvm', None)] = b'0\0'
         self.app.expected_calls[
+            ('test-vm', 'admin.vm.feature.Set', 'qrexec', b'True')] = b'0\0'
+        self.app.expected_calls[
             ('test-vm', 'admin.vm.Start', None, None)] = b'0\0'
         self.app.expected_calls[
             ('test-vm', 'admin.vm.Shutdown', None, None)] = b'0\0'
@@ -284,6 +286,8 @@ class TC_00_qvm_template_postprocess(qubesadmin.tests.QubesTestCase):
             ('test-vm', 'admin.vm.property.Set', 'netvm', b'')] = b'0\0'
         self.app.expected_calls[
             ('test-vm', 'admin.vm.property.Reset', 'netvm', None)] = b'0\0'
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.feature.Set', 'qrexec', b'True')] = b'0\0'
         self.app.expected_calls[
             ('test-vm', 'admin.vm.Start', None, None)] = b'0\0'
         self.app.expected_calls[


### PR DESCRIPTION
- features improvements
- fix qvm-template-postinstall (calling qubes.PostInstall service)

See also devel-2-qvm-run-1 and devel-2-qvm-run-2 branches - two different versions of qvm-run fix. Both fails on tests (no idea how to easily fix them), but both works otherwise.