### PR TITLE
Convert tests to use stdlib's AsyncMock()

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -9,6 +9,5 @@ mock
 lxml
 PyYAML
 xcffib
-asynctest
 tqdm
 pyxdg

--- a/qubesadmin/tests/tools/__init__.py
+++ b/qubesadmin/tests/tools/__init__.py
@@ -80,6 +80,5 @@ class MockEventsReader(object):
         self.current_event = rest
         return data + delim
 
-    @asyncio.coroutine
     def __call__(self, vm=None):
         return self, (lambda: None)

--- a/qubesadmin/tests/tools/qvm_backup.py
+++ b/qubesadmin/tests/tools/qvm_backup.py
@@ -22,7 +22,6 @@ import os
 import unittest.mock as mock
 
 import asyncio
-import asynctest
 
 import qubesadmin.tests
 import qubesadmin.tests.tools
@@ -178,7 +177,7 @@ class TC_00_qvm_backup(qubesadmin.tests.QubesTestCase):
                 None)] = \
             b'0\0'
         try:
-            mock_events = asynctest.CoroutineMock()
+            mock_events = mock.AsyncMock()
             patch = mock.patch(
                 'qubesadmin.events.EventsDispatcher._get_events_reader',
                 mock_events)

--- a/qubesadmin/tests/tools/qvm_shutdown.py
+++ b/qubesadmin/tests/tools/qvm_shutdown.py
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU Lesser General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 import asyncio
-import asynctest
 import unittest.mock
 
 import qubesadmin.tests
@@ -87,7 +86,7 @@ class TC_00_qvm_shutdown(qubesadmin.tests.QubesTestCase):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 
-        mock_events = asynctest.CoroutineMock()
+        mock_events = unittest.mock.AsyncMock()
         patch = unittest.mock.patch(
             'qubesadmin.events.EventsDispatcher._get_events_reader',
             mock_events)
@@ -118,7 +117,7 @@ class TC_00_qvm_shutdown(qubesadmin.tests.QubesTestCase):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 
-        mock_events = asynctest.CoroutineMock()
+        mock_events = unittest.mock.AsyncMock()
         patch = unittest.mock.patch(
             'qubesadmin.events.EventsDispatcher._get_events_reader',
             mock_events)
@@ -165,7 +164,7 @@ class TC_00_qvm_shutdown(qubesadmin.tests.QubesTestCase):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 
-        mock_events = asynctest.CoroutineMock()
+        mock_events = unittest.mock.AsyncMock()
         patch = unittest.mock.patch(
             'qubesadmin.events.EventsDispatcher._get_events_reader',
             mock_events)

--- a/qubesadmin/tests/tools/qvm_start_daemon.py
+++ b/qubesadmin/tests/tools/qvm_start_daemon.py
@@ -25,8 +25,6 @@ import unittest.mock
 import re
 import asyncio
 
-import asynctest
-
 import qubesadmin.tests
 import qubesadmin.tools.qvm_start_daemon
 from  qubesadmin.tools.qvm_start_daemon import GUI_DAEMON_OPTIONS
@@ -208,7 +206,7 @@ global: {
 }
 ''')
 
-    @asynctest.patch('asyncio.create_subprocess_exec')
+    @unittest.mock.patch('asyncio.create_subprocess_exec')
     def test_020_start_gui_for_vm(self, proc_mock):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
@@ -243,7 +241,7 @@ global: {
 
         self.assertAllCalled()
 
-    @asynctest.patch('asyncio.create_subprocess_exec')
+    @unittest.mock.patch('asyncio.create_subprocess_exec')
     def test_021_start_gui_for_vm_hvm(self, proc_mock):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
@@ -316,7 +314,7 @@ global: {
         pidfile.flush()
         self.addCleanup(pidfile.close)
 
-        patch_proc = asynctest.patch('asyncio.create_subprocess_exec')
+        patch_proc = unittest.mock.patch('asyncio.create_subprocess_exec')
         patch_monitor_layout = unittest.mock.patch.object(
             qubesadmin.tools.qvm_start_daemon,
             'get_monitor_layout',
@@ -363,10 +361,7 @@ global: {
             ('test-vm', 'admin.vm.feature.CheckWithTemplate', 'gui-emulated',
              None)] = \
             b'2\x00QubesFeatureNotFoundError\x00\x00Feature not set\x00'
-        proc_mock = unittest.mock.Mock()
-        with asynctest.patch('asyncio.create_subprocess_exec',
-                                 lambda *args: self.mock_coroutine(proc_mock,
-                                                                   *args)):
+        with unittest.mock.patch('asyncio.create_subprocess_exec') as proc_mock:
             with unittest.mock.patch.object(self.launcher,
                                             'common_guid_args', lambda vm: []):
                 loop.run_until_complete(self.launcher.start_gui_for_stubdomain(
@@ -397,10 +392,7 @@ global: {
             ('test-vm', 'admin.vm.feature.CheckWithTemplate', 'gui-emulated',
              None)] = \
             b'0\x001'
-        proc_mock = unittest.mock.Mock()
-        with asynctest.patch('asyncio.create_subprocess_exec',
-                                 lambda *args: self.mock_coroutine(proc_mock,
-                                                                   *args)):
+        with unittest.mock.patch('asyncio.create_subprocess_exec') as proc_mock:
             with unittest.mock.patch.object(self.launcher,
                                             'common_guid_args', lambda vm: []):
                 loop.run_until_complete(self.launcher.start_gui_for_stubdomain(


### PR DESCRIPTION
asynctest doesn't work with Python 3.8+, but AsyncMock() and few other
parts are available in the standard library already.

See Martiusweb/asynctest#144 and Martiusweb/asynctest#126