### PR TITLE
Make incorrect label name error more descriptive

### DIFF
--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -250,7 +250,7 @@ class QubesBase(qubesadmin.base.PropertyHolder):
     def get_label(self, label):
         """Get label as identified by index or name
 
-        :throws KeyError: when label is not found
+        :throws QubesLabelNotFoundError: when label is not found
         """
 
         # first search for name, verbatim
@@ -264,7 +264,7 @@ class QubesBase(qubesadmin.base.PropertyHolder):
             for i in self.labels.values():
                 if i.index == int(label):
                     return i
-        raise KeyError(label)
+        raise qubesadmin.exc.QubesLabelNotFoundError(label)
 
     @staticmethod
     def get_vm_class(clsname):

--- a/qubesadmin/exc.py
+++ b/qubesadmin/exc.py
@@ -138,6 +138,13 @@ class QubesTagNotFoundError(QubesException, KeyError):
         return QubesException.__str__(self)
 
 
+class QubesLabelNotFoundError(QubesException, KeyError):
+    """Label does not exists"""
+    def __str__(self):
+        # KeyError overrides __str__ method
+        return QubesException.__str__(self)
+
+
 class StoragePoolException(QubesException):
     ''' A general storage exception '''
 

--- a/qubesadmin/tests/app.py
+++ b/qubesadmin/tests/app.py
@@ -278,6 +278,13 @@ class TC_10_QubesBase(qubesadmin.tests.QubesTestCase):
         self.assertEqual(label.name, 'red')
         self.assertAllCalled()
 
+    def test_021_get_nonexistant_label(self):
+        self.app.expected_calls[('dom0', 'admin.label.List', None, None)] = \
+            b'0\x00red\nblue\n'
+        with self.assertRaises(qubesadmin.exc.QubesLabelNotFoundError):
+            self.app.get_label('green')
+        self.assertAllCalled()
+
     def clone_setup_common_calls(self, src, dst):
         # have each property type with default=no, each special-cased,
         # and some with default=yes


### PR DESCRIPTION
Instead of unintuitive Value Error now we have dedicated QubesLabelNotFoundError.