### PR TITLE
Support setting ephemeral_volatile volume

### DIFF
--- a/doc/manpages/qvm-pool.rst
+++ b/doc/manpages/qvm-pool.rst
@@ -127,6 +127,13 @@ Create a pool backed by the `file` driver.
 
     qvm-pool add foo file -o dir_path=/mnt/foo
 
+Have pool ``lvm`` encrypt its volatile volumes with an ephemeral key for
+anti-forensics:
+
+::
+
+    qvm-pool set -o encrypted_volatile=True lvm
+
 Authors
 -------
 | Bahtiar \`kalkin-\` Gadimov <bahtiar at gadimov dot de>

--- a/qubesadmin/storage.py
+++ b/qubesadmin/storage.py
@@ -407,6 +407,22 @@ class Pool(object):
         self._config = None
 
     @property
+    def ephemeral_volatile(self):
+        """Whether volatile volumes in this pool should be encrypted with an
+           ephemeral key in dom0"""
+        return bool(self.config['ephemeral_volatile'])
+
+    @ephemeral_volatile.setter
+    def ephemeral_volatile(self, value):
+        """Set ephemeral_volatile property"""
+        self.app.qubesd_call(
+            'dom0',
+            'admin.pool.Set.ephemeral_volatile',
+            self.name,
+            str(value).encode('ascii'))
+        self._config = None
+
+    @property
     def volumes(self):
         """ Volumes managed by this pool """
         try:

--- a/qubesadmin/tests/tools/qvm_pool.py
+++ b/qubesadmin/tests/tools/qvm_pool.py
@@ -121,9 +121,19 @@ class TC_00_qvm_pool(qubesadmin.tests.QubesTestCase):
         self.app.expected_calls[
             ('dom0', 'admin.pool.Set.revisions_to_keep', 'pool-lvm', b'2')] = \
             b'0\x00'
+        self.app.expected_calls[(
+            'dom0',
+            'admin.pool.Set.ephemeral_volatile',
+            'pool-lvm',
+            b'True',
+        )] = b'0\x00'
         self.assertEqual(0,
             qubesadmin.tools.qvm_pool.main(['set', 'pool-lvm', '-o',
                 'revisions_to_keep=2'],
+                app=self.app))
+        self.assertEqual(0,
+            qubesadmin.tools.qvm_pool.main(['set', 'pool-lvm', '-o',
+                'ephemeral_volatile=True'],
                 app=self.app))
         self.assertAllCalled()
 


### PR DESCRIPTION
This is necessary for ephemeral_volatile volumes to be configured via the Qubes tools.