### PR TITLE
qvm-template: fix parsing enablerepo/disablerepo/repoid

### DIFF
--- a/qubesadmin/tools/qvm_template.py
+++ b/qubesadmin/tools/qvm_template.py
@@ -1526,22 +1526,18 @@ def repolist(args: argparse.Namespace, app: qubesadmin.app.QubesBase) -> None:
         base.read_all_repos()
 
         # Filter (name, operation) from args.repos
-        enable_repos = []
-        disable_repos = []
         repoid = []
+        enable_disable_repos = []
         repos: typing.List[dnf.repo.Repo] = []
         if args.repos:
             for repo in args.repos:
                 name, operation = repo
                 if operation == "repoid":
                     repoid.append(name)
-                elif operation == "enablerepo":
-                    enable_repos.append(name)
-                elif operation == "disablerepo":
-                    disable_repos.append(name)
-
+                elif operation in ("enablerepo", "disablerepo"):
+                    enable_disable_repos.append(name)
             if repoid:
-                if enable_repos or disable_repos:
+                if enable_disable_repos:
                     print("Warning: Ignoring --enablerepo and --disablerepo "
                           "options.", file=sys.stderr)
                 base.repos.get_matching('*').disable()
@@ -1550,14 +1546,16 @@ def repolist(args: argparse.Namespace, app: qubesadmin.app.QubesBase) -> None:
                     dnf_repo.enable()
                     repos += list(dnf_repo)
             else:
-                for repo in enable_repos:
-                    dnf_repo = base.repos.get_matching(repo)
-                    dnf_repo.enable()
-                    repos += list(dnf_repo)
-                for repo in disable_repos:
-                    dnf_repo = base.repos.get_matching(repo)
-                    dnf_repo.disable()
-                    repos += list(dnf_repo)
+                for repo in enable_disable_repos:
+                    name, operation = repo
+                    if operation == "enablerepo":
+                        dnf_repo = base.repos.get_matching(repo)
+                        dnf_repo.enable()
+                        repos += list(dnf_repo)
+                    elif operation == "disablerepo":
+                        dnf_repo = base.repos.get_matching(repo)
+                        dnf_repo.disable()
+                        repos += list(dnf_repo)
             repos = list(set(repos))
         else:
             repos = list(base.repos.values())

--- a/qubesadmin/tools/qvm_template.py
+++ b/qubesadmin/tools/qvm_template.py
@@ -42,9 +42,6 @@ import tqdm
 import xdg.BaseDirectory
 import rpm
 
-import dnf.repo
-import dnf.conf
-
 import qubesadmin
 import qubesadmin.vm
 import qubesadmin.utils
@@ -1518,11 +1515,13 @@ def repolist(args: argparse.Namespace, app: qubesadmin.app.QubesBase) -> None:
     """
     _ = app  # unused
 
-    # python-dnf is not packaged on Debian
-    # As this is not an "essential operation", the module is imported here
-    # instead of top-level so that other operations still work.
+    # Even if python3-dnf is now available on Debian 11+, this is not
+    # an "essential operation" so the module is imported here
+    # instead of top-level. Any other operation still work in case where
+    # a failure occurs with python3-dnf.
     try:
-        import dnf
+        import dnf.repo
+        import dnf.conf
     except ModuleNotFoundError:
         print("Error: Python module 'dnf' not found.", file=sys.stderr)
         sys.exit(1)

--- a/qubesadmin/tools/qvm_template.py
+++ b/qubesadmin/tools/qvm_template.py
@@ -103,7 +103,7 @@ class RepoOptCallback(argparse.Action):
     def __call__(self, parser_arg, namespace, values, option_string=None):
         operation = option_string.lstrip('-')
         repo_actions = getattr(namespace, self.dest)
-        repo_actions.append((values, operation))
+        repo_actions.append((operation, values))
 
 
 def get_parser() -> argparse.ArgumentParser:
@@ -1531,7 +1531,7 @@ def repolist(args: argparse.Namespace, app: qubesadmin.app.QubesBase) -> None:
         repos: typing.List[dnf.repo.Repo] = []
         if args.repos:
             for repo in args.repos:
-                name, operation = repo
+                operation, name = repo
                 if operation == "repoid":
                     repoid.append(name)
                 elif operation in ("enablerepo", "disablerepo"):
@@ -1547,7 +1547,7 @@ def repolist(args: argparse.Namespace, app: qubesadmin.app.QubesBase) -> None:
                     repos += list(dnf_repo)
             else:
                 for repo in enable_disable_repos:
-                    name, operation = repo
+                    operation, name = repo
                     if operation == "enablerepo":
                         dnf_repo = base.repos.get_matching(repo)
                         dnf_repo.enable()


### PR DESCRIPTION
The 8304507 commit stores list of (repoid, option) on the list, but on 
place expected those two in the other order. Adjust accordingly.

Fixes: 8304507 qvm-template: preserve order of --enablerepo/--disablerepo/--repoid
Fixes QubesOS/qubes-issues#7170