### PR TITLE
Simplify class

### DIFF
--- a/qubesadmin/tools/qvm_create.py
+++ b/qubesadmin/tools/qvm_create.py
@@ -98,7 +98,8 @@ def main(args=None, app=None):
         vm_classes = args.app.qubesd_call('dom0', 'admin.vmclass.List').decode()
         vm_classes = vm_classes.splitlines()
         print("case insensitive, trailing 'VM' optional")
-        print('\n'.join(sorted(vm_classes)))
+        clsList=map(lambda x: x.lower().replace("vm", ""),sorted(vm_classes))
+        print('\n'.join(clsList))
         return 0
 
     pools = {}


### PR DESCRIPTION
The `--class` option should accept lowercase-definitions, especially "dispvm", since all other commands use lowercase-options. (e.g. `qvm-run --dispvm`)
The easiest way to implement this backwards-compatibly was to lowercase the argument, titlecase it and replace "vm" with "VM". Because it was easy to implement, I decided to allow omission of the trailing "vm", so `dispvm` and `disp` would both be valid.

First commit is the functional implementation, second I changed the `--help-classes`-output to show lowercase, "vm"-removed class options.