### PR TITLE
qvm-shutdown: report errors, don't crash on DispVMs

### DIFF
--- a/qubesadmin/tests/tools/qvm_shutdown.py
+++ b/qubesadmin/tests/tools/qvm_shutdown.py
@@ -293,6 +293,7 @@ class TC_00_qvm_shutdown(qubesadmin.tests.QubesTestCase):
         self.app.expected_calls[
             ('sys-net', 'admin.vm.List', None, None)] = \
             b'0\x00sys-net class=AppVM state=Halted\n'
-        qubesadmin.tools.qvm_shutdown.main(
-            ['--wait', '--all', '--timeout=1'], app=self.app)
+        with self.assertRaisesRegexp(SystemExit, '2'):
+            qubesadmin.tools.qvm_shutdown.main(
+                ['--wait', '--all', '--timeout=1'], app=self.app)
         self.assertAllCalled()

--- a/qubesadmin/tools/__init__.py
+++ b/qubesadmin/tools/__init__.py
@@ -408,12 +408,12 @@ class QubesArgumentParser(argparse.ArgumentParser):
         return namespace
 
 
-    def error_runtime(self, message):
+    def error_runtime(self, message, exit_code=1):
         '''Runtime error, without showing usage.
 
         :param str message: message to show
         '''
-        self.exit(1, '{}: error: {}\n'.format(self.prog, message))
+        self.exit(exit_code, '{}: error: {}\n'.format(self.prog, message))
 
 
     @staticmethod


### PR DESCRIPTION
qvm-shutdown with the --wait option checks if the machine
state is 'Halted', but a disposable VM is usually deleted by
the time of the final check, resulting in a non-zero exit code.

This change handles properly disposable VMs, and makes sure
we always output an error message when finishing with a non-zero
exit code.

Fixes QubesOS/qubes-issues#5245.