### PR TITLE
Added an option to qvm-firewall to reset all rules

### DIFF
--- a/qubesadmin/tests/tools/qvm_firewall.py
+++ b/qubesadmin/tests/tools/qvm_firewall.py
@@ -243,3 +243,15 @@ class TC_10_qvm_firewall(qubesadmin.tests.QubesTestCase):
             ['test-vm', 'del', 'drop', 'proto=icmp'],
             app=self.app
         )
+
+    def test_030_reset(self):
+        self.app.expected_calls[('test-vm', 'admin.vm.firewall.Get',
+                None, None)] = \
+            b'0\0action=accept dsthost=qubes-os.org\n' \
+            b'action=drop proto=icmp\n'
+        self.app.expected_calls[('test-vm', 'admin.vm.firewall.Set', None,
+            b'action=accept\n')] = b'0\0'
+        qubesadmin.tools.qvm_firewall.main(
+            ['test-vm', 'reset'],
+            app=self.app
+        )

--- a/qubesadmin/tools/qvm_firewall.py
+++ b/qubesadmin/tools/qvm_firewall.py
@@ -125,6 +125,11 @@ action_del.add_argument('rule', metavar='match', nargs='*', action=RuleAction,
 
 action_list = action.add_parser('list', help='list rules')
 
+action_reset = action.add_parser(
+    'reset',
+    help='remove all firewall rules and reset to default '
+         '(accept all connections)')
+
 parser.add_argument('--reload', '-r', action='store_true',
     help='force reload of rules even when unchanged')
 
@@ -193,6 +198,10 @@ def main(args=None, app=None):
             rules_add(vm, args)
         elif args.command == 'del':
             rules_del(vm, args)
+        elif args.command == 'reset':
+            vm.firewall.rules.clear()
+            vm.firewall.rules.append(qubesadmin.firewall.Rule('action=accept'))
+            vm.firewall.save_rules()
         else:
             if args.raw:
                 rules_list_raw(vm)


### PR DESCRIPTION
Rules will be reset to a single 'accept' line, which is something
that the GUI tools like. It's an easy way to get out of CLI firewall
modifications if someone wants to go back to using GUI for them.

fixes QubesOS/qubes-issues#4710