### PR TITLE
Use fcntl locking for the PID file

### DIFF
--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -23,6 +23,7 @@
 import os
 import signal
 import subprocess
+import fcntl
 import asyncio
 import re
 import functools
@@ -30,7 +31,6 @@ import sys
 import xcffib
 import xcffib.xproto  # pylint: disable=unused-import
 
-import daemon.pidfile
 import qubesadmin
 import qubesadmin.events
 import qubesadmin.exc
@@ -750,7 +750,24 @@ def main(args=None):
         kde=args.kde)
 
     if args.watch:
-        with daemon.pidfile.TimeoutPIDLockFile(args.pidfile):
+        fd = os.open(args.pidfile,
+                     os.O_RDWR | os.O_CREAT | os.O_CLOEXEC,
+                     0o600)
+        with os.fdopen(fd, 'r+') as lock_f:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                try:
+                    pid = int(lock_f.read().strip())
+                except ValueError:
+                    pid = 'unknown'
+                print('Another GUI daemon process (with PID {}) is already '
+                      'running'.format(pid),
+                      file=sys.stderr)
+                sys.exit(1)
+            print(os.getpid(), file=lock_f)
+            lock_f.flush()
+            lock_f.truncate()
             loop = asyncio.get_event_loop()
             # pylint: disable=no-member
             events = qubesadmin.events.EventsDispatcher(args.app)


### PR DESCRIPTION
This handles the case where qvm-start-daemon gets killed and leaves a
stale PID file.  Previously, qvm-start-daemon would refuse to start.
Now, it successfully locks the file and starts normally.

Fixes QubesOS/qubes-issues#6780.