### PR TITLE
Avoid inheriting from multiple builtin exceptions

### DIFF
--- a/qubesadmin/exc.py
+++ b/qubesadmin/exc.py
@@ -149,7 +149,7 @@ class StoragePoolException(QubesException):
     ''' A general storage exception '''
 
 
-class QubesDaemonCommunicationError(QubesException, IOError):
+class QubesDaemonCommunicationError(QubesException):
     '''Error while communicating with qubesd, may mean insufficient
     permissions as well'''
 


### PR DESCRIPTION
Python 3.10 breaks inheriting from both IOError and AttributeError at
the same time. Python developers decided this is not supposed to work:
https://bugs.python.org/issue45464

QubesOS/qubes-issues#6969