### PR TITLE
Move qvm-console from qubes-core-agent-linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ install:
 	$(PYTHON) setup.py install -O1 $(PYTHON_PREFIX_ARG) --root $(DESTDIR)
 	install -d $(DESTDIR)/etc/xdg/autostart
 	install -m 0644 etc/qvm-start-gui.desktop $(DESTDIR)/etc/xdg/autostart/
+	install -D scripts/qvm-console $(DESTDIR)/usr/bin/qvm-console
 
 clean:
 	rm -rf test-packages/__pycache__ qubesadmin/__pycache__

--- a/scripts/qvm-console
+++ b/scripts/qvm-console
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+print_usage() {
+cat >&2 <<USAGE
+Usage: $0 vmname
+Connects to another VM console using the admin.vm.Console RPC service.
+USAGE
+}
+
+if [ $# -lt 1 ] ; then
+    print_usage
+    exit 1
+fi
+
+QREXEC_REQUESTED_TARGET="$1"
+
+qrexec_console() {
+    QREXEC_REQUESTED_TARGET="$1"
+
+    qrexec-client-vm "$QREXEC_REQUESTED_TARGET" admin.vm.Console
+
+    # exit code 200 is flock exit code in admin.vm.Console
+    exit_code=$?
+    if [ $exit_code -gt 0 ]; then
+        if [ $exit_code -ne 200 ]; then
+            printf "Cannot connect to %s" "$QREXEC_REQUESTED_TARGET"
+        else
+            printf "A qube is already connected to %s" "$QREXEC_REQUESTED_TARGET"
+        fi
+        exit 1
+    fi
+}
+
+export -f qrexec_console
+
+printf "Use '^]' to exit remote console\n"
+socat file:/dev/tty,rawer,escape=0x1d EXEC:"/bin/bash -c \'qrexec_console $QREXEC_REQUESTED_TARGET 2>/dev/null\'"
+printf '\n'


### PR DESCRIPTION
See QubesOS/qubes-core-agent-linux#191 where qvm-console is removed from qubes-core-agent-linux.