### PR TITLE
qvm-create: added --standalone and --disp shortcuts

### DIFF
--- a/doc/manpages/qvm-create.rst
+++ b/doc/manpages/qvm-create.rst
@@ -24,6 +24,14 @@ Options
 
    Decrease verbosity.
 
+.. option:: --standalone
+
+   shortcut for --class StandaloneVM, see below
+
+..option :: --disp
+
+   shortcut for --class DispVM --label red, see below
+
 .. option:: --help-classes
 
    List available qube classes and exit. See below for short description.

--- a/doc/manpages/qvm-create.rst
+++ b/doc/manpages/qvm-create.rst
@@ -28,7 +28,7 @@ Options
 
    shortcut for --class StandaloneVM, see below
 
-..option :: --disp
+.. option:: --disp
 
    shortcut for --class DispVM --label red, see below
 

--- a/qubesadmin/tests/tools/qvm_create.py
+++ b/qubesadmin/tests/tools/qvm_create.py
@@ -328,3 +328,25 @@ class TC_00_qvm_create(qubesadmin.tests.QubesTestCase):
                     app=self.app)
         self.assertIn('red, blue', stderr.getvalue())
         self.assertAllCalled()
+
+    def test_014_standalone_shortcut(self):
+        self.app.expected_calls[('dom0', 'admin.vm.Create.StandaloneVM',
+            None, b'name=new-vm label=red')] = b'0\x00'
+        self.app.expected_calls[('dom0', 'admin.label.List', None, None)] = \
+            b'0\x00red\nblue\n'
+        self.app.expected_calls[('dom0', 'admin.vm.List', None, None)] = \
+            b'0\x00new-vm class=StandaloneVM state=Halted\n'
+        qubesadmin.tools.qvm_create.main(['-l', 'red', '--standalone', 'new-vm'],
+            app=self.app)
+        self.assertAllCalled()
+
+    def test_015_disp_shortcut(self):
+        self.app.expected_calls[('dom0', 'admin.vm.Create.DispVM',
+            None, b'name=new-vm label=red')] = b'0\x00'
+        self.app.expected_calls[('dom0', 'admin.label.List', None, None)] = \
+            b'0\x00red\nblue\n'
+        self.app.expected_calls[('dom0', 'admin.vm.List', None, None)] = \
+            b'0\x00new-vm class=DispVM state=Halted\n'
+        qubesadmin.tools.qvm_create.main(['--disp', 'new-vm'],
+            app=self.app)
+        self.assertAllCalled()

--- a/qubesadmin/tools/qvm_create.py
+++ b/qubesadmin/tools/qvm_create.py
@@ -47,9 +47,9 @@ parser.add_argument('--standalone',
     action="store_true",
     help=' shortcut for --class StandaloneVM')
 
-parser.add_argument('--disp'
-    action=qubesadmin.tools.SinglePropertyAction,
-    help='alias for --class DispVM --label red --template <argument or default DVM>')
+parser.add_argument('--disp',
+    action="store_true",
+    help='alias for --class DispVM --label red')
 
 parser.add_argument('--property', '--prop',
     action=qubesadmin.tools.PropertyAction,
@@ -121,12 +121,11 @@ def main(args=None, app=None):
     if args.one_pool:
         pool = args.one_pool
 
-    if 'disp' in args.properties:
+    if args.disp:
         args.properties.setdefault('label', 'red')
         args.cls = 'DispVM'
-        args.properties.setdefault('template', args.properties['disp'])
 
-    if 'standalone' in args.properties:
+    if args.standalone:
         args.cls = 'StandaloneVM'
 
     if 'label' not in args.properties:

--- a/qubesadmin/tools/qvm_create.py
+++ b/qubesadmin/tools/qvm_create.py
@@ -43,6 +43,14 @@ parser.add_argument('--class', '-C', dest='cls',
     default='AppVM',
     help='specify the class of the new domain (default: %(default)s)')
 
+parser.add_argument('--standalone',
+    action="store_true",
+    help=' shortcut for --class StandaloneVM')
+
+parser.add_argument('--disp'
+    action=qubesadmin.tools.SinglePropertyAction,
+    help='alias for --class DispVM --label red --template <argument or default DVM>')
+
 parser.add_argument('--property', '--prop',
     action=qubesadmin.tools.PropertyAction,
     help='set domain\'s property, like "internal", "memory" or "vcpus"')
@@ -112,6 +120,14 @@ def main(args=None, app=None):
                     'Pool argument must be of form: -P volume_name=pool_name')
     if args.one_pool:
         pool = args.one_pool
+
+    if 'disp' in args.properties:
+        args.properties.setdefault('label', 'red')
+        args.cls = 'DispVM'
+        args.properties.setdefault('template', args.properties['disp'])
+
+    if 'standalone' in args.properties:
+        args.cls = 'StandaloneVM'
 
     if 'label' not in args.properties:
         parser.error('--label option is mandatory')


### PR DESCRIPTION
`--standalone` = `--class StandaloneVM`
`--disp` = `--class DispVM --label red --template`

Currently, both shortcuts take precedence over a specified `--class`. The `--label` and `--template` option of the `--disp`-shortcut are implemented using `args.properties.setdefault`, so specified `--label` and `--template` take precedence.

I'm uncertain which behavior would be expected of `--standalone --class [not StandaloneVM]`, so I'd change it according to other peoples expectations.

Sidenote: I'd like to label dispVMs with the usual red recycle-arrow, but don't know which label I would have to specify for that?

after a recommendation in a previous PR: https://github.com/QubesOS/qubes-core-admin-client/pull/83#pullrequestreview-180583699