### PR TITLE
Performance improvements for Admin API

### DIFF
--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -659,11 +659,8 @@ class QubesLocal(QubesBase):
             raise qubesadmin.exc.QubesDaemonCommunicationError(
                 'Failed to connect to qubesd service: %s', str(e))
 
-        # src, method, dest, arg
-        for call_arg in ('dom0', method, dest, arg):
-            if call_arg is not None:
-                client_socket.sendall(call_arg.encode('ascii'))
-            client_socket.sendall(b'\0')
+        call_header = '{}+{} dom0 name {}\0'.format(method, arg or '', dest)
+        client_socket.sendall(call_header.encode('ascii'))
         if payload is not None:
             client_socket.sendall(payload)
 

--- a/qubesadmin/base.py
+++ b/qubesadmin/base.py
@@ -233,7 +233,7 @@ class PropertyHolder(object):
         if prop_type == 'vm':
             if value == '':
                 return None
-            return self.app.domains[value]
+            return self.app.domains.get_blind(value)
         if prop_type == 'label':
             if value == '':
                 return None

--- a/qubesadmin/devices.py
+++ b/qubesadmin/devices.py
@@ -209,7 +209,7 @@ class DeviceCollection(object):
                               ['True', 'yes', True])
             if persistent is not None and dev_persistent != persistent:
                 continue
-            backend_domain = self._vm.app.domains[backend_domain]
+            backend_domain = self._vm.app.domains.get_blind(backend_domain)
             yield DeviceAssignment(backend_domain, ident, options,
                                    persistent=dev_persistent,
                                    frontend_domain=self._vm,

--- a/qubesadmin/events/__init__.py
+++ b/qubesadmin/events/__init__.py
@@ -31,8 +31,19 @@ import qubesadmin.exc
 class EventsDispatcher(object):
     ''' Events dispatcher, responsible for receiving events and calling
     appropriate handlers'''
-    def __init__(self, app, api_method='admin.Events'):
-        '''Initialize EventsDispatcher'''
+    def __init__(self, app, api_method='admin.Events', enable_cache=True):
+        """Initialize EventsDispatcher
+
+        :param app :py:class:`qubesadmin.Qubes` object
+        :param api_method Admin API method producing events
+        :param enable_cache Enable caching (see below)
+
+        Connecting :py:class:`EventsDispatcher` object to a
+        :py:class:`qubesadmin.Qubes` implicitly enables caching. It is important
+        to actually run the dispatcher (:py:meth:`listen_for_events`), otherwise
+        the cache won't be updated. Alternatively, disable caching by setting
+        :py:attr:`qubesadmin.Qubes.cache_enabled` property to `False`.
+        """
         #: Qubes() object
         self.app = app
 
@@ -40,6 +51,9 @@ class EventsDispatcher(object):
 
         #: event handlers - dict of event -> handlers
         self.handlers = {}
+
+        if enable_cache:
+            self.app.cache_enabled = True
 
     def add_handler(self, event, handler):
         '''Register handler for event

--- a/qubesadmin/events/__init__.py
+++ b/qubesadmin/events/__init__.py
@@ -79,10 +79,9 @@ class EventsDispatcher(object):
         if self.app.qubesd_connection_type == 'socket':
             reader, writer = yield from asyncio.open_unix_connection(
                 qubesadmin.config.QUBESD_SOCKET)
-            writer.write(b'dom0\0')  # source
-            writer.write(self._api_method.encode() + b'\0')  # method
-            writer.write(dest.encode('ascii') + b'\0')  # dest
-            writer.write(b'\0')  # arg
+            writer.write(self._api_method.encode() + b'+ ')  # method+arg
+            writer.write(b'dom0 ')  # source
+            writer.write(b'name ' + dest.encode('ascii') + b'\0')  # dest
             writer.write_eof()
 
             def cleanup_func():

--- a/qubesadmin/events/__init__.py
+++ b/qubesadmin/events/__init__.py
@@ -215,6 +215,9 @@ class EventsDispatcher(object):
         if event.startswith('property-set:') or \
                 event.startswith('property-reset:'):
             self.app._invalidate_cache(subject, event, **kwargs)
+        elif event in ('domain-pre-start', 'domain-start', 'domain-shutdown',
+                       'domain-paused', 'domain-unpaused'):
+            self.app._update_power_state_cache(subject, event, **kwargs)
 
         handlers = [h_func for h_name, h_func_set in self.handlers.items()
             for h_func in h_func_set

--- a/qubesadmin/events/utils.py
+++ b/qubesadmin/events/utils.py
@@ -57,7 +57,7 @@ def wait_for_domain_shutdown(vms):
         return
     app = list(vms)[0].app
     vms = set(vms)
-    events = qubesadmin.events.EventsDispatcher(app)
+    events = qubesadmin.events.EventsDispatcher(app, enable_cache=False)
     events.add_handler('domain-shutdown',
         functools.partial(interrupt_on_vm_shutdown, vms))
     events.add_handler('connection-established',

--- a/qubesadmin/tests/app.py
+++ b/qubesadmin/tests/app.py
@@ -771,19 +771,19 @@ class TC_20_QubesLocal(unittest.TestCase):
         self.listen_and_send(b'0\0')
         self.app.qubesd_call('test-vm', 'some.method', 'arg1', b'payload')
         self.assertEqual(self.get_request(),
-            b'dom0\0some.method\0test-vm\0arg1\0payload')
+            b'some.method+arg1 dom0 name test-vm\0payload')
 
     def test_001_qubesd_call_none_arg(self):
         self.listen_and_send(b'0\0')
         self.app.qubesd_call('test-vm', 'some.method', None, b'payload')
         self.assertEqual(self.get_request(),
-            b'dom0\0some.method\0test-vm\0\0payload')
+            b'some.method+ dom0 name test-vm\0payload')
 
     def test_002_qubesd_call_none_payload(self):
         self.listen_and_send(b'0\0')
         self.app.qubesd_call('test-vm', 'some.method', None, None)
         self.assertEqual(self.get_request(),
-            b'dom0\0some.method\0test-vm\0\0')
+            b'some.method+ dom0 name test-vm\0')
 
     def test_003_qubesd_call_payload_stream(self):
         payload_input = os.path.join(self.tmpdir, 'payload-input')
@@ -851,7 +851,7 @@ class TC_20_QubesLocal(unittest.TestCase):
                 stderr=subprocess.PIPE)
 
         self.assertEqual(self.get_request(),
-            b'dom0\0admin.vm.Start\0some-vm\0\0')
+            b'admin.vm.Start+ dom0 name some-vm\0')
 
     def test_011_run_service_filter_esc(self):
         self.listen_and_send(b'0\0')
@@ -865,7 +865,7 @@ class TC_20_QubesLocal(unittest.TestCase):
                 stderr=subprocess.PIPE)
 
         self.assertEqual(self.get_request(),
-            b'dom0\0admin.vm.Start\0some-vm\0\0')
+            b'admin.vm.Start+ dom0 name some-vm\0')
 
     @mock.patch('os.isatty', lambda fd: fd == 2)
     def test_012_run_service_user(self):
@@ -880,7 +880,7 @@ class TC_20_QubesLocal(unittest.TestCase):
                 stderr=subprocess.PIPE)
 
         self.assertEqual(self.get_request(),
-            b'dom0\0admin.vm.Start\0some-vm\0\0')
+            b'admin.vm.Start+ dom0 name some-vm\0')
 
     def test_013_run_service_default_target(self):
         with self.assertRaises(ValueError):

--- a/qubesadmin/tests/app.py
+++ b/qubesadmin/tests/app.py
@@ -131,6 +131,33 @@ class TC_00_VMCollection(qubesadmin.tests.QubesTestCase):
             self.fail('VM not found in collection')
         self.assertAllCalled()
 
+    def test_010_getitem_cache_power_state(self):
+        self.app.cache_enabled = True
+        self.app.expected_calls[('dom0', 'admin.vm.List', None, None)] = \
+            b'0\x00test-vm class=AppVM state=Running\n'
+        try:
+            vm = self.app.domains['test-vm']
+            self.assertEqual(vm.name, 'test-vm')
+            self.assertEqual(vm.klass, 'AppVM')
+            self.assertEqual(vm.get_power_state(), 'Running')
+        except KeyError:
+            self.fail('VM not found in collection')
+        self.assertAllCalled()
+
+    def test_011_getitem_non_cache_power_state(self):
+        self.app.expected_calls[('dom0', 'admin.vm.List', None, None)] = \
+            b'0\x00test-vm class=AppVM state=Running\n'
+        self.app.expected_calls[('test-vm', 'admin.vm.CurrentState', None, None)] = \
+            b'0\x00power_state=Running mem=1024'
+        try:
+            vm = self.app.domains['test-vm']
+            self.assertEqual(vm.name, 'test-vm')
+            self.assertEqual(vm.klass, 'AppVM')
+            self.assertEqual(vm.get_power_state(), 'Running')
+        except KeyError:
+            self.fail('VM not found in collection')
+        self.assertAllCalled()
+
 
 class TC_10_QubesBase(qubesadmin.tests.QubesTestCase):
     def setUp(self):

--- a/qubesadmin/tests/events.py
+++ b/qubesadmin/tests/events.py
@@ -166,7 +166,7 @@ class TC_00_Events(qubesadmin.tests.QubesTestCase):
                 self.read_all, sock2))
             loop.run_until_complete(asyncio.wait([task, reader]))
             self.assertEqual(reader.result(),
-                b'dom0\0admin.Events\0dom0\0\0')
+                b'admin.Events+ dom0 name dom0\0')
             self.assertIsInstance(task.result()[0], asyncio.StreamReader)
             cleanup_func = task.result()[1]
             cleanup_func()
@@ -192,7 +192,7 @@ class TC_00_Events(qubesadmin.tests.QubesTestCase):
                 self.read_all, sock2))
             loop.run_until_complete(asyncio.wait([task, reader]))
             self.assertEqual(reader.result(),
-                b'dom0\0admin.Events\0test-vm\0\0')
+                b'admin.Events+ dom0 name test-vm\0')
             self.assertIsInstance(task.result()[0], asyncio.StreamReader)
             cleanup_func = task.result()[1]
             cleanup_func()

--- a/qubesadmin/tests/tools/qubes_prefs.py
+++ b/qubesadmin/tests/tools/qubes_prefs.py
@@ -29,11 +29,9 @@ class TC_00_qubes_prefs(qubesadmin.tests.QubesTestCase):
             ('dom0', 'admin.property.List', None, None)] = \
             b'0\x00prop1\nprop2\n'
         self.app.expected_calls[
-            ('dom0', 'admin.property.Get', 'prop1', None)] = \
-            b'0\x00default=True type=str value1'
-        self.app.expected_calls[
-            ('dom0', 'admin.property.Get', 'prop2', None)] = \
-            b'0\x00default=False type=str value2'
+            ('dom0', 'admin.property.GetAll', None, None)] = \
+            b'0\x00prop1 default=True type=str value1\n' \
+            b'prop2 default=False type=str value2\n'
         with qubesadmin.tests.tools.StdoutBuffer() as stdout:
             self.assertEqual(0, qubesadmin.tools.qubes_prefs.main([], app=self.app))
         self.assertEqual(stdout.getvalue(),

--- a/qubesadmin/tests/tools/qvm_ls.py
+++ b/qubesadmin/tests/tools/qvm_ls.py
@@ -278,42 +278,34 @@ class TC_90_List_with_qubesd_calls(qubesadmin.tests.QubesTestCase):
             b'0\x00vm1 class=AppVM state=Running\n' \
             b'template1 class=TemplateVM state=Halted\n' \
             b'sys-net class=AppVM state=Running\n'
-        self.app.expected_calls[
-            ('vm1', 'admin.vm.CurrentState', None, None)] = \
-            b'0\x00power_state=Running'
-        self.app.expected_calls[
-            ('sys-net', 'admin.vm.CurrentState', None, None)] = \
-            b'0\x00power_state=Running'
-        self.app.expected_calls[
-            ('template1', 'admin.vm.CurrentState', None, None)] = \
-            b'0\x00power_state=Halted'
         props = {
-            'label': b'type=label green',
-            'template': b'type=vm template1',
-            'netvm': b'type=vm sys-net',
+            'label': 'type=label green',
+            'template': 'type=vm template1',
+            'netvm': 'type=vm sys-net',
 #           'virt_mode': b'type=str pv',
         }
-        for key, value in props.items():
-            self.app.expected_calls[
-                ('vm1', 'admin.vm.property.Get', key, None)] = \
-                b'0\x00default=True ' + value
-
-        # setup template1
-        props['label'] = b'type=label black'
-        for key, value in props.items():
-            self.app.expected_calls[
-                ('template1', 'admin.vm.property.Get', key, None)] = \
-                b'0\x00default=True ' + value
         self.app.expected_calls[
-            ('template1', 'admin.vm.property.Get', 'template', None)] = \
-            b''  # request refused - no such property
+            ('vm1', 'admin.vm.property.GetAll', None, None)] = \
+            b'0\x00' + ''.join(
+                '{} default=True {}\n'.format(key, value)
+                for key, value in props.items()).encode()
 
         # setup sys-net
-        props['label'] = b'type=label red'
-        for key, value in props.items():
-            self.app.expected_calls[
-                ('sys-net', 'admin.vm.property.Get', key, None)] = \
-                b'0\x00default=True ' + value
+        props['label'] = 'type=label red'
+        self.app.expected_calls[
+            ('sys-net', 'admin.vm.property.GetAll', None, None)] = \
+            b'0\x00' + ''.join(
+                '{} default=True {}\n'.format(key, value)
+                for key, value in props.items()).encode()
+
+        # setup template1
+        props['label'] = 'type=label black'
+        del props['template']
+        self.app.expected_calls[
+            ('template1', 'admin.vm.property.GetAll', None, None)] = \
+            b'0\x00' + ''.join(
+                '{} default=True {}\n'.format(key, value)
+                for key, value in props.items()).encode()
 
         with qubesadmin.tests.tools.StdoutBuffer() as stdout:
             qubesadmin.tools.qvm_ls.main([], app=self.app)
@@ -337,22 +329,24 @@ class TC_90_List_with_qubesd_calls(qubesadmin.tests.QubesTestCase):
             ('sys-net', 'admin.vm.CurrentState', None, None)] = \
             b'0\x00power_state=Running'
         props = {
-            'label': b'type=label green',
-            'template': b'type=vm template1',
-            'netvm': b'type=vm sys-net',
+            'label': 'type=label green',
+            'template': 'type=vm template1',
+            'netvm': 'type=vm sys-net',
 #           'virt_mode': b'type=str pv',
         }
-        for key, value in props.items():
-            self.app.expected_calls[
-                ('vm1', 'admin.vm.property.Get', key, None)] = \
-                b'0\x00default=True ' + value
+        self.app.expected_calls[
+            ('vm1', 'admin.vm.property.GetAll', None, None)] = \
+            b'0\x00' + ''.join(
+                '{} default=True {}\n'.format(key, value)
+                for key, value in props.items()).encode()
 
         # setup sys-net
-        props['label'] = b'type=label red'
-        for key, value in props.items():
-            self.app.expected_calls[
-                ('sys-net', 'admin.vm.property.Get', key, None)] = \
-                b'0\x00default=True ' + value
+        props['label'] = 'type=label red'
+        self.app.expected_calls[
+            ('sys-net', 'admin.vm.property.GetAll', None, None)] = \
+            b'0\x00' + ''.join(
+                '{} default=True {}\n'.format(key, value)
+                for key, value in props.items()).encode()
 
         with qubesadmin.tests.tools.StdoutBuffer() as stdout:
             qubesadmin.tools.qvm_ls.main(['vm1', 'sys-net'], app=self.app)

--- a/qubesadmin/tests/tools/qvm_prefs.py
+++ b/qubesadmin/tests/tools/qvm_prefs.py
@@ -33,11 +33,9 @@ class TC_00_qvm_prefs(qubesadmin.tests.QubesTestCase):
             ('dom0', 'admin.vm.property.List', None, None)] = \
             b'0\x00prop1\nprop2\n'
         self.app.expected_calls[
-            ('dom0', 'admin.vm.property.Get', 'prop1', None)] = \
-            b'0\x00default=True type=str value1'
-        self.app.expected_calls[
-            ('dom0', 'admin.vm.property.Get', 'prop2', None)] = \
-            b'0\x00default=False type=str value2'
+            ('dom0', 'admin.vm.property.GetAll', None, None)] = \
+            b'0\x00prop1 default=True type=str value1\n' \
+            b'prop2 default=False type=str value2\n'
         with qubesadmin.tests.tools.StdoutBuffer() as stdout:
             self.assertEqual(0, qubesadmin.tools.qvm_prefs.main([
                 'dom0'], app=self.app))
@@ -46,7 +44,7 @@ class TC_00_qvm_prefs(qubesadmin.tests.QubesTestCase):
             'prop2  -  value2\n')
         with qubesadmin.tests.tools.StdoutBuffer() as stdout:
             self.assertEqual(0, qubesadmin.tools.qvm_prefs.main([
-                'dom0','--hide-default'], app=self.app))
+                'dom0', '--hide-default'], app=self.app))
         self.assertEqual(stdout.getvalue(),
             'prop2  -  value2\n')
         self.assertAllCalled()

--- a/qubesadmin/tools/qvm_ls.py
+++ b/qubesadmin/tools/qvm_ls.py
@@ -664,6 +664,10 @@ def main(args=None, app=None):
         parser.print_error(str(e))
         return 1
 
+    # fetch all the properties with one Admin API call, instead of issuing
+    # one call per property
+    args.app.cache_enabled = True
+
     if args.raw_list:
         args.raw_data = True
         args.fields = 'name'

--- a/qubesadmin/tools/qvm_prefs.py
+++ b/qubesadmin/tools/qvm_prefs.py
@@ -93,6 +93,9 @@ def process_actions(parser, args, target):
         return 0
 
     if args.property is None:
+        # fetch all the properties with one Admin API call, instead of issuing
+        # one call per property
+        args.app.cache_enabled = True
         properties = target.property_list()
         width = max(len(prop) for prop in properties)
 

--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -52,10 +52,11 @@ class QubesVM(qubesadmin.base.PropertyHolder):
 
     firewall = None
 
-    def __init__(self, app, name, klass=None):
+    def __init__(self, app, name, klass=None, power_state=None):
         super(QubesVM, self).__init__(app, 'admin.vm.property.', name)
         self._volumes = None
         self._klass = klass
+        self._power_state_cache = power_state
         self.log = logging.getLogger(name)
         self.tags = qubesadmin.tags.Tags(self)
         self.features = qubesadmin.features.Features(self)
@@ -181,8 +182,13 @@ class QubesVM(qubesadmin.base.PropertyHolder):
 
         '''
 
+        if self._power_state_cache is not None:
+            return self._power_state_cache
         try:
-            return self._get_current_state()['power_state']
+            power_state = self._get_current_state()['power_state']
+            if self.app.cache_enabled:
+                self._power_state_cache = power_state
+            return power_state
         except qubesadmin.exc.QubesDaemonNoResponseError:
             return 'NA'
 


### PR DESCRIPTION
- cache results
- get more data at once
- avoid checking for objects existence twice

TODO: most of the improvements are active only with Qubes().cache_enabled=True.
It needs to be enabled in tools that would benefit from it.

QubesOS/qubes-issues#5415
QubesOS/qubes-issues#5099