### PR TITLE
Fix a pref name in the qvm-prefs man page

### DIFF
--- a/doc/manpages/qvm-prefs.rst
+++ b/doc/manpages/qvm-prefs.rst
@@ -101,7 +101,7 @@ default_user
 
     TemplateBasedVM use its template's value as a default.
 
-dispvm_allowed
+template_for_dispvms
     Property type: bool
 
     Allow to use this VM as a base AppVM for Disposable VM. I.e. start this


### PR DESCRIPTION
```
[user@dom0 ~]$ qvm-prefs foo-dvm dispvm_allowed
usage: qvm-prefs [--verbose] [--quiet] [--help] [--help-properties]
                 [--hide-default] [--get] [--set] [--default]
                 VMNAME [PROPERTY] [VALUE]
qvm-prefs: error: no such property: 'dispvm_allowed'
[user@dom0 ~]$ qvm-prefs foo-dvm template_for_dispvms
True
```