### PR TITLE
qvm-start-daemon: update initial keyboard layout

### DIFF
--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -793,6 +793,7 @@ def main(args=None):
             x_fd = conn.get_file_descriptor()
             loop.add_reader(x_fd, x_watcher.event_reader,
                             events_listener.cancel)
+            x_watcher.update_keyboard_layout()
 
             try:
                 loop.run_until_complete(events_listener)


### PR DESCRIPTION
Announce keyboard layout on initial startup too, not only on a config
change. This way the layout set initially during installation will be
propagated to the VMs too.

Fixes QubesOS/qubes-issues#6814