### PR TITLE
Stop leaking terminal escapes via stderr

### DIFF
--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -26,6 +26,7 @@ import os
 import shlex
 import socket
 import subprocess
+import sys
 
 import logging
 
@@ -505,7 +506,9 @@ class QubesLocal(QubesBase):
             pass
         qrexec_opts = ['-d', dest]
         if filter_esc:
-            qrexec_opts.extend(['-t', '-T'])
+            qrexec_opts.extend(['-t'])
+        if filter_esc or os.isatty(sys.stderr.fileno()):
+            qrexec_opts.extend(['-T'])
         if localcmd:
             qrexec_opts.extend(['-l', localcmd])
         if user is None:


### PR DESCRIPTION
What I meant to do with https://github.com/QubesOS/qubes-core-admin/pull/167

---

This restores Qubes R3.2 behavior

Before this patch, the following:

    qvm-run -p sys-firewall 'echo -e "\e[0;46mcyan!" >&2' | wc -l

leaks the escape sequences through to the dom0 terminal via stderr,
in this case demonstrated by the ability to change the text color while
it should be fixed to red.

This can also be abused with xterm reporting sequences to cause input
to be sent to the dom0 terminal. This is potentially a security issue.