### PR TITLE
fix stubdomain gui starting when 'gui' is empty

### DIFF
--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -601,7 +601,8 @@ class DAEMONLauncher:
         try:
             if getattr(vm, 'guivm', None) != vm.app.local_name:
                 return
-            if not vm.features.check_with_template('gui', True):
+            if not vm.features.check_with_template('gui', True) and \
+                    not vm.features.check_with_template('gui-emulated', True):
                 return
             if vm.virt_mode == 'hvm' and \
                     kwargs.get('start_guid', 'True') == 'True':


### PR DESCRIPTION
'gui' feature advertised with ~None~ empty which is None, but 'not None' is True here

This fixes QubesOS/qubes-issues#5739