### PR TITLE
Improvements to qvm-pool argument parser

### DIFF
--- a/doc/manpages/qvm-pool.rst
+++ b/doc/manpages/qvm-pool.rst
@@ -1,11 +1,16 @@
 .. program:: qvm-pool
 
-:program:`qvm-pool` -- manage pools
+:program:`qvm-pool` -- Manage pools
 ===================================
 
 Synopsis
 --------
-:command:`qvm-pool` [-h] [--verbose] [--quiet] [--help-drivers] [-o options] [-l | -i *NAME* | -a *NAME* *DRIVER* | -r *NAME*]
+| :command:`qvm-pool` {add,a} [*options*] <*pool_name*> <*driver*>
+| :command:`qvm-pool` {drivers,d} [*options*]
+| :command:`qvm-pool` {info,i} [*options*] <*pool_name*>
+| :command:`qvm-pool` {list,ls,l} [*options*]
+| :command:`qvm-pool` {remove,rm,i} [*options*] <*pool_name*> ...
+| :command:`qvm-pool` {set,s} [*options*] <*pool_name*>
 
 Options
 -------
@@ -22,49 +27,82 @@ Options
 
     Increase verbosity
 
-.. option:: --help-drivers
+Commands
+--------
 
-    List all known drivers with their options. The listed driver options can be
-    used with the ``-o options`` switch.
+add
+^^^
+| :command:`qvm-pool add` [-h] [--verbose] [--quiet] *POOL_NAME* *DRIVER*
 
-.. option:: -o options
+Add a new pool.
 
-    Comma separated list of driver options. See ``--help-drivers`` for a list of
-    driver options.
-    
-.. option:: --list, -l
+.. option:: --option, -o
 
-    List all pools.
+    Set option for the driver in `name=value` format. You can specify this
+    option multiple times. For supported drivers and their options,
+    see ``drivers``.
 
-.. option:: --info NAME, -i NAME
+aliases: a
 
-    Show information about a pool
+drivers
+^^^^^^^
+| :command:`qvm-pool drivers` [-h] [--verbose] [--quiet]
 
-.. option:: --add NAME DRIVER, -a NAME DRIVER
+List all known drivers with their options.
+The listed driver options can be used with the ``-o options`` switch.
 
-    Add a pool. For supported drivers and their options see ``--help-drivers``.
-    Most of the drivers expect some kind of options.
+aliases: d
 
-.. option:: --remove NAME, -r NAME
+info
+^^^^
+| :command:`qvm-pool info` [-h] [--verbose] [--quiet] *POOL_NAME*
 
-    Remove a pool. This removes only the information about the pool in
-    qubes.xml, but does not delete any content (FIXME: is it really true for
-    all pool drivers?).
+Print info about a specified pool
 
-.. option:: --set NAME, -s NAME
+aliases: i
 
-    Modify a pool. This set options of a pool. Use ``--o`` to specify actual modifications.
+list
+^^^^
+| :command:`qvm-pool list` [-h] [--verbose] [--quiet]
 
+List all available pools.
+
+aliases: l, ls
+
+remove
+^^^^^^
+| :command:`qvm-pool remove` [-h] [--verbose] [--quiet] *POOL_NAME* [*POOL_NAME* ...]
+
+Remove the specified pools. This removes only the information about the pool
+from qubes.xml, but does not delete any content (FIXME: is it really true for
+all pool drivers?).
+
+aliases: r, rm
+
+set
+^^^
+| :command:`qvm-pool set` [-h] [--verbose] [--quiet] *POOL_NAME*
+
+Modify driver options for a pool.
+
+.. option:: --option, -o
+
+    Set option for the driver in `name=value` format. You can specify this
+    option multiple times. For supported drivers and their options,
+    see ``drivers``.
+
+aliases: s
 
 Examples
 --------
 
 Create a pool backed by the `file` driver.
-    
+
 ::
 
-    qvm-pool -o dir_path=/mnt/foo -a foo file
+    qvm-pool add foo file -o dir_path=/mnt/foo
 
 Authors
 -------
-| Bahtiar \`kalkin-\` Gadimov <bahtiar at gadimov dot de> 
+| Bahtiar \`kalkin-\` Gadimov <bahtiar at gadimov dot de>
+| Saswat Padhi <padhi at cs dot ucla dot edu>

--- a/doc/manpages/qvm-pool.rst
+++ b/doc/manpages/qvm-pool.rst
@@ -12,6 +12,17 @@ Synopsis
 | :command:`qvm-pool` {remove,rm,i} [*options*] <*pool_name*> ...
 | :command:`qvm-pool` {set,s} [*options*] <*pool_name*>
 
+Legacy Mode
+^^^^^^^^^^^
+| :command:`qvm-pool` [*options*] {-a, --add} <*pool_name*> <*driver*>
+| :command:`qvm-pool` [*options*] {-i, --info} <*pool_name*>
+| :command:`qvm-pool` [*options*] {-l, --list}
+| :command:`qvm-pool` [*options*] {-r, --remove} <*pool_name*>
+| :command:`qvm-pool` [*options*] {-s, --set} <*pool_name*>
+| :command:`qvm-pool` [*options*] --help-drivers
+
+.. deprecated:: 4.0.18
+
 Options
 -------
 
@@ -39,10 +50,13 @@ Add a new pool.
 .. option:: --option, -o
 
     Set option for the driver in `name=value` format. You can specify this
-    option multiple times. For supported drivers and their options,
-    see ``drivers``.
+    option multiple times.
+
+    .. seealso:: The `drivers` command for supported drivers and their options.
 
 aliases: a
+
+Legacy mode: :command:`qvm-pool` [-h] [--verbose] [--quiet] --add *POOL_NAME* *DRIVER* -o *OPTIONS*
 
 drivers
 ^^^^^^^
@@ -53,6 +67,8 @@ The listed driver options can be used with the ``-o options`` switch.
 
 aliases: d
 
+Legacy mode: :command:`qvm-pool` [-h] [--verbose] [--quiet] --help-drivers
+
 info
 ^^^^
 | :command:`qvm-pool info` [-h] [--verbose] [--quiet] *POOL_NAME*
@@ -61,6 +77,8 @@ Print info about a specified pool
 
 aliases: i
 
+Legacy mode: :command:`qvm-pool` [-h] [--verbose] [--quiet] --info *POOL_NAME*
+
 list
 ^^^^
 | :command:`qvm-pool list` [-h] [--verbose] [--quiet]
@@ -68,6 +86,8 @@ list
 List all available pools.
 
 aliases: l, ls
+
+Legacy mode: :command:`qvm-pool` [-h] [--verbose] [--quiet] --list
 
 remove
 ^^^^^^
@@ -79,6 +99,8 @@ all pool drivers?).
 
 aliases: r, rm
 
+Legacy mode: :command:`qvm-pool` [-h] [--verbose] [--quiet] --remove *POOL_NAME* [*POOL_NAME* ...]
+
 set
 ^^^
 | :command:`qvm-pool set` [-h] [--verbose] [--quiet] *POOL_NAME*
@@ -88,10 +110,13 @@ Modify driver options for a pool.
 .. option:: --option, -o
 
     Set option for the driver in `name=value` format. You can specify this
-    option multiple times. For supported drivers and their options,
-    see ``drivers``.
+    option multiple times.
+
+    .. seealso:: The `drivers` command for supported drivers and their options.
 
 aliases: s
+
+Legacy mode: :command:`qvm-pool` [-h] [--verbose] [--quiet] --set *POOL_NAME* -o *OPTIONS*
 
 Examples
 --------

--- a/qubesadmin/tests/tools/qvm_pool.py
+++ b/qubesadmin/tests/tools/qvm_pool.py
@@ -35,7 +35,7 @@ class TC_00_qvm_pool(qubesadmin.tests.QubesTestCase):
             b'0\x00driver=lvm\nvolume_group=qubes_dom0\nthin_pool=pool00\n'
         with qubesadmin.tests.tools.StdoutBuffer() as stdout:
             self.assertEqual(0,
-                qubesadmin.tools.qvm_pool.main(['ls'], app=self.app))
+                qubesadmin.tools.qvm_pool.main(['list'], app=self.app))
         self.assertEqual(stdout.getvalue(),
             'NAME       DRIVER\n'
             'pool-file  file\n'
@@ -71,7 +71,18 @@ class TC_00_qvm_pool(qubesadmin.tests.QubesTestCase):
         self.app.expected_calls[
             ('dom0', 'admin.pool.Remove', 'test-pool', None)] = b'0\x00'
         self.assertEqual(0,
-            qubesadmin.tools.qvm_pool.main(['rm', 'test-pool'],
+            qubesadmin.tools.qvm_pool.main(['remove', 'test-pool'],
+                app=self.app))
+        self.assertAllCalled()
+
+    def test_031_remove_multiple(self):
+        self.app.expected_calls[
+            ('dom0', 'admin.pool.Remove', 'test-pool-1', None)] = b'0\x00'
+        self.app.expected_calls[
+            ('dom0', 'admin.pool.Remove', 'test-pool-2', None)] = b'0\x00'
+        self.assertEqual(0,
+            qubesadmin.tools.qvm_pool.main(
+                ['remove', 'test-pool-1', 'test-pool-2'],
                 app=self.app))
         self.assertAllCalled()
 
@@ -83,7 +94,7 @@ class TC_00_qvm_pool(qubesadmin.tests.QubesTestCase):
             b'0\x00driver=lvm\nvolume_group=qubes_dom0\nthin_pool=pool00\n'
         with qubesadmin.tests.tools.StdoutBuffer() as stdout:
             self.assertEqual(0,
-                qubesadmin.tools.qvm_pool.main(['i', 'pool-lvm'],
+                qubesadmin.tools.qvm_pool.main(['info', 'pool-lvm'],
                     app=self.app))
         self.assertEqual(stdout.getvalue(),
             'name          pool-lvm\n'
@@ -100,7 +111,7 @@ class TC_00_qvm_pool(qubesadmin.tests.QubesTestCase):
             ('dom0', 'admin.pool.Set.revisions_to_keep', 'pool-lvm', b'2')] = \
             b'0\x00'
         self.assertEqual(0,
-            qubesadmin.tools.qvm_pool.main(['s', 'pool-lvm', '-o',
+            qubesadmin.tools.qvm_pool.main(['set', 'pool-lvm', '-o',
                 'revisions_to_keep=2'],
                 app=self.app))
         self.assertAllCalled()
@@ -112,5 +123,5 @@ class TC_00_qvm_pool(qubesadmin.tests.QubesTestCase):
             qubesadmin.tools.qvm_pool.main(
                 ['set', 'pool-lvm', '-o', 'prop=1'],
                 app=self.app)
-        self.assertEqual(e.exception.code, 2)
+        self.assertEqual(e.exception.code, 1)
         self.assertAllCalled()

--- a/qubesadmin/tests/tools/qvm_pool.py
+++ b/qubesadmin/tests/tools/qvm_pool.py
@@ -35,21 +35,21 @@ class TC_00_qvm_pool(qubesadmin.tests.QubesTestCase):
             b'0\x00driver=lvm\nvolume_group=qubes_dom0\nthin_pool=pool00\n'
         with qubesadmin.tests.tools.StdoutBuffer() as stdout:
             self.assertEqual(0,
-                qubesadmin.tools.qvm_pool.main(['-l'], app=self.app))
+                qubesadmin.tools.qvm_pool.main(['ls'], app=self.app))
         self.assertEqual(stdout.getvalue(),
             'NAME       DRIVER\n'
             'pool-file  file\n'
             'pool-lvm   lvm\n')
         self.assertAllCalled()
 
-    def test_010_list_drivers(self):
+    def test_010_drivers(self):
         self.app.expected_calls[
             ('dom0', 'admin.pool.ListDrivers', None, None)] = \
             b'0\x00file dir_path revisions_to_keep\n' \
             b'lvm volume_group thin_pool revisions_to_keep\n'
         with qubesadmin.tests.tools.StdoutBuffer() as stdout:
             self.assertEqual(0,
-                qubesadmin.tools.qvm_pool.main(['--help-drivers'], app=self.app))
+                qubesadmin.tools.qvm_pool.main(['drivers'], app=self.app))
         self.assertEqual(stdout.getvalue(),
             'DRIVER  OPTIONS\n'
             'file    dir_path, revisions_to_keep\n'
@@ -63,7 +63,7 @@ class TC_00_qvm_pool(qubesadmin.tests.QubesTestCase):
             b'name=test-pool\ndir_path=/some/path\n')] = b'0\x00'
         self.assertEqual(0,
             qubesadmin.tools.qvm_pool.main(
-                ['--add', 'test-pool', 'file', '-o', 'dir_path=/some/path'],
+                ['add', 'test-pool', 'file', '-o', 'dir_path=/some/path'],
                 app=self.app))
         self.assertAllCalled()
 
@@ -71,7 +71,7 @@ class TC_00_qvm_pool(qubesadmin.tests.QubesTestCase):
         self.app.expected_calls[
             ('dom0', 'admin.pool.Remove', 'test-pool', None)] = b'0\x00'
         self.assertEqual(0,
-            qubesadmin.tools.qvm_pool.main(['--remove', 'test-pool'],
+            qubesadmin.tools.qvm_pool.main(['rm', 'test-pool'],
                 app=self.app))
         self.assertAllCalled()
 
@@ -83,7 +83,7 @@ class TC_00_qvm_pool(qubesadmin.tests.QubesTestCase):
             b'0\x00driver=lvm\nvolume_group=qubes_dom0\nthin_pool=pool00\n'
         with qubesadmin.tests.tools.StdoutBuffer() as stdout:
             self.assertEqual(0,
-                qubesadmin.tools.qvm_pool.main(['-i', 'pool-lvm'],
+                qubesadmin.tools.qvm_pool.main(['i', 'pool-lvm'],
                     app=self.app))
         self.assertEqual(stdout.getvalue(),
             'name          pool-lvm\n'
@@ -100,7 +100,7 @@ class TC_00_qvm_pool(qubesadmin.tests.QubesTestCase):
             ('dom0', 'admin.pool.Set.revisions_to_keep', 'pool-lvm', b'2')] = \
             b'0\x00'
         self.assertEqual(0,
-            qubesadmin.tools.qvm_pool.main(['-s', 'pool-lvm', '-o',
+            qubesadmin.tools.qvm_pool.main(['s', 'pool-lvm', '-o',
                 'revisions_to_keep=2'],
                 app=self.app))
         self.assertAllCalled()
@@ -110,7 +110,7 @@ class TC_00_qvm_pool(qubesadmin.tests.QubesTestCase):
             b'0\x00pool-file\npool-lvm\n'
         with self.assertRaises(SystemExit) as e:
             qubesadmin.tools.qvm_pool.main(
-                ['-s', 'pool-lvm', '-o', 'prop=1'],
+                ['set', 'pool-lvm', '-o', 'prop=1'],
                 app=self.app)
         self.assertEqual(e.exception.code, 2)
         self.assertAllCalled()

--- a/qubesadmin/tests/tools/qvm_pool_legacy.py
+++ b/qubesadmin/tests/tools/qvm_pool_legacy.py
@@ -23,7 +23,7 @@ import qubesadmin.tests.tools
 import qubesadmin.tools.qvm_pool
 
 
-class TC_00_qvm_pool(qubesadmin.tests.QubesTestCase):
+class TC_00_qvm_pool_legacy(qubesadmin.tests.QubesTestCase):
     def test_000_list(self):
         self.app.expected_calls[('dom0', 'admin.pool.List', None, None)] = \
             b'0\x00pool-file\npool-lvm\n'
@@ -35,21 +35,21 @@ class TC_00_qvm_pool(qubesadmin.tests.QubesTestCase):
             b'0\x00driver=lvm\nvolume_group=qubes_dom0\nthin_pool=pool00\n'
         with qubesadmin.tests.tools.StdoutBuffer() as stdout:
             self.assertEqual(0,
-                qubesadmin.tools.qvm_pool.main(['list'], app=self.app))
+                qubesadmin.tools.qvm_pool.main(['-l'], app=self.app))
         self.assertEqual(stdout.getvalue(),
             'NAME       DRIVER\n'
             'pool-file  file\n'
             'pool-lvm   lvm\n')
         self.assertAllCalled()
 
-    def test_010_drivers(self):
+    def test_010_list_drivers(self):
         self.app.expected_calls[
             ('dom0', 'admin.pool.ListDrivers', None, None)] = \
             b'0\x00file dir_path revisions_to_keep\n' \
             b'lvm volume_group thin_pool revisions_to_keep\n'
         with qubesadmin.tests.tools.StdoutBuffer() as stdout:
             self.assertEqual(0,
-                qubesadmin.tools.qvm_pool.main(['drivers'], app=self.app))
+                qubesadmin.tools.qvm_pool.main(['--help-drivers'], app=self.app))
         self.assertEqual(stdout.getvalue(),
             'DRIVER  OPTIONS\n'
             'file    dir_path, revisions_to_keep\n'
@@ -63,18 +63,7 @@ class TC_00_qvm_pool(qubesadmin.tests.QubesTestCase):
             b'name=test-pool\ndir_path=/some/path\n')] = b'0\x00'
         self.assertEqual(0,
             qubesadmin.tools.qvm_pool.main(
-                ['add', 'test-pool', 'file', '-o', 'dir_path=/some/path'],
-                app=self.app))
-        self.assertAllCalled()
-
-    def test_021_add_multiple(self):
-        self.app.expected_calls[
-            ('dom0', 'admin.pool.Add', 'file',
-            b'name=test-pool\ndir_path=/some/path\nrw=True\n')] = b'0\x00'
-        self.assertEqual(0,
-            qubesadmin.tools.qvm_pool.main(
-                ['add', 'test-pool', 'file', '-o', 'dir_path=/some/path',
-                                             '-o', 'rw=True'],
+                ['--add', 'test-pool', 'file', '-o', 'dir_path=/some/path'],
                 app=self.app))
         self.assertAllCalled()
 
@@ -82,18 +71,7 @@ class TC_00_qvm_pool(qubesadmin.tests.QubesTestCase):
         self.app.expected_calls[
             ('dom0', 'admin.pool.Remove', 'test-pool', None)] = b'0\x00'
         self.assertEqual(0,
-            qubesadmin.tools.qvm_pool.main(['remove', 'test-pool'],
-                app=self.app))
-        self.assertAllCalled()
-
-    def test_031_remove_multiple(self):
-        self.app.expected_calls[
-            ('dom0', 'admin.pool.Remove', 'test-pool-1', None)] = b'0\x00'
-        self.app.expected_calls[
-            ('dom0', 'admin.pool.Remove', 'test-pool-2', None)] = b'0\x00'
-        self.assertEqual(0,
-            qubesadmin.tools.qvm_pool.main(
-                ['remove', 'test-pool-1', 'test-pool-2'],
+            qubesadmin.tools.qvm_pool.main(['--remove', 'test-pool'],
                 app=self.app))
         self.assertAllCalled()
 
@@ -105,7 +83,7 @@ class TC_00_qvm_pool(qubesadmin.tests.QubesTestCase):
             b'0\x00driver=lvm\nvolume_group=qubes_dom0\nthin_pool=pool00\n'
         with qubesadmin.tests.tools.StdoutBuffer() as stdout:
             self.assertEqual(0,
-                qubesadmin.tools.qvm_pool.main(['info', 'pool-lvm'],
+                qubesadmin.tools.qvm_pool.main(['-i', 'pool-lvm'],
                     app=self.app))
         self.assertEqual(stdout.getvalue(),
             'name          pool-lvm\n'
@@ -122,7 +100,7 @@ class TC_00_qvm_pool(qubesadmin.tests.QubesTestCase):
             ('dom0', 'admin.pool.Set.revisions_to_keep', 'pool-lvm', b'2')] = \
             b'0\x00'
         self.assertEqual(0,
-            qubesadmin.tools.qvm_pool.main(['set', 'pool-lvm', '-o',
+            qubesadmin.tools.qvm_pool.main(['-s', 'pool-lvm', '-o',
                 'revisions_to_keep=2'],
                 app=self.app))
         self.assertAllCalled()
@@ -132,7 +110,7 @@ class TC_00_qvm_pool(qubesadmin.tests.QubesTestCase):
             b'0\x00pool-file\npool-lvm\n'
         with self.assertRaises(SystemExit) as e:
             qubesadmin.tools.qvm_pool.main(
-                ['set', 'pool-lvm', '-o', 'prop=1'],
+                ['-s', 'pool-lvm', '-o', 'prop=1'],
                 app=self.app)
-        self.assertEqual(e.exception.code, 1)
+        self.assertEqual(e.exception.code, 2)
         self.assertAllCalled()

--- a/qubesadmin/tools/qvm_pool.py
+++ b/qubesadmin/tools/qvm_pool.py
@@ -22,7 +22,6 @@
 
 from __future__ import print_function
 
-import argparse
 import sys
 
 import qubesadmin
@@ -114,8 +113,8 @@ def init_info_parser(sub_parsers):
     ''' Add 'info' action related options '''
     i_parser = sub_parsers.add_parser(
         'info', aliases=('i',), help='Print info about the specified pools')
-    i_parser.add_argument(metavar='POOL_NAME', dest='pools', nargs='+',
-                             action=qubesadmin.tools.PoolsAction)
+    i_parser.add_argument(metavar='POOL_NAME', dest='pools',
+                          action=qubesadmin.tools.PoolsAction)
     i_parser.set_defaults(func=info_pools)
 
 

--- a/qubesadmin/tools/qvm_pool_legacy.py
+++ b/qubesadmin/tools/qvm_pool_legacy.py
@@ -1,0 +1,208 @@
+# pylint: disable=too-few-public-methods
+
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2016 Bahtiar `kalkin-` Gadimov <bahtiar@gadimov.de>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+'''Manages Qubes pools and their options'''
+
+from __future__ import print_function
+
+import argparse
+import sys
+
+import qubesadmin
+import qubesadmin.exc
+import qubesadmin.tools
+
+
+class _Info(qubesadmin.tools.PoolsAction):
+    ''' Action for argument parser that displays pool info and exits. '''
+
+    def __init__(self, option_strings, help='print pool info and exit',
+                 **kwargs):
+        # pylint: disable=redefined-builtin
+        super(_Info, self).__init__(option_strings, help=help, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, 'command', 'info')
+        super(_Info, self).__call__(parser, namespace, values, option_string)
+
+
+def pool_info(pool):
+    ''' Prints out pool name and config '''
+    data = [("name", pool.name)]
+    data += [i for i in sorted(pool.config.items()) if i[0] != 'name']
+    qubesadmin.tools.print_table(data)
+
+
+def list_pools(app):
+    ''' Prints out all known pools and their drivers '''
+    result = [('NAME', 'DRIVER')]
+    for pool in app.pools.values():
+        result += [(pool.name, pool.driver)]
+    qubesadmin.tools.print_table(result)
+
+
+class _Remove(argparse.Action):
+    ''' Action for argument parser that removes a pool '''
+
+    def __init__(self, option_strings, dest=None, default=None, metavar=None):
+        super(_Remove, self).__init__(option_strings=option_strings,
+                                      dest=dest,
+                                      metavar=metavar,
+                                      default=default,
+                                      help='remove pool')
+
+    def __call__(self, parser, namespace, name, option_string=None):
+        setattr(namespace, 'command', 'remove')
+        setattr(namespace, 'name', name)
+
+
+class _Add(argparse.Action):
+    ''' Action for argument parser that adds a pool. '''
+
+    def __init__(self, option_strings, dest=None, default=None, metavar=None):
+        super(_Add, self).__init__(option_strings=option_strings,
+                                   dest=dest,
+                                   metavar=metavar,
+                                   default=default,
+                                   nargs=2,
+                                   help='add pool')
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        name, driver = values
+        setattr(namespace, 'command', 'add')
+        setattr(namespace, 'name', name)
+        setattr(namespace, 'driver', driver)
+
+
+class _Set(qubesadmin.tools.PoolsAction):
+    ''' Action for argument parser that sets pool options. '''
+
+    def __init__(self, option_strings, dest=None, default=None, metavar=None):
+        super(_Set, self).__init__(option_strings=option_strings,
+                                   dest=dest,
+                                   metavar=metavar,
+                                   default=default,
+                                   help='modify pool (use -o to specify '
+                                        'modifications)')
+
+    def __call__(self, parser, namespace, name, option_string=None):
+        setattr(namespace, 'command', 'set')
+        super(_Set, self).__call__(parser, namespace, name, option_string)
+
+
+class _Options(argparse.Action):
+    ''' Action for argument parser that parsers options. '''
+
+    def __init__(self, option_strings, dest, default, metavar='options'):
+        super(_Options, self).__init__(
+            option_strings=option_strings,
+            dest=dest,
+            metavar=metavar,
+            default=default,
+            help='comma-separated list of driver options')
+
+    def __call__(self, parser, namespace, options, option_string=None):
+        setattr(namespace, 'options',
+                dict([option.split('=', 1) for option in options.split(',')]))
+
+
+def get_parser():
+    ''' Parses the provided args '''
+    parser = qubesadmin.tools.QubesArgumentParser(description=__doc__)
+    parser.add_argument('-o', action=_Options, dest='options', default={})
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-l',
+                       '--list',
+                       dest='command',
+                       const='list',
+                       action='store_const',
+                       help='list all pools and exit (default action)')
+    group.add_argument('-i', '--info', metavar='POOLNAME', dest='pools',
+                       action=_Info, default=[])
+    group.add_argument('-a',
+                       '--add',
+                       action=_Add,
+                       dest='command',
+                       metavar=('NAME', 'DRIVER'))
+    group.add_argument('-r', '--remove', metavar='NAME', action=_Remove)
+    group.add_argument('-s', '--set', metavar='POOLNAME', dest='pool',
+                       action=_Set, default=[])
+    group.add_argument('--help-drivers',
+                       dest='command',
+                       const='list-drivers',
+                       action='store_const',
+                       help='list all drivers with their options and exit')
+    return parser
+
+
+def main(args=None, app=None):
+    '''Main routine of :program:`qvm-pools`.
+
+    :param list args: Optional arguments to override those delivered from \
+        command line.
+    '''
+    parser = get_parser()
+    try:
+        args = parser.parse_args(args, app=app)
+    except qubesadmin.exc.QubesException as e:
+        parser.print_error(str(e))
+        return 1
+
+    if args.command is None or args.command == 'list':
+        list_pools(args.app)
+    elif args.command == 'list-drivers':
+        result = [('DRIVER', 'OPTIONS')]
+        for driver in sorted(args.app.pool_drivers):
+            params = args.app.pool_driver_parameters(driver)
+            driver_options = ', '.join(params)
+            result += [(driver, driver_options)]
+        qubesadmin.tools.print_table(result)
+    elif args.command == 'add':
+        try:
+            args.app.add_pool(name=args.name, driver=args.driver,
+                **args.options)
+        except qubesadmin.exc.QubesException as e:
+            parser.error('failed to add pool %s: %s\n' % (args.name, str(e)))
+    elif args.command == 'remove':
+        try:
+            args.app.remove_pool(args.name)
+        except KeyError:
+            parser.print_error('no such pool %s\n' % args.name)
+        except qubesadmin.exc.QubesException as e:
+            parser.error('failed to remove pool %s: %s\n' % (args.name, str(e)))
+    elif args.command == 'info':
+        for pool in args.pools:
+            pool_info(pool)
+    elif args.command == 'set':
+        pool = args.pool[0]
+        for opt, value in args.options.items():
+            if not hasattr(type(pool), opt):
+                parser.error('setting pool option %s is not supported' % (
+                    pool.name))
+            try:
+                setattr(pool, opt, value)
+            except qubesadmin.exc.QubesException as e:
+                parser.error('failed to set pool %s option %s: %s\n' % (
+                    pool.name, opt, str(e)))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This change introduces a complete rewrite of the argument parser for the `qvm-pool` tool.
As suggested by @marmarek in QubesOS/qubes-issues#5407, the goal is to be consistent with other tools such as `qvm-device`, `qvm-volume` etc.

(resolves QubesOS/qubes-issues#5407)