### PR TITLE
Improvements to vm.run_service() function

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -13,6 +13,7 @@ extension-pkg-whitelist=lxml.etree
 disable=
   bad-continuation,
   raising-format-tuple,
+  import-outside-toplevel,
   inconsistent-return-statements,
   duplicate-code,
   fixme,

--- a/qubesadmin/backup/restore.py
+++ b/qubesadmin/backup/restore.py
@@ -555,10 +555,8 @@ class ExtractWorker3(Process):
                         file_size = int(match.groups()[0])
                         size_func(file_size)
                         break
-                    else:
-                        self.log.warning(
-                            'unexpected tar output (no file size report): %s',
-                            line)
+                    self.log.warning(
+                        'unexpected tar output (no file size report): %s', line)
 
         return data_func(tar2_process.stdout)
 

--- a/qubesadmin/base.py
+++ b/qubesadmin/base.py
@@ -359,7 +359,7 @@ class WrapperObjectsCollection(object):
     def keys(self):
         '''Get list of names.'''
         self.refresh_cache()
-        return [key for key in self._names_list]
+        return list(self._names_list)
 
     def items(self):
         '''Get list of (key, value) pairs'''

--- a/qubesadmin/events/__init__.py
+++ b/qubesadmin/events/__init__.py
@@ -176,8 +176,7 @@ class EventsDispatcher(object):
                 except asyncio.IncompleteReadError as err:
                     if err.partial == b'':
                         break
-                    else:
-                        raise
+                    raise
 
                 if not subject:
                     subject = None

--- a/qubesadmin/tests/app.py
+++ b/qubesadmin/tests/app.py
@@ -880,26 +880,34 @@ class TC_30_QubesRemote(unittest.TestCase):
         ])
         self.assertEqual(value, b'return-value')
 
+    @mock.patch('os.isatty', lambda fd: fd == 2)
     def test_010_run_service(self):
         self.app.run_service('some-vm', 'service.name')
         self.proc_mock.assert_called_once_with([
             qubesadmin.config.QREXEC_CLIENT_VM,
-            'some-vm', 'service.name'],
+            '-T', 'some-vm', 'service.name'],
             stdin=subprocess.PIPE, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
 
+    @mock.patch('os.isatty', lambda fd: fd == 2)
     def test_011_run_service_filter_esc(self):
-        with self.assertRaises(NotImplementedError):
-            p = self.app.run_service('some-vm', 'service.name', filter_esc=True)
+        self.app.run_service('some-vm', 'service.name', filter_esc=True)
+        self.proc_mock.assert_called_once_with([
+            qubesadmin.config.QREXEC_CLIENT_VM,
+            '-t', '-T', 'some-vm', 'service.name'],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
 
+    @mock.patch('os.isatty', lambda fd: fd == 2)
     def test_012_run_service_user(self):
         with self.assertRaises(ValueError):
             p = self.app.run_service('some-vm', 'service.name', user='user')
 
+    @mock.patch('os.isatty', lambda fd: fd == 2)
     def test_013_run_service_default_target(self):
         self.app.run_service('', 'service.name')
         self.proc_mock.assert_called_once_with([
             qubesadmin.config.QREXEC_CLIENT_VM,
-            '', 'service.name'],
+            '-T', '', 'service.name'],
             stdin=subprocess.PIPE, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)

--- a/qubesadmin/tests/tools/qvm_start_gui.py
+++ b/qubesadmin/tests/tools/qvm_start_gui.py
@@ -511,7 +511,7 @@ HDMI1 connected 2560x1920+0+0 (normal left inverted right x axis y axis) 206mm x
         loop.run_until_complete(self.launcher.send_monitor_layout(
             vm, layout=monitor_layout, startup=True))
         mock_run_service.assert_called_once_with(
-            'qubes.SetMonitorLayout', b'1920 1080 0 0\n')
+            'qubes.SetMonitorLayout', autostart=False, input=b'1920 1080 0 0\n')
         self.assertAllCalled()
 
     def test_061_send_monitor_layout_exclude(self):

--- a/qubesadmin/tools/qvm_backup_restore.py
+++ b/qubesadmin/tools/qvm_backup_restore.py
@@ -256,7 +256,7 @@ def main(args=None, app=None):
 
     if args.pass_file is None:
         if input("Do you want to proceed? [y/N] ").upper() != "Y":
-            exit(0)
+            sys.exit(0)
 
     try:
         backup.restore_do(restore_info)

--- a/qubesadmin/tools/qvm_ls.py
+++ b/qubesadmin/tools/qvm_ls.py
@@ -634,7 +634,8 @@ def main(args=None, app=None):
                    if set(dom.tags).intersection(set(args.tags))]
 
     pwrstates = {state: getattr(args, state) for state in DOMAIN_POWER_STATES}
-    domains = filter(lambda x: matches_power_states(x, **pwrstates), domains)
+    domains = [d for d in domains
+               if matches_power_states(d, **pwrstates)]
 
     table = Table(domains, columns, spinner, args.raw_data)
     table.write_table(sys.stdout)

--- a/qubesadmin/tools/qvm_start_gui.py
+++ b/qubesadmin/tools/qvm_start_gui.py
@@ -25,6 +25,8 @@ import signal
 import subprocess
 import asyncio
 import re
+
+import functools
 import xcffib
 import xcffib.xproto  # pylint: disable=unused-import
 
@@ -292,8 +294,10 @@ class GUILauncher(object):
 
         try:
             yield from asyncio.get_event_loop().run_in_executor(None,
-                vm.run_service_for_stdio, 'qubes.SetMonitorLayout',
-                    ''.join(layout).encode())
+                functools.partial(vm.run_service_for_stdio,
+                                  'qubes.SetMonitorLayout',
+                                  input=''.join(layout).encode(),
+                                  autostart=False))
         except subprocess.CalledProcessError as e:
             vm.log.warning('Failed to send monitor layout: %s', e.stderr)
 


### PR DESCRIPTION
- support `filter_esc=True` option in the VM too; depends on QubesOS/qubes-core-qrexec#9
- add `autostart=` option to allow not starting a VM for the call
- use `autostart=False` in qvm-start-gui, to not start a VM just to send it a monitor layout

QubesOS/qubes-issues#5322