### PR TITLE
Avoid admin.vm.List calls when constructing wrapper objects

### DIFF
--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -38,7 +38,6 @@ import qubesadmin.vm
 import qubesadmin.config
 
 BUF_SIZE = 4096
-VM_ENTRY_POINT = 'qubesadmin.vm'
 
 class VMCollection(object):
     '''Collection of VMs objects'''
@@ -220,20 +219,13 @@ class QubesBase(qubesadmin.base.PropertyHolder):
     def get_vm_class(clsname):
         '''Find the class for a domain.
 
-        Classes are registered as setuptools' entry points in ``qubes.vm``
-        group. Any package may supply their own classes.
+        Compatibility function, client tools use str to identify domain classes.
 
         :param str clsname: name of the class
-        :return type: class
+        :return str: class
         '''
 
-        try:
-            return qubesadmin.utils.get_entry_point_one(
-                VM_ENTRY_POINT, clsname)
-        except KeyError:
-            raise qubesadmin.exc.QubesException(
-                'no such VM class: {!r}'.format(clsname))
-            # don't catch TypeError
+        return clsname
 
     def add_new_vm(self, cls, name, label, template=None, pool=None,
             pools=None):

--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -83,11 +83,14 @@ class VMCollection(object):
                 del self._vm_objects[name]
 
     def __getitem__(self, item):
-        if item not in self:
+        if not self.app.blind_mode and item not in self:
             raise KeyError(item)
         if item not in self._vm_objects:
-            cls = qubesadmin.utils.get_entry_point_one(VM_ENTRY_POINT,
-                self._vm_list[item]['class'])
+            if self.app.blind_mode:
+                cls = qubesadmin.vm.QubesVM
+            else:
+                cls = qubesadmin.utils.get_entry_point_one(VM_ENTRY_POINT,
+                    self._vm_list[item]['class'])
             self._vm_objects[item] = cls(self.app, item)
         return self._vm_objects[item]
 
@@ -128,6 +131,8 @@ class QubesBase(qubesadmin.base.PropertyHolder):
     qubesd_connection_type = None
     #: logger
     log = None
+    #: do not check for object (VM, label etc) existence before really needed
+    blind_mode = False
 
     def __init__(self):
         super(QubesBase, self).__init__(self, 'admin.property.', 'dom0')

--- a/qubesadmin/backup/restore.py
+++ b/qubesadmin/backup/restore.py
@@ -1456,7 +1456,7 @@ class BackupRestore(object):
                 except KeyError:
                     host_template = None
                 present_on_host = (host_template and
-                    isinstance(host_template, qubesadmin.vm.TemplateVM))
+                    host_template.klass == 'TemplateVM')
                 present_in_backup = (template_name in restore_info.keys() and
                     restore_info[template_name].good_to_go and
                     restore_info[template_name].vm.klass ==

--- a/qubesadmin/base.py
+++ b/qubesadmin/base.py
@@ -292,7 +292,7 @@ class WrapperObjectsCollection(object):
                 del self._objects[name]
 
     def __getitem__(self, item):
-        if item not in self:
+        if not self.app.blind_mode and item not in self:
             raise KeyError(item)
         if item not in self._objects:
             self._objects[item] = self._object_class(self.app, item)

--- a/qubesadmin/events/__init__.py
+++ b/qubesadmin/events/__init__.py
@@ -191,7 +191,10 @@ class EventsDispatcher(object):
         if subject:
             if event in ['property-set:name']:
                 self.app.domains.clear_cache()
-            subject = self.app.domains[subject]
+            try:
+                subject = self.app.domains[subject]
+            except KeyError:
+                return
         else:
             # handle cache refreshing on best-effort basis
             if event in ['domain-add', 'domain-delete']:

--- a/qubesadmin/tests/__init__.py
+++ b/qubesadmin/tests/__init__.py
@@ -29,6 +29,7 @@ import qubesadmin.app
 class TestVM(object):
     def __init__(self, name, **kwargs):
         self.name = name
+        self.klass = 'TestVM'
         for key, value in kwargs.items():
             setattr(self, key, value)
 

--- a/qubesadmin/tests/app.py
+++ b/qubesadmin/tests/app.py
@@ -94,7 +94,7 @@ class TC_00_VMCollection(qubesadmin.tests.QubesTestCase):
             b'test-vm2 class=AppVM state=Running\n'
         values = self.app.domains.values()
         for obj in values:
-            self.assertIsInstance(obj, qubesadmin.vm.AppVM)
+            self.assertIsInstance(obj, qubesadmin.vm.QubesVM)
         self.assertEqual(set([vm.name for vm in values]),
             set(['test-vm', 'test-vm2']))
         self.assertAllCalled()
@@ -122,6 +122,17 @@ class TC_00_VMCollection(qubesadmin.tests.QubesTestCase):
         self.assertNotIn('test-non-existent', self.app.domains)
         self.assertAllCalled()
 
+    def test_009_getitem_cache_class(self):
+        self.app.expected_calls[('dom0', 'admin.vm.List', None, None)] = \
+            b'0\x00test-vm class=AppVM state=Running\n'
+        try:
+            vm = self.app.domains['test-vm']
+            self.assertEqual(vm.name, 'test-vm')
+            self.assertEqual(vm.klass, 'AppVM')
+        except KeyError:
+            self.fail('VM not found in collection')
+        self.assertAllCalled()
+
 
 class TC_10_QubesBase(qubesadmin.tests.QubesTestCase):
     def test_010_new_simple(self):
@@ -131,7 +142,7 @@ class TC_10_QubesBase(qubesadmin.tests.QubesTestCase):
             b'0\x00new-vm class=AppVM state=Running\n'
         vm = self.app.add_new_vm('AppVM', 'new-vm', 'red')
         self.assertEqual(vm.name, 'new-vm')
-        self.assertEqual(vm.__class__.__name__, 'AppVM')
+        self.assertEqual(vm.klass, 'AppVM')
         self.assertAllCalled()
 
     def test_011_new_template(self):
@@ -141,7 +152,7 @@ class TC_10_QubesBase(qubesadmin.tests.QubesTestCase):
             b'0\x00new-template class=TemplateVM state=Running\n'
         vm = self.app.add_new_vm('TemplateVM', 'new-template', 'red')
         self.assertEqual(vm.name, 'new-template')
-        self.assertEqual(vm.__class__.__name__, 'TemplateVM')
+        self.assertEqual(vm.klass, 'TemplateVM')
         self.assertAllCalled()
 
     def test_012_new_template_based(self):
@@ -151,7 +162,7 @@ class TC_10_QubesBase(qubesadmin.tests.QubesTestCase):
             b'0\x00new-vm class=AppVM state=Running\n'
         vm = self.app.add_new_vm('AppVM', 'new-vm', 'red', 'some-template')
         self.assertEqual(vm.name, 'new-vm')
-        self.assertEqual(vm.__class__.__name__, 'AppVM')
+        self.assertEqual(vm.klass, 'AppVM')
         self.assertAllCalled()
 
     def test_013_new_objects_params(self):
@@ -165,7 +176,7 @@ class TC_10_QubesBase(qubesadmin.tests.QubesTestCase):
         vm = self.app.add_new_vm(self.app.get_vm_class('AppVM'), 'new-vm',
             self.app.get_label('red'), self.app.domains['some-template'])
         self.assertEqual(vm.name, 'new-vm')
-        self.assertEqual(vm.__class__.__name__, 'AppVM')
+        self.assertEqual(vm.klass, 'AppVM')
         self.assertAllCalled()
 
     def test_014_new_pool(self):
@@ -175,7 +186,7 @@ class TC_10_QubesBase(qubesadmin.tests.QubesTestCase):
             b'0\x00new-vm class=AppVM state=Running\n'
         vm = self.app.add_new_vm('AppVM', 'new-vm', 'red', pool='some-pool')
         self.assertEqual(vm.name, 'new-vm')
-        self.assertEqual(vm.__class__.__name__, 'AppVM')
+        self.assertEqual(vm.klass, 'AppVM')
         self.assertAllCalled()
 
     def test_015_new_pools(self):
@@ -187,7 +198,7 @@ class TC_10_QubesBase(qubesadmin.tests.QubesTestCase):
         vm = self.app.add_new_vm('AppVM', 'new-vm', 'red',
             pools={'private': 'some-pool', 'volatile': 'other-pool'})
         self.assertEqual(vm.name, 'new-vm')
-        self.assertEqual(vm.__class__.__name__, 'AppVM')
+        self.assertEqual(vm.klass, 'AppVM')
         self.assertAllCalled()
 
     def test_016_new_template_based_default(self):
@@ -198,7 +209,7 @@ class TC_10_QubesBase(qubesadmin.tests.QubesTestCase):
         vm = self.app.add_new_vm('AppVM', 'new-vm', 'red',
             template=qubesadmin.DEFAULT)
         self.assertEqual(vm.name, 'new-vm')
-        self.assertEqual(vm.__class__.__name__, 'AppVM')
+        self.assertEqual(vm.klass, 'AppVM')
         self.assertAllCalled()
 
     def test_020_get_label(self):
@@ -422,7 +433,7 @@ class TC_10_QubesBase(qubesadmin.tests.QubesTestCase):
         new_vm = self.app.clone_vm('test-vm', 'new-name',
             new_cls='StandaloneVM')
         self.assertEqual(new_vm.name, 'new-name')
-        self.assertEqual(new_vm.__class__.__name__, 'StandaloneVM')
+        self.assertEqual(new_vm.klass, 'StandaloneVM')
         self.assertAllCalled()
 
     def test_035_clone_fail(self):

--- a/qubesadmin/tests/app.py
+++ b/qubesadmin/tests/app.py
@@ -99,6 +99,28 @@ class TC_00_VMCollection(qubesadmin.tests.QubesTestCase):
             set(['test-vm', 'test-vm2']))
         self.assertAllCalled()
 
+    def test_007_getitem_blind_mode(self):
+        self.app.blind_mode = True
+        try:
+            vm = self.app.domains['test-vm']
+            self.assertEqual(vm.name, 'test-vm')
+        except KeyError:
+            self.fail('VM not found in collection')
+        self.assertAllCalled()
+
+        with self.assertNotRaises(KeyError):
+            vm = self.app.domains['test-non-existent']
+        self.assertAllCalled()
+
+    def test_008_in_blind_mode(self):
+        self.app.blind_mode = True
+        self.app.expected_calls[('dom0', 'admin.vm.List', None, None)] = \
+            b'0\x00test-vm class=AppVM state=Running\n'
+        self.assertIn('test-vm', self.app.domains)
+        self.assertAllCalled()
+
+        self.assertNotIn('test-non-existent', self.app.domains)
+        self.assertAllCalled()
 
 
 class TC_10_QubesBase(qubesadmin.tests.QubesTestCase):

--- a/qubesadmin/tests/tools/qvm_start.py
+++ b/qubesadmin/tests/tools/qvm_start.py
@@ -81,7 +81,7 @@ class TC_00_qvm_start(qubesadmin.tests.QubesTestCase):
             ('some-vm', 'admin.vm.Start', None, None)] = b'0\x00'
         self.app.expected_calls[
             ('some-vm', 'admin.vm.device.block.Attach', 'dom0+sr0',
-                b'devtype=cdrom persistent=True')] = b'0\x00'
+                b'devtype=cdrom persistent=True read-only=True')] = b'0\x00'
         self.app.expected_calls[
             ('some-vm', 'admin.vm.device.block.Set.persistent', 'dom0+sr0',
             b'False')] = b'0\x00'
@@ -101,7 +101,7 @@ class TC_00_qvm_start(qubesadmin.tests.QubesTestCase):
             ('some-vm', 'admin.vm.Start', None, None)] = b'0\x00'
         self.app.expected_calls[
             ('some-vm', 'admin.vm.device.block.Attach', 'dom0+sdb1',
-                b'devtype=disk persistent=True')] = b'0\x00'
+                b'devtype=disk persistent=True read-only=False')] = b'0\x00'
         self.app.expected_calls[
             ('some-vm', 'admin.vm.device.block.Set.persistent', 'dom0+sdb1',
             b'False')] = b'0\x00'
@@ -121,7 +121,7 @@ class TC_00_qvm_start(qubesadmin.tests.QubesTestCase):
             ('some-vm', 'admin.vm.Start', None, None)] = b'0\x00'
         self.app.expected_calls[
             ('some-vm', 'admin.vm.device.block.Attach', 'dom0+sdb1',
-                b'devtype=disk persistent=True')] = b'0\x00'
+                b'devtype=disk persistent=True read-only=False')] = b'0\x00'
         self.app.expected_calls[
             ('some-vm', 'admin.vm.device.block.Set.persistent', 'dom0+sdb1',
             b'False')] = b'0\x00'
@@ -142,7 +142,7 @@ class TC_00_qvm_start(qubesadmin.tests.QubesTestCase):
             ('some-vm', 'admin.vm.Start', None, None)] = b'0\x00'
         self.app.expected_calls[
             ('some-vm', 'admin.vm.device.block.Attach', 'dom0+loop12',
-                b'devtype=cdrom persistent=True')] = b'0\x00'
+                b'devtype=cdrom persistent=True read-only=True')] = b'0\x00'
         self.app.expected_calls[
             ('some-vm', 'admin.vm.device.block.Set.persistent', 'dom0+loop12',
             b'False')] = b'0\x00'
@@ -168,7 +168,7 @@ class TC_00_qvm_start(qubesadmin.tests.QubesTestCase):
             ('some-vm', 'admin.vm.Start', None, None)] = b'0\x00'
         self.app.expected_calls[
             ('some-vm', 'admin.vm.device.block.Attach', 'other-vm+loop7',
-                b'devtype=cdrom persistent=True')] = b'0\x00'
+                b'devtype=cdrom persistent=True read-only=True')] = b'0\x00'
         self.app.expected_calls[
             ('some-vm', 'admin.vm.device.block.Set.persistent',
             'other-vm+loop7',
@@ -193,7 +193,7 @@ class TC_00_qvm_start(qubesadmin.tests.QubesTestCase):
             b'some-vm class=AppVM state=Running\n'
         self.app.expected_calls[
             ('some-vm', 'admin.vm.device.block.Attach', 'other-vm+loop7',
-                b'devtype=cdrom persistent=True')] = b'0\x00'
+                b'devtype=cdrom persistent=True read-only=True')] = b'0\x00'
         self.app.expected_calls[
             ('some-vm', 'admin.vm.Start', None, None)] = \
             b'2\x00QubesException\x00\x00An error occurred\x00'
@@ -214,7 +214,7 @@ class TC_00_qvm_start(qubesadmin.tests.QubesTestCase):
             b'some-vm class=AppVM state=Running\n'
         self.app.expected_calls[
             ('some-vm', 'admin.vm.device.block.Attach', 'other-vm+loop7',
-                b'devtype=cdrom persistent=True')] = \
+                b'devtype=cdrom persistent=True read-only=True')] = \
             b'2\x00QubesException\x00\x00An error occurred\x00'
         retcode = qubesadmin.tools.qvm_start.main([
             '--cdrom=other-vm:loop7',

--- a/qubesadmin/tools/__init__.py
+++ b/qubesadmin/tools/__init__.py
@@ -156,7 +156,7 @@ class VmNameAction(QubesAction):
             namespace.domains = [
                 vm
                 for vm in app.domains
-                if not isinstance(vm, qubesadmin.vm.AdminVM) and
+                if not vm.klass == 'AdminVM' and
                    vm.name not in namespace.exclude
             ]
         else:

--- a/qubesadmin/tools/qvm_check.py
+++ b/qubesadmin/tools/qvm_check.py
@@ -64,8 +64,7 @@ def main(args=None, app=None):
             print_msg(paused, "is paused", "are paused")
         return 0 if paused else 1
     elif args.template:
-        template = [vm for vm in domains if isinstance(vm,
-            qubesadmin.vm.TemplateVM)]
+        template = [vm for vm in domains if vm.klass == 'TemplateVM']
         if args.verbose:
             print_msg(template, "is a template", "are templates")
         return 0 if template else 1

--- a/qubesadmin/tools/qvm_ls.py
+++ b/qubesadmin/tools/qvm_ls.py
@@ -214,19 +214,16 @@ class FlagsColumn(Column):
         When it is HVM (optimised VM), the letter is capital.
         '''
 
-        if isinstance(vm, qubesadmin.vm.AdminVM):
-            return '0'
-
-        ret = None
-        # TODO right order, depending on inheritance
-        if isinstance(vm, qubesadmin.vm.TemplateVM):
-            ret = 't'
-        if isinstance(vm, qubesadmin.vm.AppVM):
-            ret = 'a'
-        if isinstance(vm, qubesadmin.vm.StandaloneVM):
-            ret = 's'
-        if isinstance(vm, qubesadmin.vm.DispVM):
-            ret = 'd'
+        type_codes = {
+            'AdminVM': '0',
+            'TemplateVM': 't',
+            'AppVM': 'a',
+            'StandaloneVM': 's',
+            'DispVM': 'd',
+        }
+        ret = type_codes.get(vm.klass, None)
+        if ret == '0':
+            return ret
 
         if ret is not None:
             if getattr(vm, 'virt_mode', 'pv') == 'hvm':
@@ -338,7 +335,7 @@ Column('STATE',
     doc='Current power state.')
 
 Column('CLASS',
-    attr=(lambda vm: type(vm).__name__),
+    attr=(lambda vm: vm.klass),
     doc='Class of the qube.')
 
 

--- a/qubesadmin/tools/qvm_run.py
+++ b/qubesadmin/tools/qvm_run.py
@@ -108,7 +108,7 @@ parser.add_argument('--exclude', action='append', default=[],
     help='exclude the qube from --all')
 
 parser.add_argument('cmd', metavar='COMMAND',
-    help='command to run')
+    help='command or service to run')
 
 def copy_stdin(stream):
     '''Copy stdin to *stream*'''

--- a/qubesadmin/tools/qvm_start.py
+++ b/qubesadmin/tools/qvm_start.py
@@ -118,13 +118,15 @@ def get_drive_assignment(app, drive_str):
         except subprocess.CalledProcessError:
             raise qubesadmin.exc.QubesException(
                 'Failed to setup loop device for %s', ident)
+        loop_name = loop_name.strip()
         assert loop_name.startswith(b'/dev/loop')
         ident = loop_name.decode().split('/')[2]
         # FIXME: synchronize with udev + exposing device in qubesdb
 
-    options = {}
-    if devtype:
-        options['devtype'] = devtype
+    options = {
+        'devtype': devtype,
+        'read-only': devtype == 'cdrom'
+    }
     assignment = qubesadmin.devices.DeviceAssignment(
         backend_domain,
         ident,

--- a/qubesadmin/tools/qvm_start.py
+++ b/qubesadmin/tools/qvm_start.py
@@ -109,7 +109,7 @@ def get_drive_assignment(app, drive_str):
                 'Existing block device identifier needed when running from '
                 'outside of dom0 (see qvm-block)')
         try:
-            if isinstance(backend_domain, qubesadmin.vm.AdminVM):
+            if backend_domain.klass == 'AdminVM':
                 loop_name = subprocess.check_output(
                     ['sudo', 'losetup', '-f', '--show', ident])
             else:

--- a/qubesadmin/tools/qvm_start_gui.py
+++ b/qubesadmin/tools/qvm_start_gui.py
@@ -296,7 +296,7 @@ class GUILauncher(object):
         '''Send monitor layout to all (running) VMs'''
         monitor_layout = get_monitor_layout()
         for vm in self.app.domains:
-            if isinstance(vm, qubesadmin.vm.AdminVM):
+            if vm.klass == 'AdminVM':
                 continue
             if vm.is_running():
                 if not vm.features.check_with_template('gui', True):
@@ -325,7 +325,7 @@ class GUILauncher(object):
         monitor_layout = get_monitor_layout()
         self.app.domains.clear_cache()
         for vm in self.app.domains:
-            if isinstance(vm, qubesadmin.vm.AdminVM):
+            if vm.klass == 'AdminVM':
                 continue
             if not vm.features.check_with_template('gui', True):
                 continue

--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -46,9 +46,10 @@ class QubesVM(qubesadmin.base.PropertyHolder):
 
     firewall = None
 
-    def __init__(self, app, name):
+    def __init__(self, app, name, klass=None):
         super(QubesVM, self).__init__(app, 'admin.vm.property.', name)
         self._volumes = None
+        self._klass = klass
         self.log = logging.getLogger(name)
         self.tags = qubesadmin.tags.Tags(self)
         self.features = qubesadmin.features.Features(self)
@@ -314,6 +315,14 @@ class QubesVM(qubesadmin.base.PropertyHolder):
             e.cmd = command
             raise e
 
+    @property
+    def klass(self):
+        ''' Qube class '''
+        # use cached value if available
+        if self._klass is None:
+            # pylint: disable=no-member
+            self._klass = super(QubesVM, self).klass
+        return self._klass
 
 # pylint: disable=abstract-method
 class AdminVM(QubesVM):

--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -316,6 +316,21 @@ class QubesVM(qubesadmin.base.PropertyHolder):
             raise e
 
     @property
+    def appvms(self):
+        ''' Returns a generator containing all domains based on the current
+            TemplateVM.
+
+            Do not check vm type of self, core (including its extentions) have
+            ultimate control what can be a template of what.
+        '''
+        for vm in self.app.domains:
+            try:
+                if vm.template == self:
+                    yield vm
+            except AttributeError:
+                pass
+
+    @property
     def klass(self):
         ''' Qube class '''
         # use cached value if available
@@ -342,18 +357,8 @@ class StandaloneVM(QubesVM):
 
 class TemplateVM(QubesVM):
     '''Template for AppVM'''
+    pass
 
-    @property
-    def appvms(self):
-        ''' Returns a generator containing all domains based on the current
-            TemplateVM.
-        '''
-        for vm in self.app.domains:
-            try:
-                if vm.template == self:
-                    yield vm
-            except AttributeError:
-                pass
 
 class DispVMWrapper(QubesVM):
     '''Wrapper class for new DispVM, supporting only service call

--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -138,29 +138,6 @@ class QubesVM(qubesadmin.base.PropertyHolder):
         '''
         self.qubesd_call(self._method_dest, 'admin.vm.Unpause')
 
-    def suspend(self):
-        '''
-        Suspend domain.
-
-        Give domain a chance to prepare for suspend - for example suspend
-        used PCI devices.
-
-        :return:
-        '''
-        raise NotImplementedError
-        #self.qubesd_call(self._method_dest, 'admin.vm.Suspend')
-
-    def resume(self):
-        '''
-        Resume domain.
-
-        Opposite to :py:meth:`suspend`.
-
-        :return:
-        '''
-        raise NotImplementedError
-        #self.qubesd_call(self._method_dest, 'admin.vm.Resume')
-
     def get_power_state(self):
         '''Return power state description string.
 

--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -339,27 +339,6 @@ class QubesVM(qubesadmin.base.PropertyHolder):
             self._klass = super(QubesVM, self).klass
         return self._klass
 
-# pylint: disable=abstract-method
-class AdminVM(QubesVM):
-    '''Dom0'''
-    pass
-
-
-class AppVM(QubesVM):
-    '''Application VM'''
-    pass
-
-
-class StandaloneVM(QubesVM):
-    '''Standalone Application VM'''
-    pass
-
-
-class TemplateVM(QubesVM):
-    '''Template for AppVM'''
-    pass
-
-
 class DispVMWrapper(QubesVM):
     '''Wrapper class for new DispVM, supporting only service call
 

--- a/setup.py
+++ b/setup.py
@@ -38,13 +38,6 @@ if __name__ == '__main__':
         },
         entry_points={
             'console_scripts': list(get_console_scripts()),
-            'qubesadmin.vm': [
-                'AppVM = qubesadmin.vm:AppVM',
-                'TemplateVM = qubesadmin.vm:TemplateVM',
-                'StandaloneVM = qubesadmin.vm:StandaloneVM',
-                'AdminVM = qubesadmin.vm:AdminVM',
-                'DispVM = qubesadmin.vm:DispVM',
-            ],
         },
 
         )


### PR DESCRIPTION
The main purpose of this PR is to avoid race condition in events handling - when application got an event, VM may be already removed. And at this point, it's impossible to get VM class, because admin.vm.List will fail. But with the current code, it is required for constructing wrapper object.
The main reason is domain-shutdown event for DispVMs, but the race applies to other cases too. And also importantly - some mgmt VMs may not be allowed to list domains, but still access some actions. This approach is simpler than filtering response to admin.vm.List.

This PR introduce "blind mode", where domain wrapper object is constructed without checking if given domain exists (when referenced by a name directly). In such a case domain class is not available, so return QubesVM instance. After some consideration, abandon individual classes for different VM types and always use QubesVM, even not in blind mode - to avoid various corner cases depending on enabling or not blind mode. In fact domain class is rarely used by Admin API _client_ side - all domain properties are enforced by the server side. In fact this also makes extending qubesd easier, because one does not need to provide appropriate extensions (new domain classes) to client side anymore.

The introduced blind mode is not enabled here by default. It requires careful evaluation on case-by-case basis (especially on error reporting - by default errors with blind mode could be very misleading). The plan is to enable it in qubes-dbus first. Then introduce generic --blind-mode switch to all qvm-* tools. And only then consider enabling in some other places by default (if needed).

This PR contains also few bug fixes, beside the above main functionality. If you like to have them in separate PR, just ask.