### PR TITLE
Fixed https://github.com/QubesOS/qubes-issues/issues/2983

### DIFF
--- a/qubesadmin/tools/qvm_backup_restore.py
+++ b/qubesadmin/tools/qvm_backup_restore.py
@@ -247,8 +247,8 @@ def main(args=None, app=None):
         parser.error_runtime(str(e))
 
     if args.vms:
-        backup.options.exclude += [vm.name for vm in restore_info.values()
-            if vm.name not in args.vms]
+        backup.options.exclude += [vm_info.vm.name for vm_info in restore_info.values()
+            if vm_info.vm.name not in args.vms] # use original name here, not renamed
         restore_info = backup.restore_info_verify(restore_info)
 
     print(backup.get_restore_summary(restore_info))


### PR DESCRIPTION
now using the original name (vm_info.vm.name) for exclusion calculation instead of the new (renamed) one (vm_info.name), so we can restore any list of VMs as expected