### PR TITLE
qvm-remove: remove misleading handling of QubesVMInUseError

### DIFF
--- a/qubesadmin/tools/qvm_remove.py
+++ b/qubesadmin/tools/qvm_remove.py
@@ -48,15 +48,6 @@ def main(args=None, app=None):  # pylint: disable=missing-docstring
         for vm in args.domains:
             try:
                 del args.app.domains[vm.name]
-            except qubesadmin.exc.QubesVMInUseError:
-                dependencies = qubesadmin.utils.vm_dependencies(vm.app, vm)
-                print("VM {} cannot be removed. It is in use as:".format(
-                    vm.name))
-                for (holder, prop) in dependencies:
-                    if holder:
-                        print(" - {} for {}".format(prop, holder.name))
-                    else:
-                        print(" - global property {}".format(prop))
             except qubesadmin.exc.QubesException as e:
                 parser.error_runtime(e)
         retcode = 0


### PR DESCRIPTION
Currently qvm-remove handles QubesVMInUseError by assuming that the
remove failed due to dependencies between VMs, and tries to recover
these. However, qubesd does not actually check these dependencies,
and throws QubesVMInUseError for different reasons (such as
"installed by package manager"), providing an explanatory message
which we disregard.

Instead, we should just display the message, as we do in the GUI.

See also QubesOS/qubes-core-admin#308 for which this was needed.