### PR TITLE
qvm-template: use rpm2archive instead of rpm2cpio

### DIFF
--- a/qubesadmin/tests/tools/qvm_template.py
+++ b/qubesadmin/tests/tools/qvm_template.py
@@ -145,13 +145,15 @@ class TC_00_qvm_template(qubesadmin.tests.QubesTestCase):
                 'test-vm', path, dirpath)
         self.assertEqual(ret, True)
         self.assertEqual(mock_popen.mock_calls, [
-            mock.call(['rpm2cpio', path], stdout=subprocess.PIPE),
+            mock.call(['rpm2archive', '-'],
+                stdin=mock.ANY,
+                stdout=subprocess.PIPE),
             mock.call([
-                    'cpio',
-                    '-idm',
-                    '-D',
+                    'tar',
+                    'xz',
+                    '-C',
                     dirpath,
-                    './var/lib/qubes/vm-templates/test-vm/*'
+                    './var/lib/qubes/vm-templates/test-vm/'
                 ], stdin=pipe, stdout=subprocess.DEVNULL),
             mock.call().wait(),
             mock.call().wait()
@@ -171,13 +173,15 @@ class TC_00_qvm_template(qubesadmin.tests.QubesTestCase):
                 'test-vm', path, dirpath)
         self.assertEqual(ret, False)
         self.assertEqual(mock_popen.mock_calls, [
-            mock.call(['rpm2cpio', path], stdout=subprocess.PIPE),
+            mock.call(['rpm2archive', '-'],
+                stdin=mock.ANY,
+                stdout=subprocess.PIPE),
             mock.call([
-                    'cpio',
-                    '-idm',
-                    '-D',
+                    'tar',
+                    'xz',
+                    '-C',
                     dirpath,
-                    './var/lib/qubes/vm-templates/test-vm/*'
+                    './var/lib/qubes/vm-templates/test-vm/'
                 ], stdin=pipe, stdout=subprocess.DEVNULL),
             mock.call().wait()
         ])

--- a/qubesadmin/tools/qvm_template.py
+++ b/qubesadmin/tools/qvm_template.py
@@ -673,16 +673,19 @@ def extract_rpm(name: str, path: str, target: str) -> bool:
 
     :return: Whether the extraction succeeded
     """
-    rpm2cpio = subprocess.Popen(['rpm2cpio', path], stdout=subprocess.PIPE)
+    with open(path, 'rb') as pkg_f:
+        rpm2cpio = subprocess.Popen(['rpm2archive', "-"],
+            stdin=pkg_f,
+            stdout=subprocess.PIPE)
     # `-D` is GNUism
-    cpio = subprocess.Popen([
-            'cpio',
-            '-idm',
-            '-D',
+    tar = subprocess.Popen([
+            'tar',
+            'xz',
+            '-C',
             target,
-            '.%s/%s/*' % (PATH_PREFIX, name)
+            '.%s/%s/' % (PATH_PREFIX, name)
         ], stdin=rpm2cpio.stdout, stdout=subprocess.DEVNULL)
-    return rpm2cpio.wait() == 0 and cpio.wait() == 0
+    return rpm2cpio.wait() == 0 and tar.wait() == 0
 
 
 def filter_version(


### PR DESCRIPTION
The rpm2archive _does_ support writing to a pipe, not only to a file, so
it can be used here. rpm2archive deals better with various rpm formats
(especially with tar payload), but more importantly, does not rely on
LONGARCHIVESIZE tag that is zeroed by rpmcanon.

Fun fact: rpm2cpio worked on Fedora with rpmcanon only because Fedora
has a rpm2cpio patches to weaken payload size check.

QubesOS/qubes-issues#7080