### PR TITLE
Fix qvm-run --dispvm some-command

### DIFF
--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -494,6 +494,7 @@ class QubesLocal(QubesBase):
         :param str user: username to run service as
         :param str localcmd: Command to connect stdin/stdout to
         :param bool wait: wait for remote process to finish
+        :param int connect_timeout: qrexec client connection timeout
         :rtype: subprocess.Popen
         '''
 
@@ -516,6 +517,8 @@ class QubesLocal(QubesBase):
             user = 'DEFAULT'
         if not wait:
             qrexec_opts.extend(['-e'])
+        if 'connect_timeout' in kwargs:
+            qrexec_opts.extend(['-w', str(kwargs.pop('connect_timeout'))])
         kwargs.setdefault('stdin', subprocess.PIPE)
         kwargs.setdefault('stdout', subprocess.PIPE)
         kwargs.setdefault('stderr', subprocess.PIPE)

--- a/qubesadmin/tests/tools/qvm_run.py
+++ b/qubesadmin/tests/tools/qvm_run.py
@@ -428,3 +428,55 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
         self.assertEqual(ret, 0)
         self.assertEqual(self.app.service_calls, [])
         self.assertAllCalled()
+
+    def test_014_dispvm_local_gui(self):
+        self.app.qubesd_connection_type = 'socket'
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.CreateDisposable', None, None)] = \
+            b'0\0disp123'
+        self.app.expected_calls[('disp123', 'admin.vm.Kill', None, None)] = \
+            b'0\0'
+        self.app.expected_calls[
+            ('disp123', 'admin.vm.property.Get', 'qrexec_timeout', None)] = \
+            b'0\0default=yes type=int 30'
+        ret = qubesadmin.tools.qvm_run.main(
+            ['--dispvm', '--', 'test.command'], app=self.app)
+        self.assertEqual(ret, 0)
+        self.assertEqual(self.app.service_calls, [
+            ('disp123', 'qubes.VMShell', {
+                'localcmd': None,
+                'stdout': subprocess.DEVNULL,
+                'stderr': subprocess.DEVNULL,
+                'user': None,
+                'connect_timeout': 30,
+            }),
+            ('disp123', 'qubes.VMShell',
+            b'id -un | /etc/qubes-rpc/qubes.WaitForSession >/dev/null '
+            b'2>/dev/null; test.command; exit\n'),
+        ])
+        self.assertAllCalled()
+
+    def test_015_dispvm_local_no_gui(self):
+        self.app.qubesd_connection_type = 'socket'
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.CreateDisposable', None, None)] = \
+            b'0\0disp123'
+        self.app.expected_calls[('disp123', 'admin.vm.Kill', None, None)] = \
+            b'0\0'
+        self.app.expected_calls[
+            ('disp123', 'admin.vm.property.Get', 'qrexec_timeout', None)] = \
+            b'0\0default=yes type=int 30'
+        ret = qubesadmin.tools.qvm_run.main(
+            ['--dispvm', '--no-gui', 'test.command'], app=self.app)
+        self.assertEqual(ret, 0)
+        self.assertEqual(self.app.service_calls, [
+            ('disp123', 'qubes.VMShell', {
+                'localcmd': None,
+                'stdout': subprocess.DEVNULL,
+                'stderr': subprocess.DEVNULL,
+                'user': None,
+                'connect_timeout': 30,
+            }),
+            ('disp123', 'qubes.VMShell', b'test.command; exit\n'),
+        ])
+        self.assertAllCalled()

--- a/qubesadmin/tests/tools/qvm_run.py
+++ b/qubesadmin/tests/tools/qvm_run.py
@@ -343,6 +343,9 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             b'0\0disp123'
         self.app.expected_calls[('disp123', 'admin.vm.Kill', None, None)] = \
             b'0\0'
+        self.app.expected_calls[
+            ('disp123', 'admin.vm.property.Get', 'qrexec_timeout', None)] = \
+            b'0\0default=yes type=int 30'
         ret = qubesadmin.tools.qvm_run.main(
             ['--dispvm', '--service', 'test.service'], app=self.app)
         self.assertEqual(ret, 0)
@@ -352,6 +355,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                 'stdout': subprocess.DEVNULL,
                 'stderr': subprocess.DEVNULL,
                 'user': None,
+                'connect_timeout': 30,
             }),
             ('disp123', 'test.service', b''),
         ])
@@ -364,6 +368,9 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             b'0\0disp123'
         self.app.expected_calls[('disp123', 'admin.vm.Kill', None, None)] = \
             b'0\0'
+        self.app.expected_calls[
+            ('disp123', 'admin.vm.property.Get', 'qrexec_timeout', None)] = \
+            b'0\0default=yes type=int 30'
         ret = qubesadmin.tools.qvm_run.main(
             ['--dispvm=test-vm', '--service', 'test.service'], app=self.app)
         self.assertEqual(ret, 0)
@@ -373,6 +380,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                 'stdout': subprocess.DEVNULL,
                 'stderr': subprocess.DEVNULL,
                 'user': None,
+                'connect_timeout': 30,
             }),
             ('disp123', 'test.service', b''),
         ])

--- a/qubesadmin/tests/vm/dispvm.py
+++ b/qubesadmin/tests/vm/dispvm.py
@@ -28,11 +28,14 @@ class TC_00_Dispvm(qubesadmin.tests.QubesTestCase):
             ('dom0', 'admin.vm.CreateDisposable', None, None)] = b'0\0disp123'
         self.app.expected_calls[
             ('disp123', 'admin.vm.Kill', None, None)] = b'0\0'
+        self.app.expected_calls[
+            ('disp123', 'admin.vm.property.Get', 'qrexec_timeout', None)] = \
+            b'0\0default=yes type=int 30'
         vm = qubesadmin.vm.DispVM.from_appvm(self.app, None)
         (stdout, stderr) = vm.run_service_for_stdio('test.service')
         vm.cleanup()
         self.assertEqual(self.app.service_calls, [
-            ('disp123', 'test.service', {}),
+            ('disp123', 'test.service', {'connect_timeout': 30}),
             ('disp123', 'test.service', b''),
         ])
         self.assertAllCalled()
@@ -44,11 +47,14 @@ class TC_00_Dispvm(qubesadmin.tests.QubesTestCase):
             b'0\0disp123'
         self.app.expected_calls[
             ('disp123', 'admin.vm.Kill', None, None)] = b'0\0'
+        self.app.expected_calls[
+            ('disp123', 'admin.vm.property.Get', 'qrexec_timeout', None)] = \
+            b'0\0default=yes type=int 30'
         vm = qubesadmin.vm.DispVM.from_appvm(self.app, 'test-vm')
         (stdout, stderr) = vm.run_service_for_stdio('test.service')
         vm.cleanup()
         self.assertEqual(self.app.service_calls, [
-            ('disp123', 'test.service', {}),
+            ('disp123', 'test.service', {'connect_timeout': 30}),
             ('disp123', 'test.service', b''),
         ])
         self.assertAllCalled()

--- a/qubesadmin/tools/qvm_run.py
+++ b/qubesadmin/tools/qvm_run.py
@@ -213,7 +213,8 @@ def main(args=None, app=None):
                         user=args.user,
                         localcmd=args.localcmd,
                         **run_kwargs)
-                    proc.stdin.write(vm.prepare_input_for_vmshell(args.cmd))
+                    proc.stdin.write(vm.prepare_input_for_vmshell(args.cmd,
+                        wait_for_session=(args.gui and args.dispvm)))
                     proc.stdin.flush()
                 if args.passio and not args.localcmd:
                     copy_proc = multiprocessing.Process(target=copy_stdin,

--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -350,6 +350,9 @@ class DispVMWrapper(QubesVM):
                     'admin.vm.CreateDisposable')
                 dispvm = dispvm.decode('ascii')
                 self._method_dest = dispvm
+                # Service call may wait for session start, give it more time
+                # than default 5s
+                kwargs['connect_timeout'] = self.qrexec_timeout
         return super(DispVMWrapper, self).run_service(service, **kwargs)
 
     def cleanup(self):

--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -276,11 +276,14 @@ class QubesVM(qubesadmin.base.PropertyHolder):
         return stdouterr
 
     @staticmethod
-    def prepare_input_for_vmshell(command, input=None):
+    def prepare_input_for_vmshell(command, input=None, wait_for_session=False):
         '''Prepare shell input for the given command and optional (real) input
         '''  # pylint: disable=redefined-builtin
         if input is None:
             input = b''
+        if wait_for_session:
+            command = 'id -un | /etc/qubes-rpc/qubes.WaitForSession ' \
+                      '>/dev/null 2>/dev/null; ' + command
         return b''.join((command.rstrip('\n').encode('utf-8'),
             b'; exit\n', input))
 


### PR DESCRIPTION
There were two similar problems related to waiting for user session in newly
created DispVM.

Fixes QubesOS/qubes-issues#3012