### PR TITLE
Do not crash on unexpected output from xrandr

### DIFF
--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -24,6 +24,7 @@ import os
 import signal
 import subprocess
 import asyncio
+import logging
 import re
 import functools
 import sys
@@ -278,7 +279,11 @@ def get_monitor_layout():
             ['xrandr', '-q'], stdout=subprocess.PIPE).stdout:
         line = line.decode()
         if not line.startswith("Screen") and not line.startswith(" "):
-            output_params = REGEX_OUTPUT.match(line).groupdict()
+            match = REGEX_OUTPUT.match(line)
+            if not match:
+                logging.warning('Invalid output from xrandr: %r', line)
+                continue
+            output_params = match.groupdict()
             if output_params['width']:
                 phys_size = ""
                 if output_params['width_mm'] and int(output_params['width_mm']):


### PR DESCRIPTION
If xrandr prints something unexpected, it is better to ignore the
unexpected output than to crash.  In the future, we should use XCB
instead of the xrandr command-line tool, but this is a much quicker
improvement.

This was reported in https://github.com/QubesOS/qubes-issues/issues/4729#issuecomment-588787114.