### PR TITLE
Fix issue #3303

### DIFF
--- a/qubesadmin/backup/restore.py
+++ b/qubesadmin/backup/restore.py
@@ -1775,7 +1775,8 @@ class BackupRestore(object):
                 restore_info['dom0'].good_to_go:
             vms_dirs.append(os.path.dirname(restore_info['dom0'].subdir))
             vms_size += restore_info['dom0'].size
-            handlers[restore_info['dom0'].subdir] = (self._handle_dom0, None)
+            if not self.options.verify_only:
+                handlers[restore_info['dom0'].subdir] = (self._handle_dom0, None)
         try:
             self._restore_vm_data(vms_dirs=vms_dirs, vms_size=vms_size,
                 handlers=handlers)

--- a/qubesadmin/tools/qvm_backup_restore.py
+++ b/qubesadmin/tools/qvm_backup_restore.py
@@ -134,8 +134,12 @@ def handle_broken(app, args, restore_info):
                 "Or use --rename-conflicting to restore those VMs under "
                 "modified names (with numbers at the end).")
 
-    app.log.info("The above VMs will be copied and added to your system.")
-    app.log.info("Exisiting VMs will NOT be removed.")
+    if args.verify_only:
+        app.log.info("The above VM archive(s) will be verified.")
+        app.log.info("Existing VMs will NOT be removed or altered.")
+    else:
+        app.log.info("The above VMs will be copied and added to your system.")
+        app.log.info("Exisiting VMs will NOT be removed.")
 
     if there_are_missing_templates:
         app.log.warning("*** One or more TemplateVMs are missing on the "


### PR DESCRIPTION
This allows qvm-backup-restore to perform verify-only operations whether or not archive contains vm names that match live qubesdb.
issue #3303