### PR TITLE
Clarify the network-manager qubes service default state

### DIFF
--- a/doc/manpages/qvm-service.rst
+++ b/doc/manpages/qvm-service.rst
@@ -87,8 +87,8 @@ crond
     Enable CRON service.
 
 network-manager
-    Default: enabled in every qube that has provides_network preference
-    set to True and disabled in all other qubes
+    Default: enabled in every qube that has no netvm and has provides_network
+    preference set to True
 
     Enable NetworkManager. Only VM with direct access to network device needs
     this service, but can be useful in ProxyVM to ease VPN setup.

--- a/doc/manpages/qvm-service.rst
+++ b/doc/manpages/qvm-service.rst
@@ -87,7 +87,8 @@ crond
     Enable CRON service.
 
 network-manager
-    Default: enabled in NetVM
+    Default: enabled in every qube that has provides_network preference
+    set to True and disabled in all other qubes
 
     Enable NetworkManager. Only VM with direct access to network device needs
     this service, but can be useful in ProxyVM to ease VPN setup.


### PR DESCRIPTION
The current description "enabled in NetVM" is very vague. I attached a PCI networking device to a qube and expected QubesOS to enable the service. After some experimentation I determined that:

1. The service is not enabled if the qube does not have provides_network preference set to True.
2. The service is not enabled if the qube has a netvm.
3. The service state does not depend on whether a PCI networking device is attached to the qube or not.

I propose we clarify the manpage to avoid giving users wrong expectations.