### PR TITLE
Choose QubesLocal or QubesRemote based on /etc/qubes-release presence

### DIFF
--- a/qubesadmin/__init__.py
+++ b/qubesadmin/__init__.py
@@ -28,7 +28,7 @@ import qubesadmin.app
 
 DEFAULT = qubesadmin.base.DEFAULT
 
-if os.path.exists(qubesadmin.config.QUBESD_SOCKET):
+if os.path.exists('/etc/qubes-release'):
     Qubes = qubesadmin.app.QubesLocal
 else:
     Qubes = qubesadmin.app.QubesRemote


### PR DESCRIPTION
Do not check for qubesd socket (at module import time), because if not
running at this precise time, it will lead to wrong choice. And a weird
error message in consequence (looking for qrexec-client-vm in dom0).

Fixes QubesOS/qubes-issues#2917