### PR TITLE
Change qvm_prefs to handle "None" as Property None

### DIFF
--- a/qubesadmin/base.py
+++ b/qubesadmin/base.py
@@ -275,6 +275,8 @@ class PropertyHolder(object):
                 value = value.name
             if value is None:
                 value = ''
+            if str(value).lower() == "none":
+                value = ''
             try:
                 self.qubesd_call(
                     self._method_dest,

--- a/qubesadmin/base.py
+++ b/qubesadmin/base.py
@@ -275,8 +275,6 @@ class PropertyHolder(object):
                 value = value.name
             if value is None:
                 value = ''
-            if str(value).lower() == "none":
-                value = ''
             try:
                 self.qubesd_call(
                     self._method_dest,

--- a/qubesadmin/tests/tools/qvm_prefs.py
+++ b/qubesadmin/tests/tools/qvm_prefs.py
@@ -135,3 +135,29 @@ class TC_00_qvm_prefs(qubesadmin.tests.QubesTestCase):
             qubesadmin.tools.qvm_prefs.main(['dom0', 'prop1'], app=self.app)
         self.assertEqual('', stdout.getvalue())
         self.assertAllCalled()
+
+    def test_008_set_vm_prop_none(self):
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.List', None, None)] = \
+            b'0\x00dom0 class=AdminVM state=Running\n'
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.property.Set', 'netvm', b'')] = \
+            b'0\x00'
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.property.Set', 'default_dispvm', b'')] = \
+            b'0\x00'
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.property.Set', 'user', b'none')] = \
+            b'0\x00'
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.property.Set', 'prop1', b'None')] = \
+            b'0\x00'
+        self.assertEqual(0, qubesadmin.tools.qvm_prefs.main([
+            'dom0', 'netvm', 'None'], app=self.app))
+        self.assertEqual(0, qubesadmin.tools.qvm_prefs.main([
+            'dom0', 'default_dispvm', 'none'], app=self.app))
+        self.assertEqual(0, qubesadmin.tools.qvm_prefs.main([
+            'dom0', 'user', 'none'], app=self.app))
+        self.assertEqual(0, qubesadmin.tools.qvm_prefs.main([
+            'dom0', 'prop1', 'None'], app=self.app))
+        self.assertAllCalled()

--- a/qubesadmin/tools/qvm_prefs.py
+++ b/qubesadmin/tools/qvm_prefs.py
@@ -112,6 +112,9 @@ def process_actions(parser, args, target):
         args.property = args.property.replace('-', '_')
 
     if args.value is not None:
+        if str(args.value).lower() == "none":
+            if args.property in ["default_dispvm", "netvm", "template"]:
+                args.value = ''
         try:
             setattr(target, args.property, args.value)
         except AttributeError:


### PR DESCRIPTION
This changes to accept the string none as the value None,
as if an empty string was entered. This allows setting the
netvm to "None" as described in QubesOS/qubes-issues#3942