### PR TITLE
Fix fallout from qvm-appmenus --force-root

### DIFF
--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -462,7 +462,22 @@ class QubesBase(qubesadmin.base.PropertyHolder):
                 appmenus_cmd = \
                     ['qvm-appmenus', '--init', '--update',
                      '--source', src_vm.name, dst_vm.name]
-                subprocess.check_output(appmenus_cmd, stderr=subprocess.STDOUT)
+                runas = []
+                if os.getuid() == 0:
+                    try:
+                        user = self.domains[self.local_name].default_user
+                    except (KeyError, qubesadmin.exc.QubesException):
+                        try:
+                            user = grp.getgrnam('qubes').gr_mem[0]
+                        except KeyError:
+                            user = None
+                    if not user:
+                        raise qubesadmin.exc.QubesException(
+                            'Failed to find local user account')
+                    runas = ['runuser', '-u', user, '--']
+
+                subprocess.check_output(runas + appmenus_cmd,
+                    stderr=subprocess.STDOUT)
             except OSError as e:
                 # this file needs to be python 2.7 compatible,
                 # so no FileNotFoundError
@@ -473,6 +488,11 @@ class QubesBase(qubesadmin.base.PropertyHolder):
             except subprocess.CalledProcessError as e:
                 self.log.error('Failed to clone appmenus: %s',
                                e.output.decode())
+                if not ignore_errors:
+                    raise qubesadmin.exc.QubesException(
+                        'Failed to clone appmenus') from e
+            except qubesadmin.exc.QubesException as e:
+                self.log.error('Failed to clone appmenus: %s', e)
                 if not ignore_errors:
                     raise qubesadmin.exc.QubesException(
                         'Failed to clone appmenus') from e

--- a/qubesadmin/backup/restore.py
+++ b/qubesadmin/backup/restore.py
@@ -1859,11 +1859,13 @@ class BackupRestore(object):
     def _handle_appmenus_list(self, vm, stream):
         '''Handle whitelisted-appmenus.list file'''
         try:
-            subprocess.check_call(
-                ['qvm-appmenus', '--set-whitelist=-', vm.name],
-                stdin=stream)
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            self.log.error('Failed to set application list for %s', vm.name)
+            appmenus_list = stream.read().decode('ascii').splitlines()
+            # remove empty lines
+            appmenus_list = [l for l in appmenus_list if l]
+            vm.features['menu-items'] = ' '.join(appmenus_list)
+        except QubesException as e:
+            self.log.error(
+                'Failed to set application list for %s: %s', vm.name, e)
 
     def _handle_volume_data(self, vm, volume, stream):
         '''Wrap volume data import with logging'''


### PR DESCRIPTION
qvm-appmenus now refuses to run as root by default, for a good reason.
Run it as a normal user whenever possible. Or, if just menu entries list
is to be set, do it directly by setting 'menu-items' feature.

QubesOS/qubes-issues#6888