### PR TITLE
Improve qvm-volume tool

### DIFF
--- a/doc/manpages/qvm-volume.rst
+++ b/doc/manpages/qvm-volume.rst
@@ -60,6 +60,30 @@ passed or stdout is redirected to a pipe or file.
 
 aliases: ls, l
 
+info
+^^^^
+| :command:`qvm-volume info` [-h] [--verbose] [--quiet] *VMNAME:VOLUME* [*PROPERTY*]
+
+Show information about given volume - all properties and available revisions
+(for `revert` action). If specific property is given, only its value is printed.
+For list of revisions use `revisions` value.
+
+aliases: i
+
+config
+^^^^^^
+| :command:`qvm-volume config` [-h] [--verbose] [--quiet] *VMNAME:VOLUME* *PROPERTY* *VALUE*
+
+Set property of given volume. Properties currently possible to change:
+
+  - `rw` - `True` if volume should be writeable by the qube, `False` otherwise
+  - `revisions_to_keep` - how many revisions (previous versions of volume)
+   should be keep. At each qube shutdown its previous state is saved in new
+   revision, and the oldest revisions are remove so that only
+   `revisions_to_keep` are left. Set to `0` to not leave any previous versions.
+
+aliases: c, set, s
+
 extend
 ^^^^^^
 | :command:`qvm-volume extend` [-h] [--verbose] [--quiet] *POOL_NAME:VOLUME_ID* *NEW_SIZE*

--- a/doc/manpages/qvm-volume.rst
+++ b/doc/manpages/qvm-volume.rst
@@ -86,14 +86,14 @@ aliases: c, set, s
 
 extend
 ^^^^^^
-| :command:`qvm-volume extend` [-h] [--verbose] [--quiet] *POOL_NAME:VOLUME_ID* *NEW_SIZE*
+| :command:`qvm-volume extend` [-h] [--verbose] [--quiet] *VMNAME:VOLUME* *NEW_SIZE*
 
 Extend the volume with *POOL_NAME:VOLUME_ID* TO *NEW_SIZE*
 
 revert
 ^^^^^^
 
-| :command:`qvm-volume revert` [-h] [--verbose] [--quiet] *POOL_NAME:VOLUME_ID*
+| :command:`qvm-volume revert` [-h] [--verbose] [--quiet] *VMNAME:VOLUME*
 
 Revert a volume to previous revision.
 

--- a/doc/manpages/qvm-volume.rst
+++ b/doc/manpages/qvm-volume.rst
@@ -84,11 +84,22 @@ Set property of given volume. Properties currently possible to change:
 
 aliases: c, set, s
 
-extend
+resize
 ^^^^^^
-| :command:`qvm-volume extend` [-h] [--verbose] [--quiet] *VMNAME:VOLUME* *NEW_SIZE*
+| :command:`qvm-volume resize` [-h] [--force|-f] [--verbose] [--quiet] *VMNAME:VOLUME* *NEW_SIZE*
 
-Extend the volume with *POOL_NAME:VOLUME_ID* TO *NEW_SIZE*
+Resize the volume with *VMNAME:VOLUME* TO *NEW_SIZE*
+
+If new size is smaller than current, the tool will refuse to continue unless
+`--force` option is used. One should be very careful about that, because
+shrinking volume without shrinking filesystem and other data inside first, will
+surely end with data loss.
+
+.. option:: -f, --force
+
+   Force operation even if new size is smaller than the current one.
+
+aliases: extend
 
 revert
 ^^^^^^

--- a/qubesadmin/storage.py
+++ b/qubesadmin/storage.py
@@ -142,6 +142,12 @@ class Volume(object):
         self._fetch_info()
         return self._info['rw'] == 'True'
 
+    @rw.setter
+    def rw(self, value):
+        '''Set rw property'''
+        self._qubesd_call('Set.rw', str(value).encode('ascii'))
+        self._info = None
+
     @property
     def snap_on_start(self):
         '''Create a snapshot from source on VM start.'''
@@ -170,6 +176,12 @@ class Volume(object):
         '''Number of revisions to keep around'''
         self._fetch_info()
         return int(self._info['revisions_to_keep'])
+
+    @revisions_to_keep.setter
+    def revisions_to_keep(self, value):
+        '''Set revisions_to_keep property'''
+        self._qubesd_call('Set.revisions_to_keep', str(value).encode('ascii'))
+        self._info = None
 
     def is_outdated(self):
         ''' Returns `True` if this snapshot of a source volume (for
@@ -285,6 +297,20 @@ class Pool(object):
     def driver(self):
         ''' Storage pool driver '''
         return self.config['driver']
+
+    @property
+    def revisions_to_keep(self):
+        '''Number of revisions to keep around'''
+        return int(self.config['revisions_to_keep'])
+
+    @revisions_to_keep.setter
+    def revisions_to_keep(self, value):
+        '''Set revisions_to_keep property'''
+        self.app.qubesd_call('dom0',
+            'admin.pool.Set.revisions_to_keep',
+            self.name,
+            str(value).encode('ascii'))
+        self._config = None
 
     @property
     def volumes(self):

--- a/qubesadmin/storage.py
+++ b/qubesadmin/storage.py
@@ -286,12 +286,20 @@ class Pool(object):
     @property
     def size(self):
         ''' Storage pool size, in bytes'''
-        return self.config['size']
+        try:
+            return int(self.config['size'])
+        except KeyError:
+            # pool driver does not provide size information
+            return None
 
     @property
     def usage(self):
         ''' Space used in the pool, in bytes '''
-        return self.config['usage']
+        try:
+            return int(self.config['usage'])
+        except KeyError:
+            # pool driver does not provide usage information
+            return None
 
     @property
     def driver(self):

--- a/qubesadmin/tools/qvm_volume.py
+++ b/qubesadmin/tools/qvm_volume.py
@@ -199,6 +199,13 @@ def extend_volumes(args):
     '''
     volume = args.volume
     size = qubesadmin.utils.parse_size(args.size)
+    if not args.force and size < volume.size:
+        raise qubesadmin.exc.StoragePoolException(
+            'For your own safety, shrinking of %s is'
+            ' disabled (%d < %d). If you really know what you'
+            ' are doing, resize filesystem manually first, then use `-f` '
+            'option.' %
+            (volume.name, size, volume.size))
     volume.resize(size)
 
 
@@ -237,10 +244,13 @@ def init_revert_parser(sub_parsers):
 def init_extend_parser(sub_parsers):
     ''' Add 'extend' action related options '''
     extend_parser = sub_parsers.add_parser(
-        "extend", help="extend volume from domain")
+        "resize", aliases=('extend', ), help="resize volume for domain")
     extend_parser.add_argument(metavar='VM:VOLUME', dest='volume',
                                action=qubesadmin.tools.VMVolumeAction)
     extend_parser.add_argument('size', help='New size in bytes')
+    extend_parser.add_argument('--force', '-f', action='store_true',
+        help='Force operation, even if new size is smaller than the current '
+             'one')
     extend_parser.set_defaults(func=extend_volumes)
 
 def init_info_parser(sub_parsers):


### PR DESCRIPTION
The final part for volume snapshots handling, especially revisions_to_keep
setting. This also adds an option to get more information about a single volume
(size, usage, available revisions etc).

Fixes QubesOS/qubes-issues#3256