### PR TITLE
tools/qvm-firewall: Describe available rules in --help output

### DIFF
--- a/qubesadmin/tools/qvm_firewall.py
+++ b/qubesadmin/tools/qvm_firewall.py
@@ -68,7 +68,33 @@ class RuleAction(argparse.Action):
         rule = qubesadmin.firewall.Rule(None, **kwargs)
         setattr(namespace, self.dest, rule)
 
-parser = qubesadmin.tools.QubesArgumentParser(vmname_nargs=1)
+epilog = """
+Rules can be given as positional arguments:
+    <action> [<dsthost> [<proto> [<dstports>|<icmptype>]]]
+
+And as keyword arguments:
+    action=<action> [specialtarget=dns] [dsthost=<dsthost>]
+    [proto=<proto>] [dstports=<dstports>] [icmptype=<icmptype>]
+
+Both formats, positional and keyword arguments, can be used
+interchangeably.
+
+Available rules:
+    action:        accept or drop
+    dsthost        IP, network or hostname
+                     (e.g. 10.5.3.2, 192.168.0.0/16,
+                     www.example.com, fd00::/8)
+    dstports       port or port range
+                     (e.g. 443 or 1200-1400)
+    icmptype       icmp type number (e.g. 8 for echo requests)
+    proto          icmp, tcp or udp
+    specialtarget  only the value dns is currently supported,
+                     it matches the configured dns servers of
+                     a VM
+"""
+
+parser = qubesadmin.tools.QubesArgumentParser(vmname_nargs=1, epilog=epilog,
+    formatter_class=argparse.RawTextHelpFormatter)
 
 action = parser.add_subparsers(dest='command', help='action to perform')
 


### PR DESCRIPTION
Looking at the code I noticed that there is an expires rule too but it isn't supported by the `qvm-firewall` tool. It appears to be used by the `qubes-vm-settings` to implement "Allow full access for …". I wondered if, at some point, this should be exposed in `qvm-firewall` too. Perhaps with the additional ability to specify a relative expiration time (e.g. `+300` seconds).

This is how the help text looks like now:

```
$ PYTHONPATH=$PWD python qubesadmin/tools/qvm_firewall.py --help
usage: qvm_firewall.py [--verbose] [--quiet] [--help] [--reload] [--raw]
                       VMNAME {add,del,list} ...

positional arguments:
  VMNAME          a domain name
  {add,del,list}  action to perform
    add           add rule
    del           remove rule
    list          list rules

optional arguments:
  --verbose, -v   increase verbosity
  --quiet, -q     decrease verbosity
  --help, -h      show this help message and exit
  --reload, -r    force reloading rules even when unchanged
  --raw           output rules as raw strings, instead of nice table

Rules can be given as positional arguments:
    <action> [<dsthost> [<proto> [<dstports>|<icmptype>]]]

And as keyword arguments:
    action=<action> [specialtarget=dns] [dsthost=<dsthost>]
    [proto=<proto>] [dstports=<dstports>] [icmptype=<icmptype>]

Both formats, positional and keyword arguments, can be used
interchangeably.

Available rules:
    action:        accept or drop
    dsthost        IP, network or hostname
                     (e.g. 10.5.3.2, 192.168.0.0/16,
                     www.example.com, fd00::/8)
    dstports       port or port range
                     (e.g. 443 or 1200-1400)
    icmptype       icmp type number (e.g. 8 for echo requests)
    proto          icmp, tcp or udp
    specialtarget  only the value dns is currently supported,
                     it matches the configured dns servers of
                     a VM

Command 'add':
  usage: qvm_firewall.py VMNAME add [--verbose] [--quiet] [--help]
                                    [--before BEFORE]
                                    rule [rule ...]

Command 'del':
  usage: qvm_firewall.py VMNAME del [--verbose] [--quiet] [--help]
                                    [--rule-no RULE_NO]
                                    [rule [rule ...]]

Command 'list':
  usage: qvm_firewall.py VMNAME list [--verbose] [--quiet] [--help]
```