### PR TITLE
utils: fix encoding '+' for qubes.VMExec

### DIFF
--- a/qubesadmin/tests/utils.py
+++ b/qubesadmin/tests/utils.py
@@ -116,8 +116,8 @@ class TestVMUsage(qubesadmin.tests.QubesTestCase):
 class TestVMExecEncode(qubesadmin.tests.QubesTestCase):
     def test_00_encode(self):
         self.assertEqual(
-            qubesadmin.utils.encode_for_vmexec(['ls', '-a']),
-            'ls+--a')
+            qubesadmin.utils.encode_for_vmexec(['ls', '-a', '+x']),
+            'ls+--a+-2Bx')
         self.assertEqual(
             qubesadmin.utils.encode_for_vmexec(
                 ['touch', '/home/user/.profile']),

--- a/qubesadmin/utils.py
+++ b/qubesadmin/utils.py
@@ -161,6 +161,6 @@ def encode_for_vmexec(args):
 
     parts = []
     for arg in args:
-        part = re.sub(br'[^a-zA-Z0-9_.+]', encode, arg.encode('utf-8'))
+        part = re.sub(br'[^a-zA-Z0-9_.]', encode, arg.encode('utf-8'))
         parts.append(part)
     return b'+'.join(parts).decode('ascii')


### PR DESCRIPTION
'+' in an argument needs to be encoded too, otherwise it is interpreted
as arguments separator.