### PR TITLE
set default value for features.get to None

### DIFF
--- a/qubesadmin/features.py
+++ b/qubesadmin/features.py
@@ -66,24 +66,24 @@ class Features(object):
         for key in self:
             yield key, self[key]
 
-    _NO_DEFAULT = object()
+    NO_DEFAULT = object()
 
-    def get(self, item, default=_NO_DEFAULT):
+    def get(self, item, default=None):
         '''Get a feature, return default value if missing.'''
         try:
             return self[item]
         except KeyError:
-            if default is self._NO_DEFAULT:
+            if default is self.NO_DEFAULT:
                 raise
             return default
 
-    def check_with_template(self, feature, default=_NO_DEFAULT):
+    def check_with_template(self, feature, default=None):
         ''' Check if the vm's template has the specified feature. '''
         try:
             qubesd_response = self.vm.qubesd_call(
                 self.vm.name, 'admin.vm.feature.CheckWithTemplate', feature)
             return qubesd_response.decode('utf-8')
         except KeyError:
-            if default is self._NO_DEFAULT:
+            if default is self.NO_DEFAULT:
                 raise
             return default

--- a/qubesadmin/tests/features.py
+++ b/qubesadmin/tests/features.py
@@ -59,7 +59,7 @@ class TC_00_Features(qubesadmin.tests.QubesTestCase):
             ('test-vm', 'admin.vm.feature.Get', 'feature1', None)] = \
             b'2\x00QubesFeatureNotFoundError\x00\x00feature1\x00'
         with self.assertRaises(KeyError):
-            self.vm.features.get('feature1')
+            self.vm.features.get('feature1', self.vm.features.NO_DEFAULT)
         self.assertAllCalled()
 
     def test_013_get_default(self):


### PR DESCRIPTION
Reason: behave like a typical dictionary

fixes QubesOS/qubes-issues#7068