### PR TITLE
qvm-prefs: possibility to only show non-default properties

### DIFF
--- a/doc/manpages/qubes-prefs.rst
+++ b/doc/manpages/qubes-prefs.rst
@@ -19,6 +19,10 @@ Options
 
    List available properties with short descriptions and exit.
 
+.. option:: --hide-default
+
+   Do not show properties that are set to the default value.
+
 .. option:: --verbose, -v
 
    Increase verbosity.

--- a/doc/manpages/qvm-prefs.rst
+++ b/doc/manpages/qvm-prefs.rst
@@ -19,6 +19,10 @@ Options
 
    List available properties with short descriptions and exit.
 
+.. option:: --hide-default
+
+   Do not show properties that are set to the default value.
+
 .. option:: --verbose, -v
 
    Increase verbosity.

--- a/qubesadmin/tests/tools/qubes_prefs.py
+++ b/qubesadmin/tests/tools/qubes_prefs.py
@@ -39,6 +39,11 @@ class TC_00_qubes_prefs(qubesadmin.tests.QubesTestCase):
         self.assertEqual(stdout.getvalue(),
             'prop1  D  value1\n'
             'prop2  -  value2\n')
+        with qubesadmin.tests.tools.StdoutBuffer() as stdout:
+            self.assertEqual(0, qubesadmin.tools.qubes_prefs.main([
+                '--hide-default'], app=self.app))
+        self.assertEqual(stdout.getvalue(),
+            'prop2  -  value2\n')
         self.assertAllCalled()
 
     def test_002_set_property(self):

--- a/qubesadmin/tests/tools/qvm_prefs.py
+++ b/qubesadmin/tests/tools/qvm_prefs.py
@@ -44,6 +44,11 @@ class TC_00_qvm_prefs(qubesadmin.tests.QubesTestCase):
         self.assertEqual(stdout.getvalue(),
             'prop1  D  value1\n'
             'prop2  -  value2\n')
+        with qubesadmin.tests.tools.StdoutBuffer() as stdout:
+            self.assertEqual(0, qubesadmin.tools.qvm_prefs.main([
+                'dom0','--hide-default'], app=self.app))
+        self.assertEqual(stdout.getvalue(),
+            'prop2  -  value2\n')
         self.assertAllCalled()
 
     def test_001_no_vm(self):

--- a/qubesadmin/tools/qubes_prefs.py
+++ b/qubesadmin/tools/qubes_prefs.py
@@ -20,8 +20,6 @@
 
 ''' Manipulate global properties.'''
 
-# TODO list only non-default properties
-
 from __future__ import print_function
 
 import sys

--- a/qubesadmin/tools/qvm_prefs.py
+++ b/qubesadmin/tools/qvm_prefs.py
@@ -19,7 +19,6 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 ''' Manipulate VM properties.'''
-# TODO list only non-default properties
 
 from __future__ import print_function
 
@@ -40,6 +39,10 @@ def get_parser(vmname_nargs=1):
     parser.add_argument('--help-properties',
         action='store_true',
         help='list all available properties with short descriptions and exit')
+
+    parser.add_argument('--hide-default',
+        action='store_true',
+        help='Do not show properties that are set to the default value.')
 
     parser.add_argument('--get', '-g',
         action='store_true',
@@ -101,11 +104,11 @@ def process_actions(parser, args, target):
                     name=prop, width=width))
                 continue
 
-            if target.property_is_default(prop):
-                print('{name:{width}s}  D  {value!s}'.format(
-                    name=prop, width=width, value=value))
-            else:
+            if not target.property_is_default(prop):
                 print('{name:{width}s}  -  {value!s}'.format(
+                    name=prop, width=width, value=value))
+            elif not args.hide_default:
+                print('{name:{width}s}  D  {value!s}'.format(
                     name=prop, width=width, value=value))
 
         return 0


### PR DESCRIPTION
qvm-prefs usually shows a large number of properties that are set to default,
so it would be useful to have a way to only show those properties that are
non-default. One could either add a new option like --show-only-non-default
(or perhaps --hide-default), or instead change the normal behavior and recover
the old one with e.g. --show-all.
As there was already a TODO in the source file to only show non-default
properties, I went with the second option, but I would be happy to rework
to go with the first one.