### PR TITLE
Guard qvm-start-daemon with generic 'guivm' or 'audiovm' services

### DIFF
--- a/doc/manpages/qvm-start-daemon.rst
+++ b/doc/manpages/qvm-start-daemon.rst
@@ -56,8 +56,8 @@ Options
 .. option:: --force
 
    Force running, even if this isn't GUI/Audio domain. GUI domain is a domain
-   with 'guivm-gui-agent' qvm-service enabled. Similarly for Audio domain it is
-   'audiovm-audio-agent' qvm-service.
+   with 'guivm' qvm-service enabled. Similarly for Audio domain it is
+   'audiovm' qvm-service.
 
 .. option:: --kde
 

--- a/qubesadmin/base.py
+++ b/qubesadmin/base.py
@@ -157,7 +157,8 @@ class PropertyHolder(object):
                 self._method_prefix + 'Get',
                 item,
                 None)
-        except qubesadmin.exc.QubesDaemonAccessError:
+        except (qubesadmin.exc.QubesDaemonAccessError,
+                qubesadmin.exc.QubesVMNotFoundError):
             raise qubesadmin.exc.QubesPropertyAccessError(item)
         is_default, value = self._deserialize_property(property_str)
         if self.app.cache_enabled:
@@ -179,7 +180,8 @@ class PropertyHolder(object):
                 self._method_prefix + 'GetDefault',
                 item,
                 None)
-        except qubesadmin.exc.QubesDaemonAccessError:
+        except (qubesadmin.exc.QubesDaemonAccessError,
+                qubesadmin.exc.QubesVMNotFoundError):
             raise qubesadmin.exc.QubesPropertyAccessError(item)
         if not property_str:
             raise AttributeError(item + ' has no default')
@@ -224,7 +226,8 @@ class PropertyHolder(object):
                 self._method_prefix + 'Get',
                 item,
                 None)
-        except qubesadmin.exc.QubesDaemonNoResponseError:
+        except (qubesadmin.exc.QubesDaemonNoResponseError,
+                qubesadmin.exc.QubesVMNotFoundError):
             raise qubesadmin.exc.QubesPropertyAccessError(item)
         is_default, value = self._deserialize_property(property_str)
         if self.app.cache_enabled:
@@ -353,7 +356,8 @@ class PropertyHolder(object):
                     self._method_prefix + 'Reset',
                     key,
                     None)
-            except qubesadmin.exc.QubesDaemonNoResponseError:
+            except (qubesadmin.exc.QubesDaemonNoResponseError,
+                    qubesadmin.exc.QubesVMNotFoundError):
                 raise qubesadmin.exc.QubesPropertyAccessError(key)
         else:
             if isinstance(value, qubesadmin.vm.QubesVM):
@@ -366,7 +370,8 @@ class PropertyHolder(object):
                     self._method_prefix + 'Set',
                     key,
                     str(value).encode('utf-8'))
-            except qubesadmin.exc.QubesDaemonNoResponseError:
+            except (qubesadmin.exc.QubesDaemonNoResponseError,
+                    qubesadmin.exc.QubesVMNotFoundError):
                 raise qubesadmin.exc.QubesPropertyAccessError(key)
 
     def __delattr__(self, name):
@@ -378,7 +383,8 @@ class PropertyHolder(object):
                 self._method_prefix + 'Reset',
                 name
             )
-        except qubesadmin.exc.QubesDaemonNoResponseError:
+        except (qubesadmin.exc.QubesDaemonNoResponseError,
+                qubesadmin.exc.QubesVMNotFoundError):
             raise qubesadmin.exc.QubesPropertyAccessError(name)
 
 

--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -710,12 +710,12 @@ parser.add_argument('--kde', action='store_true',
 # Add it for the help only
 parser.add_argument('--force', action='store_true', default=False,
                     help='Force running daemon without enabled services'
-                         ' \'guivm-gui-agent\' or \'audiovm-audio-agent\'')
+                         ' \'guivm\' or \'audiovm\'')
 
 
 def main(args=None):
     """ Main function of qvm-start-daemon tool"""
-    only_if_service_enabled = ['guivm-gui-agent', 'audiovm-audio-agent']
+    only_if_service_enabled = ['guivm', 'audiovm']
     enabled_services = [service for service in only_if_service_enabled if
                         os.path.exists('/var/run/qubes-service/%s' % service)]
     if not enabled_services and '--force' not in sys.argv and \


### PR DESCRIPTION
Not a flavor-specific one (guivm-gui-agent).

QubesOS/qubes-issues#4186