### PR TITLE
Better information on error in qvm-remove

### DIFF
--- a/qubesadmin/exc.py
+++ b/qubesadmin/exc.py
@@ -85,6 +85,10 @@ class QubesNoTemplateError(QubesVMError):
     '''Cannot start domain, because there is no template'''
 
 
+class QubesVMInUseError(QubesVMError):
+    '''VM is in use, cannot remove.'''
+
+
 class QubesValueError(QubesException, ValueError):
     '''Cannot set some value, because it is invalid, out of bounds, etc.'''
     pass

--- a/qubesadmin/tests/tools/qvm_remove.py
+++ b/qubesadmin/tests/tools/qvm_remove.py
@@ -21,6 +21,7 @@
 import qubesadmin.tests
 import qubesadmin.tests.tools
 import qubesadmin.tools.qvm_remove
+import unittest.mock
 
 
 class TC_00_qvm_remove(qubesadmin.tests.QubesTestCase):
@@ -33,3 +34,20 @@ class TC_00_qvm_remove(qubesadmin.tests.QubesTestCase):
             b'0\x00\n'
         qubesadmin.tools.qvm_remove.main(['-f', 'some-vm'], app=self.app)
         self.assertAllCalled()
+
+    @unittest.mock.patch('qubesadmin.utils.vm_dependencies')
+    def test_100_dependencies(self, mock_dependencies):
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.List', None, None)] = \
+            b'0\x00some-vm class=AppVM state=Running\n'
+        self.app.expected_calls[
+            ('some-vm', 'admin.vm.Remove', None, None)] = \
+            b'2\x00QubesVMInUseError\x00\x00An error occurred\x00'
+
+        mock_dependencies.return_value = \
+            [(None, 'default_template'), (self.app.domains['some-vm'], 'netvm')]
+
+        qubesadmin.tools.qvm_remove.main(['-f', 'some-vm'], app=self.app)
+
+        self.assertTrue(mock_dependencies.called,
+                        "Dependencies check not called.")


### PR DESCRIPTION
If qvm-remove fails because the VM is in use, it will display
information about where it is used. Also a test for it.

fixes QubesOS/qubes-issues#3193