### PR TITLE
Require new enough qubes-core-dom0

### DIFF
--- a/rpm_spec/qubes-core-admin-client.spec.in
+++ b/rpm_spec/qubes-core-admin-client.spec.in
@@ -33,7 +33,7 @@ Requires:   python%{python3_pkgversion}-daemon
 Requires:   python%{python3_pkgversion}-docutils
 Requires:   python%{python3_pkgversion}-lxml
 Requires:   python%{python3_pkgversion}-xcffib
-Conflicts:  qubes-core-dom0 < 4.1.12
+Conflicts:  qubes-core-dom0 <= 4.1.22
 Conflicts:  qubes-manager < 4.0.6
 
 %description -n python%{python3_pkgversion}-qubesadmin


### PR DESCRIPTION
Otherwise trying set the ‘ephemeral_volatile’ property of a pool fails
with a confusing error.  This needs testing to ensure that it will not
cause an older ‘qubes-core-dom0’ to be removed, which would be
disastrous.

Fixes QubesOS/qubes-issues#6995.