### PR TITLE
tools/qvm-run: do not color the output unless --pass-io is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Compatibility
 =============
 
 Most of the API modules are compatible with Python >= 2.7.
-Very few parts require Python >= 3.4:
+Very few parts require Python >= 3.5:
  - tools (`qvm-*`)
  - qubesadmin.events module (for asyncio module)
 
-Parts not compatible with Python < 3.4, are not installed in such environment.
+Parts not compatible with Python < 3.5, are not installed in such environment.

--- a/qubesadmin/tools/qvm_run.py
+++ b/qubesadmin/tools/qvm_run.py
@@ -197,11 +197,12 @@ def run_command_single(args, vm):
 def main(args=None, app=None):
     '''Main function of qvm-run tool'''
     args = parser.parse_args(args, app=app)
-    if args.color_output is None and args.filter_esc:
-        args.color_output = '31'
+    if args.passio:
+        if args.color_output is None and args.filter_esc:
+            args.color_output = 31
 
-    if args.color_stderr is None and os.isatty(sys.stderr.fileno()):
-        args.color_stderr = 31
+        if args.color_stderr is None and os.isatty(sys.stderr.fileno()):
+            args.color_stderr = 31
 
     if len(args.domains) > 1 and args.passio and not args.localcmd:
         parser.error('--passio cannot be used when more than 1 qube is chosen '

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,9 @@ import setuptools.command.install
 import sys
 
 exclude=[]
-if sys.version_info[0:2] < (3, 4):
-    exclude += ['qubesadmin.tools', 'qubesadmin.tests.tools']
-    exclude += ['qubesadmin.backup', 'qubesadmin.tests.backup']
 if sys.version_info[0:2] < (3, 5):
+    exclude += ['qubesadmin.backup', 'qubesadmin.tests.backup']
+    exclude += ['qubesadmin.tools', 'qubesadmin.tests.tools']
     exclude += ['qubesadmin.events']
 
 # don't import: import * is unreliable and there is no need, since this is


### PR DESCRIPTION
Since no output from VM is passed (and even if it would, it's redirected
to /dev/null), there is no need to switch output color.
This fixes the case when qvm-run is started in background - the color
change would affect further shell output.

Fixes QubesOS/qubes-issues#4808