### PR TITLE
qvm-run: Add command block to example commands

### DIFF
--- a/doc/manpages/qvm-run.rst
+++ b/doc/manpages/qvm-run.rst
@@ -16,14 +16,14 @@ Execution mode
 When executing a command, it is recommended to pass the arguments directly to
 `qvm-run`, for example:
 
-    qvm-run --pass-io personal -- ls -a
+    ``qvm-run --pass-io personal -- ls -a``
 
 (Note the `--` used to ensure that `-a` is not treated as option of `qvm-run`).
 
 If no arguments are specified, *COMMAND* will be interpreted as a shell
 command, for example:
 
-    qvm-run --pass-io personal 'ls -a'
+    ``qvm-run --pass-io personal 'ls -a'``
 
 This is more flexible but also less safe, because care must be taken to quote
 or escape special characters. Use the :option:`--no-shell` option to ensure


### PR DESCRIPTION
Makes it so the online Sphinx docs don't change them to en-dashes by mistake, e.g. https://dev.qubes-os.org/projects/core-admin-client/en/stable/manpages/qvm-run.html

I didn't see a coding style convention, so I thought it would be appropriate to add this to help fix the web docs.

Additionally, I have a question. I wasn't able to get the first example command working with `--` (the second one works fine). I am on Qubes R4.0.4. I have tried a couple of variations of the `ls` command provided. Any suggestions?

In my terminal in dom0, I get:
```bash
$ qvm-run --pass-io personal -- ls -a
usage: qvm-run [--verbose] [--quiet] [--help] [--user USER] [--autostart]
...
qvm-run: error: unrecognized arguments: -a
```
I have also tried:
`$ qvm-run --pass-io personal ls -- -a`: `qvm-run: error: unrecognized arguments: -a`
`$ qvm-run --pass-io personal -- ls -- -a`: `qvm-run: error: unrecognized arguments: -- -a`

However, `qvm-run --pass-io personal -- ls` works.

[I read about the double-dash online and it seems to depend on the command being run. It seems this isn't a problem for `ls` though.](https://serverfault.com/a/388035)