### PR TITLE
Add a lightdm session for sys-gui

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,11 @@ install:
 	install -d $(DESTDIR)/etc/xdg/autostart
 	install -m 0644 etc/qvm-start-daemon.desktop $(DESTDIR)/etc/xdg/autostart/
 	install -m 0644 etc/qvm-start-daemon-kde.desktop $(DESTDIR)/etc/xdg/autostart/
+	install -d $(DESTDIR)/usr/share/xsessions/
+	install -m 0644 xsessions/sys-gui.desktop $(DESTDIR)/usr/share/xsessions/
 	install -d $(DESTDIR)/usr/bin
 	ln -sf qvm-start-daemon $(DESTDIR)/usr/bin/qvm-start-gui
+	install -m 0755 scripts/qubes-gui-session $(DESTDIR)/usr/bin/
 
 clean:
 	rm -rf test-packages/__pycache__ qubesadmin/__pycache__

--- a/doc/manpages/qvm-start-daemon.rst
+++ b/doc/manpages/qvm-start-daemon.rst
@@ -47,7 +47,11 @@ Options
 
 .. option:: --watch
 
-   Keep watching for further domains startups, must be used with --all
+   Keep watching for further domains startups
+
+.. option:: --exit
+
+   Exit after all watched domains have exited
 
 .. option:: --force-stubdomain
 

--- a/doc/manpages/qvm-start-daemon.rst
+++ b/doc/manpages/qvm-start-daemon.rst
@@ -76,6 +76,11 @@ Options
 
    Notify running instance in --watch mode about changed monitor layout
 
+.. option:: --gui-allow-fullscreen
+
+   Override ``allow_fullscreen`` GUI option to true. Intended for use with the
+   GUI domain.
+
 Authors
 -------
 

--- a/etc/sys-gui.desktop
+++ b/etc/sys-gui.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Name=GUI Domain (sys-gui)
+Exec=qubes-gui-session sys-gui
+Type=Application

--- a/rpm_spec/qubes-core-admin-client.spec.in
+++ b/rpm_spec/qubes-core-admin-client.spec.in
@@ -60,6 +60,7 @@ make -C doc DESTDIR=$RPM_BUILD_ROOT \
 %{_bindir}/qvm-*
 %{_mandir}/man1/qvm-*.1*
 %{_mandir}/man1/qubes*.1*
+%{_datadir}/xsessions/sys-gui.desktop
 
 %files -n python%{python3_pkgversion}-qubesadmin
 %{python3_sitelib}/qubesadmin-*egg-info

--- a/scripts/qubes-gui-session
+++ b/scripts/qubes-gui-session
@@ -14,4 +14,4 @@ if [ $# -lt 1 ] ; then
 fi
 
 qvm-start sys-gui
-exec qvm-start-daemon --watch --exit "$1"
+exec qvm-start-daemon --watch --exit --gui-allow-fullscreen "$1"

--- a/scripts/qubes-gui-session
+++ b/scripts/qubes-gui-session
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+print_usage() {
+cat >&2 <<USAGE
+Usage: $0 vmname
+Starts given VM and runs its associated GUI daemon. Used as X session for the
+GUI domain.
+USAGE
+}
+
+if [ $# -lt 1 ] ; then
+    print_usage
+    exit 1
+fi
+
+qvm-start sys-gui
+exec qvm-start-daemon --watch --exit "$1"

--- a/xsessions/sys-gui.desktop
+++ b/xsessions/sys-gui.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Name=GUI Domain (sys-gui)
+Exec=qubes-gui-session
+Type=Application


### PR DESCRIPTION
Starts just sys-gui VM and qvm-start-daemon in a special mode.

See QubesOS/qubes-issues#5662.

This seems to need `allow_fullscreen`. I'd rather not add it to `sys-gui` because then it's becomes problematic to test it when running a normal session. Added an override: `qvm-start-daemon --allow-fullscreen`.

Remaining issues:

* Selecting "Logout" in `sys-gui` seems to shut down the Xephyr window but not the VM. Should it work that way? Should we detect that the GUI agent inside has died and then exit dom0 session, or rather make the VM shut down?