### PR TITLE
Added better __eq__ method to Label class

### DIFF
--- a/qubesadmin/label.py
+++ b/qubesadmin/label.py
@@ -75,3 +75,8 @@ class Label(object):
 
     def __str__(self):
         return self._name
+
+    def __eq__(self, other):
+        if isinstance(other, Label):
+            return self.name == other.name
+        return NotImplemented


### PR DESCRIPTION
Labels with the same name should not be distinguishable.

fixes QubesOS/qubes-issues#5944