### PR TITLE
backup: restore Qubes 3.x VMs as HVMs

### DIFF
--- a/qubesadmin/backup/core2.py
+++ b/qubesadmin/backup/core2.py
@@ -296,8 +296,6 @@ class Core2Qubes(qubesadmin.backup.BackupApp):
             # it this way, otherwise some OSes (Windows) will crash because
             # of substantial hardware change
             vm.features['linux-stubdom'] = False
-        else:
-            vm.properties['virt_mode'] = 'pv'
         if vm_class_name in ('QubesNetVm', 'QubesProxyVm'):
             vm.properties['provides_network'] = True
         if vm_class_name == 'QubesNetVm':

--- a/qubesadmin/tests/backup/backupcompatibility.py
+++ b/qubesadmin/tests/backup/backupcompatibility.py
@@ -154,7 +154,6 @@ parsed_qubes_xml_r2 = {
             'klass': 'TemplateVM',
             'label': 'black',
             'properties': {
-                'virt_mode': 'pv',
                 'maxmem': '1535',
             },
             'devices': {},
@@ -172,7 +171,6 @@ parsed_qubes_xml_r2 = {
             'klass': 'AppVM',
             'label': 'red',
             'properties': {
-                'virt_mode': 'pv',
                 'maxmem': '1535',
                 'memory': '200',
                 'netvm': None,
@@ -197,7 +195,6 @@ parsed_qubes_xml_r2 = {
             'klass': 'AppVM',
             'label': 'green',
             'properties': {
-                'virt_mode': 'pv',
                 'maxmem': '1535',
                 'memory': '200',
                 'provides_network': True
@@ -213,7 +210,6 @@ parsed_qubes_xml_r2 = {
             'klass': 'AppVM',
             'label': 'gray',
             'properties': {
-                'virt_mode': 'pv',
                 'maxmem': '1535',
                 'vcpus': '1'
             },
@@ -228,7 +224,7 @@ parsed_qubes_xml_r2 = {
         'banking': {
             'klass': 'AppVM',
             'label': 'green',
-            'properties': {'virt_mode': 'pv', 'maxmem': '1535'},
+            'properties': {'maxmem': '1535'},
             'devices': {},
             'tags': set(),
             'features': {'service.meminfo-writer': True},
@@ -239,7 +235,7 @@ parsed_qubes_xml_r2 = {
         'personal': {
             'klass': 'AppVM',
             'label': 'yellow',
-            'properties': {'virt_mode': 'pv', 'maxmem': '1535'},
+            'properties': {'maxmem': '1535'},
             'devices': {},
             'tags': set(),
             'features': {'service.meminfo-writer': True},
@@ -251,7 +247,6 @@ parsed_qubes_xml_r2 = {
             'klass': 'AppVM',
             'label': 'red',
             'properties': {
-                'virt_mode': 'pv',
                 'maxmem': '1535',
                 'netvm': 'test-testproxy',
                 'default_dispvm': 'disp-test-testproxy',
@@ -267,7 +262,6 @@ parsed_qubes_xml_r2 = {
             'klass': 'AppVM',
             'label': 'red',
             'properties': {
-                'virt_mode': 'pv',
                 'maxmem': '1535',
                 'memory': '200',
                 'provides_network': True},
@@ -282,7 +276,6 @@ parsed_qubes_xml_r2 = {
             'klass': 'AppVM',
             'label': 'red',
             'properties': {
-                'virt_mode': 'pv',
                 'maxmem': '1535',
                 'memory': '200',
                 'provides_network': True},
@@ -310,7 +303,7 @@ parsed_qubes_xml_r2 = {
         'test-work': {
             'klass': 'AppVM',
             'label': 'green',
-            'properties': {'virt_mode': 'pv', 'maxmem': '1535'},
+            'properties': {'maxmem': '1535'},
             'devices': {},
             'tags': set(),
             'features': {'service.meminfo-writer': True},
@@ -321,7 +314,7 @@ parsed_qubes_xml_r2 = {
         'test-template-clone': {
             'klass': 'TemplateVM',
             'label': 'green',
-            'properties': {'virt_mode': 'pv', 'maxmem': '1535'},
+            'properties': {'maxmem': '1535'},
             'devices': {},
             'tags': set(),
             'features': {
@@ -337,7 +330,7 @@ parsed_qubes_xml_r2 = {
         'test-custom-template-appvm': {
             'klass': 'AppVM',
             'label': 'yellow',
-            'properties': {'virt_mode': 'pv', 'maxmem': '1535'},
+            'properties': {'maxmem': '1535'},
             'devices': {},
             'tags': set(),
             'features': {'service.meminfo-writer': True},
@@ -348,7 +341,7 @@ parsed_qubes_xml_r2 = {
         'test-standalonevm': {
             'klass': 'StandaloneVM',
             'label': 'blue',
-            'properties': {'virt_mode': 'pv', 'maxmem': '1535'},
+            'properties': {'maxmem': '1535'},
             'devices': {},
             'tags': set(),
             'features': {
@@ -364,7 +357,7 @@ parsed_qubes_xml_r2 = {
         'test-net': {
             'klass': 'AppVM',
             'label': 'red',
-            'properties': {'virt_mode': 'pv',
+            'properties': {
                 'maxmem': '1535',
                 'memory': '200',
                 'netvm': None,
@@ -606,7 +599,6 @@ parsed_qubes_xml_v4 = {
             'klass': 'AppVM',
             'label': 'red',
             'properties': {
-                'virt_mode': 'pv',
                 'autostart': 'True',
                 'maxmem': '400',
                 'provides_network': 'True',

--- a/qubesadmin/tests/backup/v4-qubes.xml
+++ b/qubesadmin/tests/backup/v4-qubes.xml
@@ -421,7 +421,6 @@
       <properties>
         <property name="autostart">True</property>
         <property name="label">label-1</property>
-        <property name="virt_mode">pv</property>
         <property name="maxmem">400</property>
         <property name="name">sys-usb</property>
         <property name="qid">5</property>


### PR DESCRIPTION
Make use of better security of Qubes 4.x by using HVM by default. If
some VMs are incompatible with it (like MirageOS based), user can always
switch it to PV manually later.