### PR TITLE
qvm-remove: improve error message

### DIFF
--- a/qubesadmin/tests/tools/qvm_remove.py
+++ b/qubesadmin/tests/tools/qvm_remove.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf8 -*-
+# -*- encoding: utf-8 -*-
 #
 # The Qubes OS Project, http://www.qubes-os.org
 #
@@ -47,7 +47,8 @@ class TC_00_qvm_remove(qubesadmin.tests.QubesTestCase):
         mock_dependencies.return_value = \
             [(None, 'default_template'), (self.app.domains['some-vm'], 'netvm')]
 
-        qubesadmin.tools.qvm_remove.main(['-f', 'some-vm'], app=self.app)
+        with self.assertRaises(SystemExit):
+            qubesadmin.tools.qvm_remove.main(['-f', 'some-vm'], app=self.app)
 
         self.assertTrue(mock_dependencies.called,
                         "Dependencies check not called.")

--- a/qubesadmin/tools/qvm_remove.py
+++ b/qubesadmin/tools/qvm_remove.py
@@ -48,15 +48,18 @@ def main(args=None, app=None):  # pylint: disable=missing-docstring
         for vm in args.domains:
             try:
                 del args.app.domains[vm.name]
-            except qubesadmin.exc.QubesVMInUseError:
+            except qubesadmin.exc.QubesVMInUseError as e:
                 dependencies = qubesadmin.utils.vm_dependencies(vm.app, vm)
-                print("VM {} cannot be removed. It is in use as:".format(
-                    vm.name))
-                for (holder, prop) in dependencies:
-                    if holder:
-                        print(" - {} for {}".format(prop, holder.name))
-                    else:
-                        print(" - global property {}".format(prop))
+                if dependencies:
+                    print("VM {} cannot be removed. It is in use as:".format(
+                        vm.name))
+                    for (holder, prop) in dependencies:
+                        if holder:
+                            print(" - {} for {}".format(prop, holder.name))
+                        else:
+                            print(" - global property {}".format(prop))
+                # Display the original message as well
+                parser.error_runtime(e)
             except qubesadmin.exc.QubesException as e:
                 parser.error_runtime(e)
         retcode = 0


### PR DESCRIPTION
The code assumes that QubesVMInUseError is thrown for a failed
dependency check, but there are also other reasons. We need to
handle the case when dependency list is empty, and also display
the original message.

See also QubesOS/qubes-core-admin#308 for which this was needed.