### PR TITLE
Simple client optimizations

### DIFF
--- a/qubesadmin/tools/qvm_ls.py
+++ b/qubesadmin/tools/qvm_ls.py
@@ -58,7 +58,7 @@ class Column(object):
 
     def __init__(self, head, attr=None, doc=None):
         self.ls_head = head
-        self.__doc__ = doc if doc is None else qubesadmin.utils.format_doc(doc)
+        self.__doc__ = doc
 
         # intentionally not always do set self._attr,
         # to cause AttributeError in self.format()

--- a/qubesadmin/utils.py
+++ b/qubesadmin/utils.py
@@ -25,8 +25,6 @@
 '''Various utility functions.'''
 import os
 
-import pkg_resources
-
 import qubesadmin.exc
 
 
@@ -89,6 +87,7 @@ def get_entry_point_one(group, name):
     '''Get a single entry point of given type,
     raise TypeError when there are multiple.
     '''
+    import pkg_resources
     epoints = tuple(pkg_resources.iter_entry_points(group, name))
     if not epoints:
         raise KeyError(name)

--- a/qubesadmin/utils.py
+++ b/qubesadmin/utils.py
@@ -27,32 +27,7 @@ import os
 
 import pkg_resources
 
-import docutils
-import docutils.core
-import docutils.io
 import qubesadmin.exc
-
-
-def format_doc(docstring):
-    '''Return parsed documentation string, stripping RST markup.
-    '''
-
-    if not docstring:
-        return ''
-
-    # pylint: disable=unused-variable
-    output, pub = docutils.core.publish_programmatically(
-        source_class=docutils.io.StringInput,
-        source=' '.join(docstring.strip().split()),
-        source_path=None,
-        destination_class=docutils.io.NullOutput, destination=None,
-        destination_path=None,
-        reader=None, reader_name='standalone',
-        parser=None, parser_name='restructuredtext',
-        writer=None, writer_name='null',
-        settings=None, settings_spec=None, settings_overrides=None,
-        config_section=None, enable_exit_status=None)
-    return pub.writer.document.astext()
 
 
 def parse_size(size):


### PR DESCRIPTION
This is a set of optimizations consisting of the changes in the "speed up qvm-ls" branch that don't make architectural or API changes.

In particular, startup time of all tools is reduced by dropping the use of the "console entry points" system and avoiding importing the pkg_resources module, which are very slow and don't seem to provide any added value, in favor of just generating simple scripts that directly import the desired module and call main
