### PR TITLE
Add CentOS support and fix python3 dependencies for CentOS

### DIFF
--- a/rpm_spec/qubes-core-admin-client.spec
+++ b/rpm_spec/qubes-core-admin-client.spec
@@ -8,12 +8,20 @@ License:	LGPLv2.1+
 URL:		https://www.qubes-os.org
 
 BuildRequires:	python2-setuptools
-BuildRequires:	python3-setuptools
 BuildRequires:	python2-devel
+%if 0%{?rhel} >= 7
+BuildRequires:	python34-setuptools
+BuildRequires:	python34-devel
+BuildRequires:	python-sphinx
+BuildRequires:	python34-dbus
+Requires:   python34-qubesadmin
+%else
+BuildRequires:	python3-setuptools
 BuildRequires:	python3-devel
 BuildRequires:	python3-sphinx
 BuildRequires:	python3-dbus
 Requires:   python3-qubesadmin
+%endif
 BuildArch:  noarch
 
 %if 0%{?qubes_builder}
@@ -31,6 +39,16 @@ Requires:   python-docutils
 %description -n python2-qubesadmin
 Python2 module qubesadmin.
 
+%if 0%{?rhel} >= 7
+%package -n python34-qubesadmin
+Summary:    Python34 module qubesadmin
+Requires:   python-daemon
+Requires:   python34-docutils
+Conflicts:  qubes-manager < 4.0.6
+
+%description -n python34-qubesadmin
+Python34 module qubesadmin.
+%else
 %package -n python3-qubesadmin
 Summary:    Python3 module qubesadmin
 Requires:   python3-daemon
@@ -39,6 +57,7 @@ Conflicts:  qubes-manager < 4.0.6
 
 %description -n python3-qubesadmin
 Python3 module qubesadmin.
+%endif
 
 %prep
 %if !0%{?qubes_builder}
@@ -47,7 +66,11 @@ Python3 module qubesadmin.
 
 
 %build
+%if 0%{?rhel} >= 7
+make -C doc PYTHON=%{__python3} SPHINXBUILD=sphinx-build man
+%else
 make -C doc PYTHON=%{__python3} SPHINXBUILD=sphinx-build-%{python3_version} man
+%endif
 
 %install
 rm -rf build
@@ -55,9 +78,15 @@ rm -rf build
 rm -rf build
 %make_install PYTHON=%{__python3}
 
+%if 0%{?rhel} >= 7
+make -C doc DESTDIR=$RPM_BUILD_ROOT \
+    PYTHON=%{__python3} SPHINXBUILD=sphinx-build \
+    install
+%else
 make -C doc DESTDIR=$RPM_BUILD_ROOT \
     PYTHON=%{__python3} SPHINXBUILD=sphinx-build-%{python3_version} \
     install
+%endif
 
 
 %files
@@ -73,7 +102,11 @@ make -C doc DESTDIR=$RPM_BUILD_ROOT \
 %{python_sitelib}/qubesadmin-*egg-info
 %{python_sitelib}/qubesadmin
 
+%if 0%{?rhel} >= 7
+%files -n python34-qubesadmin
+%else
 %files -n python3-qubesadmin
+%endif
 %{python3_sitelib}/qubesadmin-*egg-info
 %{python3_sitelib}/qubesadmin
 


### PR DESCRIPTION
python3-sphinx and python3-daemon has no python34 packages. is it strictly necessary for now?