### PR TITLE
Update qvm-backup manpage explanation of default VMs behavior to match current code

### DIFF
--- a/doc/manpages/qvm-backup.rst
+++ b/doc/manpages/qvm-backup.rst
@@ -72,7 +72,8 @@ Arguments
 
 The first positional parameter is the backup location (absolute directory path,
 or command to pipe backup to). After that you may specify the qubes you'd
-like to backup. If not specified, all qubes are included.
+like to backup. If not specified, the default list based on the VM's "include 
+in backups" property will be used.
 
 Authors
 -------


### PR DESCRIPTION
The actual code in https://github.com/QubesOS/qubes-core-admin/blob/master/qubes/backup.py interprets a "None" list of VMs to backup as asking for the default list of VMs. See line 231 for the in-code docs and line 347 for the actual code:

```
if vms_list is None:
            vms_list = [vm for vm in app.domains if vm.include_in_backups]
```

This pull request updates the manpage to reflect the current implementation of backup.py underneath qvm-backup