### PR TITLE
Two small fixes: qvm-shutdown improvement and TestVM improvement

### DIFF
--- a/qubesadmin/tests/__init__.py
+++ b/qubesadmin/tests/__init__.py
@@ -37,6 +37,9 @@ class TestVM(object):
     def get_power_state(self):
         return getattr(self, 'power_state', 'Running')
 
+    def is_networked(self):
+        return bool(getattr(self, 'netvm', False))
+
     def __str__(self):
         return self.name
 
@@ -49,6 +52,8 @@ class TestVM(object):
 class TestVMCollection(dict):
     def __iter__(self):
         return iter(self.values())
+
+    get_blind = dict.get
 
 
 class TestProcess(object):

--- a/qubesadmin/tools/qvm_shutdown.py
+++ b/qubesadmin/tools/qvm_shutdown.py
@@ -72,7 +72,7 @@ def main(args=None, app=None):  # pylint: disable=missing-docstring
         for vm in this_round_domains:
             try:
                 vm.shutdown(force=force)
-            except qubesadmin.exc.QubesVMNotRunningError:
+            except qubesadmin.exc.QubesVMNotStartedError:
                 pass
             except qubesadmin.exc.QubesException as e:
                 if not args.wait:


### PR DESCRIPTION
* Fix too-narrow exception caught in qvm_shutdown

Instead of QubesVMNotStartedError, QubesVMNotRunningError
(which is a subclass) was being caught, which led to
unintended error raised on shutting down an
already-shut down VM.

* Improve TestVM and TestVMCollection capabilities

Added an is_network method to TestVM and get_blind
to TestVMCollection.

