### PR TITLE
added feature to list domains as network tree

### DIFF
--- a/doc/manpages/qvm-ls.rst
+++ b/doc/manpages/qvm-ls.rst
@@ -62,6 +62,11 @@ Options
    Give plain list of VM names, without header or separator. Useful in scripts.
    Same as --raw-data --fields=name
 
+.. option:: --tree, -t
+
+   List domains as a network tree. Domains are sorted as they are connected to
+   their netvms. Names are indented relative to the number of connected netvms.
+
 .. option:: --disk, -d
 
    Same as --format=disk, for compatibility with Qubes 3.x


### PR DESCRIPTION
The feature was discussed and described in detail here: https://github.com/QubesOS/qubes-issues/issues/4597

If qvm-ls -t or qvm-ls --tree is executed the domains will be listed as a network tree.

This commit will not contain any code for coloring the domain names or format the output to make it look nice, if used with the Genmon plugin.

Example:

<pre>
> qvm-ls --tree --running

NAME               STATE    CLASS    LABEL   TEMPLATE      NETVM
Vault              Running  AppVM    gray    fedora-29     -
dom0               Running  AdminVM  black   -             -
sys-net            Running  AppVM    red     fedora-29     -
└─sys-firewall     Running  AppVM    green   fedora-29     sys-net
  └─VPN-CHE        Running  AppVM    green   fedora-29     sys-firewall
    └─University   Running  AppVM    blue    debian-9      VPN-CHE
  └─VPN-DEU        Running  AppVM    green   fedora-29     sys-firewall
  └─VPN-NOR        Running  AppVM    green   fedora-29     sys-firewall
    └─Development  Running  AppVM    yellow  fedora-29     VPN-NOR
    └─Untrusted    Running  AppVM    red     debian-9      VPN-NOR
  └─sys-whonix     Running  AppVM    black   whonix-gw-14  sys-firewall
</pre>