### PR TITLE
Add a script for GuiVM session

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ install:
 	install -m 0644 etc/qvm-start-daemon-kde.desktop $(DESTDIR)/etc/xdg/autostart/
 	install -d $(DESTDIR)/usr/bin
 	ln -sf qvm-start-daemon $(DESTDIR)/usr/bin/qvm-start-gui
+	install -m 0755 scripts/qubes-guivm-session $(DESTDIR)/usr/bin/
 
 clean:
 	rm -rf test-packages/__pycache__ qubesadmin/__pycache__

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -9,3 +9,4 @@ mock
 lxml
 PyYAML
 xcffib
+asynctest

--- a/doc/manpages/qvm-start-daemon.rst
+++ b/doc/manpages/qvm-start-daemon.rst
@@ -47,7 +47,7 @@ Options
 
 .. option:: --watch
 
-   Keep watching for further domains startups, must be used with --all
+   Keep watching for further domain startups
 
 .. option:: --force-stubdomain
 

--- a/qubesadmin/tests/tools/qvm_start_daemon.py
+++ b/qubesadmin/tests/tools/qvm_start_daemon.py
@@ -23,8 +23,9 @@ import signal
 import tempfile
 import unittest.mock
 import re
-
 import asyncio
+
+import asynctest
 
 import qubesadmin.tests
 import qubesadmin.tools.qvm_start_daemon
@@ -207,7 +208,7 @@ global: {
 }
 ''')
 
-    @unittest.mock.patch('asyncio.create_subprocess_exec')
+    @asynctest.patch('asyncio.create_subprocess_exec')
     def test_020_start_gui_for_vm(self, proc_mock):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
@@ -238,7 +239,7 @@ global: {
 
         self.assertAllCalled()
 
-    @unittest.mock.patch('asyncio.create_subprocess_exec')
+    @asynctest.patch('asyncio.create_subprocess_exec')
     def test_021_start_gui_for_vm_hvm(self, proc_mock):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
@@ -307,7 +308,7 @@ global: {
         pidfile.flush()
         self.addCleanup(pidfile.close)
 
-        patch_proc = unittest.mock.patch('asyncio.create_subprocess_exec')
+        patch_proc = asynctest.patch('asyncio.create_subprocess_exec')
         patch_args = unittest.mock.patch.object(self.launcher,
                                                 'common_guid_args',
                                                 lambda vm: [])
@@ -350,7 +351,7 @@ global: {
              None)] = \
             b'2\x00QubesFeatureNotFoundError\x00\x00Feature not set\x00'
         proc_mock = unittest.mock.Mock()
-        with unittest.mock.patch('asyncio.create_subprocess_exec',
+        with asynctest.patch('asyncio.create_subprocess_exec',
                                  lambda *args: self.mock_coroutine(proc_mock,
                                                                    *args)):
             with unittest.mock.patch.object(self.launcher,
@@ -384,7 +385,7 @@ global: {
              None)] = \
             b'0\x001'
         proc_mock = unittest.mock.Mock()
-        with unittest.mock.patch('asyncio.create_subprocess_exec',
+        with asynctest.patch('asyncio.create_subprocess_exec',
                                  lambda *args: self.mock_coroutine(proc_mock,
                                                                    *args)):
             with unittest.mock.patch.object(self.launcher,

--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -634,7 +634,7 @@ class DAEMONLauncher:
                 continue
 
             if not self.is_watched(vm):
-                return
+                continue
 
             power_state = vm.get_power_state()
             if power_state == 'Running':

--- a/scripts/qubes-guivm-session
+++ b/scripts/qubes-guivm-session
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+print_usage() {
+cat >&2 <<USAGE
+Usage: $0 vmname
+Starts given VM and runs its associated GUI daemon. Used as X session for the
+GUI domain.
+USAGE
+}
+
+if [ $# -lt 1 ] ; then
+    print_usage
+    exit 1
+fi
+
+# Start VM, gui-daemon and audio
+qvm-start --skip-if-running "$1"
+qvm-start-daemon --watch "$1" &
+
+# Run the inner session (Xephyr) and wait until it exits
+exec qvm-run -p --no-gui --service "$1" qubes.GuiVMSession


### PR DESCRIPTION
See QubesOS/qubes-issues#5662.

Depends on a refactoring (and rpc service) in https://github.com/QubesOS/qubes-gui-agent-linux/pull/105.

Also needs installation by Salt:
* set qvm-feature `gui-allow-fullscreen = 1`,
* add an xsession script `/usr/share/xsessions/sys-gui.desktop`:
```
[Desktop Entry]
Name=GUI Domain (sys-gui)
Exec=qubes-guivm-session sys-gui
Type=Application
```