### PR TITLE
qvm-device/block: Alias '--ro' to '--option read-only=yes'

### DIFF
--- a/doc/manpages/qvm-device.rst
+++ b/doc/manpages/qvm-device.rst
@@ -59,6 +59,11 @@ Attach the device with *DEVICE_ID* from *BACKEND_DOMAIN* to the domain *VMNAME*
    specify this option multiple times. See below for options specific to
    different device classes.
 
+.. option:: --ro
+
+   Alias for the `read-only=yes` option. If you specify both `--ro` and
+   `--option read-only=no`, `--ro` takes precedence.
+
 .. option:: --persistent, -p
 
    Attach device persistently, which means have it attached also after qube restart.

--- a/qubesadmin/tools/qvm_device.py
+++ b/qubesadmin/tools/qvm_device.py
@@ -119,6 +119,8 @@ def attach_device(args):
     device_assignment = args.device_assignment
     vm = args.domains[0]
     options = dict(opt.split('=', 1) for opt in args.option or [])
+    if args.ro:
+        options['read-only'] = 'yes'
     device_assignment.persistent = args.persistent
     device_assignment.options = options
     vm.devices[args.devclass].attach(device_assignment)
@@ -236,6 +238,9 @@ def get_parser(device_class=None):
     attach_parser.add_argument('--option', '-o', action='append',
         help="Set option for the device in opt=value form (can be specified "
              "multiple times), see man qvm-device for details")
+    attach_parser.add_argument('--ro', action='store_true', default=False,
+        help="Attach device read-only (alias for read-only=yes option, "
+             "takes precedence)")
     attach_parser.add_argument('--persistent', '-p', action='store_true',
         default=False,
         help="Attach device persistently (so it will be automatically "


### PR DESCRIPTION
It's quicker to type and compatible with pre-R4.0 habits/scripts.

[Note that this adds an `--ro` option to the `attach` help message for _all_ device classes. I don't know if there's a good way to restrict it to `block`.]