### PR TITLE
Update list action details

### DIFF
--- a/doc/manpages/qvm-firewall.rst
+++ b/doc/manpages/qvm-firewall.rst
@@ -10,7 +10,7 @@ Synopsis
 
 :command:`qvm-firewall` [-h] [--verbose] [--quiet] [--reload] *VMNAME* del [--rule-no=*RULE_NUMBER*] [*RULE*]
 
-:command:`qvm-firewall` [-h] [--verbose] [--quiet] [--reload] *VMNAME* list [--raw]
+:command:`qvm-firewall` [-h] [--verbose] [--quiet] [--reload] [--raw] *VMNAME* list
 
 :command:`qvm-firewall` [-h] [--verbose] [--quiet] [--reload] *VMNAME* reset
 
@@ -35,7 +35,7 @@ Options
 
 .. option:: --raw
 
-   in combination with :option:`--list`, print raw rules
+   in combination with `list` action, print raw rules
 
 
 Actions description


### PR DESCRIPTION
Hi :wave:,

**OS**: `qubes-release-4.0-10`
**tool**: `qvm-firewall`'s manual

In the `SYNOPSIS` section the list action has an optional `--raw` flag after it, which doesn't get recognized when run in that order. Although this way breaks the text alignment it might save others a few minutes before figuring out the correct order. Further, the `OPTIONS` section reads: `--raw in combination with --list, print raw rules`
Yet when run it throws `error: unrecognized arguments: --list`

Cheers,