### PR TITLE
Fixed inconsistent firewall address checking

### DIFF
--- a/qubesadmin/firewall.py
+++ b/qubesadmin/firewall.py
@@ -23,6 +23,8 @@
 
 import datetime
 import socket
+import string
+
 
 class RuleOption(object):
     '''Base class for a single rule element'''
@@ -120,6 +122,9 @@ class DstHost(RuleOption):
                 except socket.error:
                     self.type = 'dsthost'
                     self.prefixlen = 0
+                    safe_set = string.ascii_lowercase + string.digits + '-._'
+                    if not all(c in safe_set for c in value):
+                        raise ValueError('Invalid hostname')
         else:
             host, prefixlen = value.split('/', 1)
             prefixlen = int(prefixlen)

--- a/qubesadmin/tests/firewall.py
+++ b/qubesadmin/tests/firewall.py
@@ -176,7 +176,6 @@ class TC_02_DstHost(qubesadmin.tests.QubesTestCase):
         with self.assertRaises(ValueError):
             qubesadmin.firewall.DstHost('2001:abcd:efab::3/64')
 
-    @unittest.expectedFailure
     def test_020_invalid_hostname(self):
         with self.assertRaises(ValueError):
             qubesadmin.firewall.DstHost('www  qubes-os.org')


### PR DESCRIPTION
core-admin-client side had less strict rules for hostname than core-admin,
leading to unexpected empty qubesd response. Fixed by copying the logic from core-admin.