### PR TITLE
Exclude installed_by_rpm when Restoring VM from Backup

### DIFF
--- a/qubesadmin/backup/restore.py
+++ b/qubesadmin/backup/restore.py
@@ -1940,6 +1940,9 @@ class BackupRestore(object):
                 # restore options
                 if prop in ['template', 'netvm', 'default_dispvm']:
                     continue
+                # exclude as this only applied before restoring
+                if prop in ['installed_by_rpm']:
+                    continue
                 self._restore_property(new_vm, prop, value)
 
             for feature, value in vm.features.items():


### PR DESCRIPTION
VMs listed as from an rpm when they were really from a backup
lead to a missleading error message when deleting.

Fixes QubesOS/qubes-issues#4192