### PR TITLE
tools/qvm-firewall: Show EXPIRE column in list output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.pyo
 build/
+doc/_build/
 pkgs/
 .coverage
 __pycache__

--- a/doc/manpages/qvm-firewall.rst
+++ b/doc/manpages/qvm-firewall.rst
@@ -31,11 +31,11 @@ Options
 
 .. option:: --reload, -r
 
-   force reloading rules even when unchanged
+   force reload of rules even when unchanged
 
 .. option:: --raw
 
-   Print raw rules when listing
+   in combination with :option:`--list`, print raw rules
 
 
 Actions description
@@ -45,7 +45,8 @@ Available actions:
 
 * add - add specified rule. See `Rule syntax` section below.
 
-* del - delete specified rule. Can be selected either by rule number using :option:`--rule-no`, or specifying rule itself.
+* del - delete specified rule. The rule to remove can be selected either by rule number using :option:`--rule-no`
+  or by specifying the rule itself using the same syntax used for adding it.
 
 * list - list all the rules for a given VM.
 
@@ -59,8 +60,8 @@ A single rule is built from:
  - action - either ``drop`` or ``accept``
  - zero or more matches
 
-Selected action is applied on given packet when all specified matches do match,
-further rules are not evaluated. If none of the rules match, default action
+Selected action is applied to packets when all specified matches match,
+further rules are not evaluated. If none of the rules match, the default action
 (``policy``) is applied.
 
 Supported matches:
@@ -76,9 +77,9 @@ Supported matches:
  - ``proto`` - specific IP protocol. Supported values: ``tcp``, ``udp``,
    ``icmp``.
 
- - ``dstports`` - destination port or ports range. Can be either a single port,
+ - ``dstports`` - destination port or ports range. Can be either a single port
    or a range separated by ``-``. Valid only together with ``proto=udp`` or
- ``proto=tcp``.
+   ``proto=tcp``.
 
  - ``icmptype`` - ICMP message type, specified as numeric value. Valid only
    together with ``proto=icmp``.
@@ -86,9 +87,10 @@ Supported matches:
  - ``specialtarget`` - predefined target. Currently the only supported value is
    ``dns``. This can be combined with other matches to narrow it down.
 
- - ``expire`` - rule matches only until specified time and then is automatically
- removed. The time can be given either as number of seconds since 1/1/1970, or
- ``+seconds`` as a relative time (``+300`` means 5 minutes from now).
+ - ``expire`` - the rule matches only until the specified time and is then
+   automatically removed. The time can be given either as number of seconds
+   since 1/1/1970 or as ``+seconds``, a relative time (``+300`` means 5
+   minutes from now).
 
 Authors
 -------

--- a/doc/manpages/qvm-firewall.rst
+++ b/doc/manpages/qvm-firewall.rst
@@ -66,6 +66,12 @@ further rules are not evaluated. If none of the rules match, default action
 Supported matches:
  - ``dsthost`` - destination host or network. Can be either IP address in CIDR
    notation, or a host name. Both IPv4 and IPv6 are supported by the rule syntax.
+   In order to allow reuse of ``--raw`` output, ``dst4`` and ``dst6`` are accepted
+   as synonyms.
+
+ - ``dst4`` - see ``dsthost``
+
+ - ``dst6`` - see ``dsthost``
 
  - ``proto`` - specific IP protocol. Supported values: ``tcp``, ``udp``,
    ``icmp``.

--- a/qubesadmin/firewall.py
+++ b/qubesadmin/firewall.py
@@ -34,6 +34,11 @@ class RuleOption(object):
         '''API representation of this rule element'''
         raise NotImplementedError
 
+    @property
+    def pretty_value(self):
+        '''Human readable representation'''
+        return str(self)
+
     def __str__(self):
         return self._value
 
@@ -212,8 +217,15 @@ class Expire(RuleOption):
 
     @property
     def expired(self):
-        '''Have this rule expired already?'''
+        '''Has this rule expired already?'''
         return self.datetime < datetime.datetime.utcnow()
+
+    @property
+    def pretty_value(self):
+        '''Human readable representation'''
+        now = datetime.datetime.utcnow()
+        duration = (self.datetime - now).total_seconds()
+        return "{:+.0f}s".format(duration)
 
 
 class Comment(RuleOption):

--- a/qubesadmin/tests/tools/qvm_firewall.py
+++ b/qubesadmin/tests/tools/qvm_firewall.py
@@ -88,6 +88,14 @@ class TC_00_RuleAction(qubesadmin.tests.QubesTestCase):
                 None, action='accept', dsthost='127.0.0.1/32',
                 expire=now+100))
 
+    def test_006_dsthost_aliases(self):
+        ns = argparse.Namespace()
+        for name in ['dsthost', 'dst4', 'dst6']:
+            self.action(None, ns, [name + '=127.0.0.1', 'accept'])
+            self.assertEqual(ns.rule,
+                qubesadmin.firewall.Rule(
+                    None, action='accept', dsthost='127.0.0.1/32'))
+
 
 class TC_10_qvm_firewall(qubesadmin.tests.QubesTestCase):
     def setUp(self):

--- a/qubesadmin/tools/qvm_firewall.py
+++ b/qubesadmin/tools/qvm_firewall.py
@@ -135,20 +135,20 @@ def rules_list_table(vm):
     :return: None
     '''
     header = ['NO', 'ACTION', 'HOST', 'PROTOCOL', 'PORT(S)',
-        'SPECIAL TARGET', 'ICMP TYPE', 'COMMENT']
+        'SPECIAL TARGET', 'ICMP TYPE', 'EXPIRE', 'COMMENT']
     rows = []
     for (rule, rule_no) in zip(vm.firewall.rules, itertools.count()):
-        row = [str(x) if x is not None else '-' for x in [
-            rule_no,
+        row = [x.pretty_value if x is not None else '-' for x in [
             rule.action,
             rule.dsthost,
             rule.proto,
             rule.dstports,
             rule.specialtarget,
             rule.icmptype,
+            rule.expire,
             rule.comment,
         ]]
-        rows.append(row)
+        rows.append([str(rule_no)] + row)
     qubesadmin.tools.print_table([header] + rows)
 
 

--- a/qubesadmin/tools/qvm_firewall.py
+++ b/qubesadmin/tools/qvm_firewall.py
@@ -87,7 +87,7 @@ And as keyword arguments:
 Both formats, positional and keyword arguments, can be used
 interchangeably.
 
-Available rules:
+Available matches:
     action:        accept or drop
     dst4           synonym for dsthost
     dst6           synonym for dsthost
@@ -101,9 +101,9 @@ Available rules:
     specialtarget  only the value dns is currently supported,
                      it matches the configured dns servers of
                      a VM
-    expire         a rule is automatically removed at given time, given as
-                     seconds since 1/1/1970, or +seconds (e.g. +300 for rule
-                     expire in 5 minutes)
+    expire         the rule is automatically removed at the time given as
+                     seconds since 1/1/1970, or +seconds (e.g. +300 for a rule
+                     to expire in 5 minutes)
 """
 
 parser = qubesadmin.tools.QubesArgumentParser(vmname_nargs=1, epilog=epilog,
@@ -113,20 +113,20 @@ action = parser.add_subparsers(dest='command', help='action to perform')
 
 action_add = action.add_parser('add', help='add rule')
 action_add.add_argument('--before', type=int, default=None,
-    help='Add rule before rule with given number, instead of at the end')
-action_add.add_argument('rule', nargs='+', action=RuleAction,
+    help='Add rule before rule with given number instead at the end')
+action_add.add_argument('rule', metavar='match', nargs='+', action=RuleAction,
     help='rule description')
 
 action_del = action.add_parser('del', help='remove rule')
 action_del.add_argument('--rule-no', dest='rule_no', type=int,
     action='store', help='rule number')
-action_del.add_argument('rule', nargs='*', action=RuleAction,
+action_del.add_argument('rule', metavar='match', nargs='*', action=RuleAction,
     help='rule to be removed')
 
 action_list = action.add_parser('list', help='list rules')
 
 parser.add_argument('--reload', '-r', action='store_true',
-    help='force reloading rules even when unchanged')
+    help='force reload of rules even when unchanged')
 
 parser.add_argument('--raw', action='store_true',
     help='output rules as raw strings, instead of nice table')

--- a/qubesadmin/tools/qvm_firewall.py
+++ b/qubesadmin/tools/qvm_firewall.py
@@ -56,6 +56,8 @@ class RuleAction(argparse.Action):
             else:
                 raise argparse.ArgumentError(None,
                     'invalid rule description: {}'.format(opt))
+            if key in ['dst4', 'dst6']:
+                key = 'dsthost'
             if key not in allowed_opts:
                 raise argparse.ArgumentError(None,
                     'Invalid rule element: {}'.format(opt))
@@ -87,6 +89,8 @@ interchangeably.
 
 Available rules:
     action:        accept or drop
+    dst4           synonym for dsthost
+    dst6           synonym for dsthost
     dsthost        IP, network or hostname
                      (e.g. 10.5.3.2, 192.168.0.0/16,
                      www.example.com, fd00::/8)


### PR DESCRIPTION
Sample output:

```
[user@dom0 ~]$ qvm-firewall sys-whonix add --before 0 action=accept dsthost=8.8.8.8 proto=tcp dstports=53 expire=+1800
[user@dom0 ~]$ qvm-firewall sys-whonix add --before 0 action=accept dsthost=8.8.8.8 proto=udp dstports=53 expire=+1800
[user@dom0 ~]$ qvm-firewall sys-whonix
NO  ACTION  HOST            PROTOCOL  PORT(S)  SPECIAL TARGET  ICMP TYPE  EXPIRE  COMMENT
0   accept  8.8.8.8/32      udp       53       -               -          +1791s  -
1   accept  8.8.8.8/32      tcp       53       -               -          +1790s  -
2   drop    10.0.0.0/8      -         -        -               -          -       private address
3   drop    169.254.0.0/16  -         -        -               -          -       private address
4   drop    172.16.0.0/12   -         -        -               -          -       link local
5   drop    192.168.0.0/16  -         -        -               -          -       private address
6   drop    fc00::/8        -         -        -               -          -       site local
7   drop    fd00::/8        -         -        -               -          -       unique site local
8   drop    fe80::/10       -         -        -               -          -       link local
9   accept  -               tcp       -        -               -          -       -
10  drop    -               -         -        -               -          -       -
```

I also looked at the output with --raw, I'm wondering if it should be slightly adjusted. The output currently looks like this:

```
action=accept proto=udp dst4=8.8.8.8/32 dstports=50-50 expire=1525105863
action=accept proto=tcp dst4=8.8.8.8/32 dstports=50-50 expire=1525105729
action=drop dst4=10.0.0.0/8 comment=private address
action=drop dst4=169.254.0.0/16 comment=private address
action=drop dst4=172.16.0.0/12 comment=link local
action=drop dst4=192.168.0.0/16 comment=private address
action=drop dst6=fc00::/8 comment=site local
action=drop dst6=fd00::/8 comment=unique site local
action=drop dst6=fe80::/10 comment=link local
action=accept proto=tcp
action=drop
```

I'm not sure what the intention of --raw originally was but I often use it as a template for writing new rules. Hence, I'd like change `dst4` and `dst6` to `dsthost`  and the comments to be quoted (`comment='private address'`). That way the output can be used as input for `qvm-firewall … add` again. Since I didn't know if there is a particular reason for the output being that way, apart for it matching the underlying API, I wondered if this would be a change you'd be willing to accept. I'd be happy to implement it.