### PR TITLE
 get_label now accepts integer and has correct return-type 

### DIFF
--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -216,10 +216,8 @@ class QubesBase(qubesadmin.base.PropertyHolder):
             pass
 
         # then search for index
-        if label.isdigit():
-            for i in self.labels:
-                if i.index == int(label):
-                    return i
+        if type(label) == int or label.isdigit():
+            return self.labels.values[int(label)]
 
         raise KeyError(label)
 

--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -217,7 +217,7 @@ class QubesBase(qubesadmin.base.PropertyHolder):
 
         # then search for index
         if type(label) == int or label.isdigit():
-            return self.labels.values[int(label)]
+            return self.labels.values()[int(label)]
 
         raise KeyError(label)
 

--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -216,11 +216,10 @@ class QubesBase(qubesadmin.base.PropertyHolder):
             pass
 
         # then search for index
-        if type(label) == int or label.isdigit():
+        if isinstance(label, int) or label.isdigit():
             for i in self.labels.values():
                 if i.index == int(label):
                     return i
-
         raise KeyError(label)
 
     @staticmethod

--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -217,7 +217,9 @@ class QubesBase(qubesadmin.base.PropertyHolder):
 
         # then search for index
         if type(label) == int or label.isdigit():
-            return self.labels.values()[int(label)]
+            for i in self.labels.values():
+                if i.index == int(label):
+                    return i
 
         raise KeyError(label)
 


### PR DESCRIPTION
implementation had several issues:
No integer would be accepted (`.isdigit` isn't implemented by `int`-type)
`i` is a `str`-type, so `i.index` is a function
return type would have been `str`, not `label.Label`

new implementation takes advantage of `dict.values()` function, which returns an array. `int(int)` returns `int` btw.