### PR TITLE
Fixed metadata usage being served as strings

### DIFF
--- a/qubesadmin/storage.py
+++ b/qubesadmin/storage.py
@@ -278,7 +278,12 @@ class Pool(object):
         pool_usage_data = pool_usage_data.decode('utf-8')
         assert pool_usage_data.endswith('\n')
         pool_usage_data = pool_usage_data[:-1]
-        return dict(l.split('=', 1) for l in pool_usage_data.splitlines())
+
+        def _int_split(text):  # pylint: disable=missing-docstring
+            key, value = text.split("=", 1)
+            return key, int(value)
+
+        return dict(_int_split(l) for l in pool_usage_data.splitlines())
 
     @property
     def config(self):

--- a/qubesadmin/tests/storage.py
+++ b/qubesadmin/tests/storage.py
@@ -313,10 +313,10 @@ class TestPool(qubesadmin.tests.QubesTestCase):
             b'metadata_usage=50\n'
         pool = self.app.pools['lvm']
         self.assertEqual(pool.usage_details, {
-            'data_size': '204800',
-            'data_usage': '102400',
-            'metadata_size': '1024',
-            'metadata_usage': '50',
+            'data_size': 204800,
+            'data_usage': 102400,
+            'metadata_size': 1024,
+            'metadata_usage': 50,
         })
         self.assertAllCalled()
 


### PR DESCRIPTION
Metadata usage should be served as ints, as it is numeric.