### PR TITLE
Make Label() object hashable

### DIFF
--- a/qubesadmin/label.py
+++ b/qubesadmin/label.py
@@ -80,3 +80,6 @@ class Label(object):
         if isinstance(other, Label):
             return self.name == other.name
         return NotImplemented
+
+    def __hash__(self):
+        return hash(self.name)


### PR DESCRIPTION
Since it got custom __eq__ function, __hash__ needs to be implemented
too. Otherwise it can't be used as a key in dict.