### PR TITLE
fixed typo

### DIFF
--- a/doc/manpages/qvm-create.rst
+++ b/doc/manpages/qvm-create.rst
@@ -61,7 +61,7 @@ Options
 .. option:: -P POOL
 
     Pool to use for the new domain. All volumes besides snapshots volumes are
-    imported in to the specified POOL. ~HIS IS WHAT YOU WANT TO USE NORMALLY.
+    imported in to the specified POOL. THIS IS WHAT YOU WANT TO USE NORMALLY.
 
 .. option:: --pool=POOL:VOLUME, -p POOL:VOLUME
 


### PR DESCRIPTION
Simple typo: "\~HIS IS WHAT YOU WANT TO USE NORMALLY."
Replaced "\~" by "T"