### PR TITLE
qvm-template: load all repo files from /etc/qubes/repo-templates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ checks:tests:
     - python3 setup.py build
     - ./run-tests
   after_script:
-    - PATH=$PATH:$HOME/.local/bin codecov
+    - ci/codecov-wrapper
 
 checks:pylint:
   stage: checks

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,4 +26,4 @@ checks:pylint:
     - sudo dnf install -y python3-rpm
     - pip3 install --quiet -r ci/requirements.txt
   script:
-    - PYTHONPATH=test-packages pylint --extension-pkg-whitelist=rpm qubesadmin
+    - PYTHONPATH=test-packages pylint --extension-pkg-whitelist=rpm,lxml qubesadmin

--- a/ci/codecov-wrapper
+++ b/ci/codecov-wrapper
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+PATH="$PATH:$HOME/.local/bin"
+
+set -x
+
+if [[ "$CI_COMMIT_BRANCH" =~ ^pr- ]]; then
+    PR=${CI_COMMIT_BRANCH#pr-}
+    parents=$(git show -s --format='%P %ae')
+    if [ $(wc -w <<<"$parents") -eq 3 ] && [ "${parents##* }" = "fepitre-bot@qubes-os.org" ]; then
+        commit_sha=$(cut -f 2 -d ' ' <<<"${parents}")
+    else
+        commit_sha=$(git show -s --format='%H')
+    fi
+    exec codecov --pr "$PR" --commit "$commit_sha" "$@"
+fi
+exec codecov "$@"

--- a/qubesadmin/tests/app.py
+++ b/qubesadmin/tests/app.py
@@ -955,9 +955,10 @@ class TC_20_QubesLocal(unittest.TestCase):
 class TC_30_QubesRemote(unittest.TestCase):
     def setUp(self):
         super(TC_30_QubesRemote, self).setUp()
-        self.proc_mock = mock.Mock()
+        self.proc_mock = mock.MagicMock()
         self.proc_mock.configure_mock(**{
-            'return_value.returncode': 0
+            'return_value.returncode': 0,
+            'return_value.__enter__.return_value': self.proc_mock.return_value,
         })
         self.proc_patch = mock.patch('subprocess.Popen', self.proc_mock)
         self.proc_patch.start()
@@ -980,7 +981,9 @@ class TC_30_QubesRemote(unittest.TestCase):
                 'some.method+arg1'],
                 stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE),
-            mock.call().communicate(b'payload')
+            mock.call().__enter__(),
+            mock.call().communicate(b'payload'),
+            mock.call().__exit__(None, None, None),
         ])
 
     def test_001_qubesd_call_none_arg(self):
@@ -991,7 +994,9 @@ class TC_30_QubesRemote(unittest.TestCase):
                 'some.method'],
                 stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE),
-            mock.call().communicate(b'payload')
+            mock.call().__enter__(),
+            mock.call().communicate(b'payload'),
+            mock.call().__exit__(None, None, None),
         ])
 
     def test_002_qubesd_call_none_payload(self):
@@ -1002,7 +1007,9 @@ class TC_30_QubesRemote(unittest.TestCase):
                 'some.method'],
                 stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE),
-            mock.call().communicate(None)
+            mock.call().__enter__(),
+            mock.call().communicate(None),
+            mock.call().__exit__(None, None, None),
         ])
 
     def test_003_qubesd_call_payload_stream(self):
@@ -1024,7 +1031,9 @@ class TC_30_QubesRemote(unittest.TestCase):
                 stdin=payload_file,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE),
-            mock.call().communicate()
+            mock.call().__enter__(),
+            mock.call().communicate(),
+            mock.call().__exit__(None, None, None),
         ])
         self.assertEqual(value, b'return-value')
 
@@ -1045,9 +1054,11 @@ class TC_30_QubesRemote(unittest.TestCase):
                 'some.method+some-arg'],
                 stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE),
+            mock.call().__enter__(),
             mock.call().stdin.write(b'first line\n'),
             mock.call().stdin.write(b'some payload\n'),
-            mock.call().communicate()
+            mock.call().communicate(),
+            mock.call().__exit__(None, None, None),
         ])
         self.assertEqual(value, b'return-value')
 
@@ -1092,7 +1103,9 @@ class TC_30_QubesRemote(unittest.TestCase):
                   'some-vm', 'admin.vm.CurrentState'],
                  stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                  stderr=subprocess.PIPE),
+            call().__enter__(),
             call().communicate(None),
+            call().__exit__(None, None, None),
             call([qubesadmin.config.QREXEC_CLIENT_VM,
                   '-T', 'some-vm', 'service.name'],
                  stdin=subprocess.PIPE, stdout=subprocess.PIPE,

--- a/qubesadmin/tests/tools/qvm_start_daemon.py
+++ b/qubesadmin/tests/tools/qvm_start_daemon.py
@@ -466,6 +466,7 @@ global: {
 
     @unittest.mock.patch('subprocess.Popen')
     def test_050_get_monitor_layout1(self, proc_mock):
+        proc_mock().__enter__.return_value = proc_mock()
         proc_mock().stdout = b'''Screen 0: minimum 8 x 8, current 1920 x 1200, maximum 32767 x 32767
 HDMI1 connected 1920x1200+0+0 (normal left inverted right x axis y axis) 518mm x 324mm
    1920x1200     59.95*+
@@ -492,6 +493,7 @@ VIRTUAL1 disconnected (normal left inverted right x axis y axis)
 
     @unittest.mock.patch('subprocess.Popen')
     def test_051_get_monitor_layout_multiple(self, proc_mock):
+        proc_mock().__enter__.return_value = proc_mock()
         proc_mock().stdout = b'''Screen 0: minimum 8 x 8, current 2880 x 1024, maximum 32767 x 32767
 LVDS1 connected 1600x900+0+0 (normal left inverted right x axis y axis)
 VGA1 connected 1280x1024+1600+0 (normal left inverted right x axis y axis)
@@ -501,6 +503,7 @@ VGA1 connected 1280x1024+1600+0 (normal left inverted right x axis y axis)
 
     @unittest.mock.patch('subprocess.Popen')
     def test_052_get_monitor_layout_hidpi1(self, proc_mock):
+        proc_mock().__enter__.return_value = proc_mock()
         proc_mock().stdout = b'''Screen 0: minimum 8 x 8, current 1920 x 1200, maximum 32767 x 32767
 HDMI1 connected 2560x1920+0+0 (normal left inverted right x axis y axis) 372mm x 208mm
    1920x1200     60.00*+
@@ -513,6 +516,7 @@ HDMI1 connected 2560x1920+0+0 (normal left inverted right x axis y axis) 372mm x
 
     @unittest.mock.patch('subprocess.Popen')
     def test_052_get_monitor_layout_hidpi2(self, proc_mock):
+        proc_mock().__enter__.return_value = proc_mock()
         proc_mock().stdout = b'''Screen 0: minimum 8 x 8, current 1920 x 1200, maximum 32767 x 32767
 HDMI1 connected 2560x1920+0+0 (normal left inverted right x axis y axis) 310mm x 174mm
    1920x1200     60.00*+
@@ -525,6 +529,7 @@ HDMI1 connected 2560x1920+0+0 (normal left inverted right x axis y axis) 310mm x
 
     @unittest.mock.patch('subprocess.Popen')
     def test_052_get_monitor_layout_hidpi3(self, proc_mock):
+        proc_mock().__enter__.return_value = proc_mock()
         proc_mock().stdout = b'''Screen 0: minimum 8 x 8, current 1920 x 1200, maximum 32767 x 32767
 HDMI1 connected 2560x1920+0+0 (normal left inverted right x axis y axis) 206mm x 116mm
    1920x1200     60.00*+

--- a/qubesadmin/tests/tools/qvm_template.py
+++ b/qubesadmin/tests/tools/qvm_template.py
@@ -198,9 +198,11 @@ class TC_00_qvm_template(qubesadmin.tests.QubesTestCase):
 
     @mock.patch('subprocess.Popen')
     def test_010_extract_rpm_success(self, mock_popen):
+        mock_popen.return_value.__enter__.return_value = mock_popen.return_value
         pipe = mock.Mock()
         mock_popen.return_value.stdout = pipe
         mock_popen.return_value.wait.return_value = 0
+        mock_popen.return_value.returncode = 0
         with tempfile.NamedTemporaryFile() as fd, \
                 tempfile.TemporaryDirectory() as dir:
             path = fd.name
@@ -212,6 +214,7 @@ class TC_00_qvm_template(qubesadmin.tests.QubesTestCase):
             mock.call(['rpm2archive', '-'],
                 stdin=mock.ANY,
                 stdout=subprocess.PIPE),
+            mock.call().__enter__(),
             mock.call([
                     'tar',
                     'xz',
@@ -219,16 +222,18 @@ class TC_00_qvm_template(qubesadmin.tests.QubesTestCase):
                     dirpath,
                     './var/lib/qubes/vm-templates/test-vm/'
                 ], stdin=pipe, stdout=subprocess.DEVNULL),
-            mock.call().wait(),
-            mock.call().wait()
+            mock.call().__enter__(),
+            mock.call().__exit__(None, None, None),
+            mock.call().__exit__(None, None, None),
         ])
         self.assertAllCalled()
 
     @mock.patch('subprocess.Popen')
     def test_011_extract_rpm_fail(self, mock_popen):
+        mock_popen.return_value.__enter__.return_value = mock_popen.return_value
         pipe = mock.Mock()
         mock_popen.return_value.stdout = pipe
-        mock_popen.return_value.wait.return_value = 1
+        mock_popen.return_value.returncode = 1
         with tempfile.NamedTemporaryFile() as fd, \
                 tempfile.TemporaryDirectory() as dir:
             path = fd.name
@@ -240,6 +245,7 @@ class TC_00_qvm_template(qubesadmin.tests.QubesTestCase):
             mock.call(['rpm2archive', '-'],
                 stdin=mock.ANY,
                 stdout=subprocess.PIPE),
+            mock.call().__enter__(),
             mock.call([
                     'tar',
                     'xz',
@@ -247,7 +253,9 @@ class TC_00_qvm_template(qubesadmin.tests.QubesTestCase):
                     dirpath,
                     './var/lib/qubes/vm-templates/test-vm/'
                 ], stdin=pipe, stdout=subprocess.DEVNULL),
-            mock.call().wait()
+            mock.call().__enter__(),
+            mock.call().__exit__(None, None, None),
+            mock.call().__exit__(None, None, None),
         ])
         self.assertAllCalled()
 

--- a/qubesadmin/tools/__init__.py
+++ b/qubesadmin/tools/__init__.py
@@ -574,11 +574,11 @@ def print_table(table, stream=None):
 
     # for tests...
     if stream != sys.__stdout__:
-        p = subprocess.Popen(cmd + ['-c', '80'], stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE)
-        p.stdin.write(text_table.encode())
-        (out, _) = p.communicate()
+        with subprocess.Popen(cmd + ['-c', '80'], stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE) as p:
+            p.stdin.write(text_table.encode())
+            (out, _) = p.communicate()
         stream.write(str(out.decode()))
     else:
-        p = subprocess.Popen(cmd, stdin=subprocess.PIPE)
-        p.communicate(text_table.encode())
+        with subprocess.Popen(cmd, stdin=subprocess.PIPE) as p:
+            p.communicate(text_table.encode())

--- a/qubesadmin/tools/qvm_backup.py
+++ b/qubesadmin/tools/qvm_backup.py
@@ -177,11 +177,11 @@ def main(args=None, app=None):
 
     if args.profile is None:
         if args.passphrase_file is not None:
-            pass_f = open(args.passphrase_file) \
-                if args.passphrase_file != "-" else sys.stdin
-            passphrase = pass_f.readline().rstrip()
-            if pass_f is not sys.stdin:
-                pass_f.close()
+            if args.passphrase_file == '-':
+                passphrase = sys.stdin.readline().rstrip()
+            else:
+                with open(args.passphrase_file) as pass_f:
+                    passphrase = pass_f.readline().rstrip()
         else:
             prompt = ("Please enter the passphrase that will be used to "
                       "encrypt and verify the backup: ")

--- a/qubesadmin/tools/qvm_backup_restore.py
+++ b/qubesadmin/tools/qvm_backup_restore.py
@@ -259,10 +259,11 @@ def main(args=None, app=None):
         return
 
     if args.pass_file is not None:
-        pass_f = open(args.pass_file) if args.pass_file != "-" else sys.stdin
-        passphrase = pass_f.readline().rstrip()
-        if pass_f is not sys.stdin:
-            pass_f.close()
+        if args.pass_file == '-':
+            passphrase = sys.stdin.readline().rstrip()
+        else:
+            with open(args.pass_file) as pass_f:
+                passphrase = pass_f.readline().rstrip()
     else:
         passphrase = getpass.getpass("Please enter the passphrase to verify "
                                      "and (if encrypted) decrypt the backup: ")

--- a/qubesadmin/tools/qvm_run.py
+++ b/qubesadmin/tools/qvm_run.py
@@ -204,6 +204,7 @@ def run_command_single(args, vm):
         proc.stdin.write(vm.prepare_input_for_vmshell(shell_cmd))
         proc.stdin.flush()
     if args.localcmd:
+        # pylint: disable=consider-using-with
         local_proc = subprocess.Popen(args.localcmd,
             shell=True,
             stdout=proc.stdin,

--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -275,44 +275,45 @@ def get_monitor_layout():
     """Get list of monitors and their size/position"""
     outputs = []
 
-    for line in subprocess.Popen(
-            ['xrandr', '-q'], stdout=subprocess.PIPE).stdout:
-        line = line.decode()
-        if not line.startswith("Screen") and not line.startswith(" "):
-            match = REGEX_OUTPUT.match(line)
-            if not match:
-                logging.warning('Invalid output from xrandr: %r', line)
-                continue
-            output_params = match.groupdict()
-            if output_params['width']:
-                phys_size = ""
-                if output_params['width_mm'] and int(output_params['width_mm']):
-                    # don't provide real values for privacy reasons - see
-                    # #1951 for details
-                    dpi = (int(output_params['width']) * 254 //
-                           int(output_params['width_mm']) // 10)
-                    if dpi > 300:
-                        dpi = 300
-                    elif dpi > 200:
-                        dpi = 200
-                    elif dpi > 150:
-                        dpi = 150
-                    else:
-                        # if lower, don't provide this info to the VM at all
-                        dpi = 0
-                    if dpi:
-                        # now calculate dimensions based on approximate DPI
-                        phys_size = " {} {}".format(
-                            int(output_params['width']) * 254 // dpi // 10,
-                            int(output_params['height']) * 254 // dpi // 10,
-                        )
-                outputs.append("%s %s %s %s%s\n" % (
-                    output_params['width'],
-                    output_params['height'],
-                    output_params['x'],
-                    output_params['y'],
-                    phys_size,
-                ))
+    with subprocess.Popen(['xrandr', '-q'], stdout=subprocess.PIPE) as proc:
+        for line in proc.stdout:
+            line = line.decode()
+            if not line.startswith("Screen") and not line.startswith(" "):
+                match = REGEX_OUTPUT.match(line)
+                if not match:
+                    logging.warning('Invalid output from xrandr: %r', line)
+                    continue
+                output_params = match.groupdict()
+                if output_params['width']:
+                    phys_size = ""
+                    if output_params['width_mm'] \
+                            and int(output_params['width_mm']):
+                        # don't provide real values for privacy reasons - see
+                        # #1951 for details
+                        dpi = (int(output_params['width']) * 254 //
+                               int(output_params['width_mm']) // 10)
+                        if dpi > 300:
+                            dpi = 300
+                        elif dpi > 200:
+                            dpi = 200
+                        elif dpi > 150:
+                            dpi = 150
+                        else:
+                            # if lower, don't provide this info to the VM at all
+                            dpi = 0
+                        if dpi:
+                            # now calculate dimensions based on approximate DPI
+                            phys_size = " {} {}".format(
+                                int(output_params['width']) * 254 // dpi // 10,
+                                int(output_params['height']) * 254 // dpi // 10,
+                            )
+                    outputs.append("%s %s %s %s%s\n" % (
+                        output_params['width'],
+                        output_params['height'],
+                        output_params['x'],
+                        output_params['y'],
+                        phys_size,
+                    ))
     return outputs
 
 

--- a/qubesadmin/tools/qvm_template.py
+++ b/qubesadmin/tools/qvm_template.py
@@ -27,6 +27,7 @@ import enum
 import fcntl
 import fnmatch
 import functools
+import glob
 import itertools
 import json
 import operator
@@ -124,7 +125,7 @@ def get_parser() -> argparse.ArgumentParser:
             description=help_str)
 
     parser_main.add_argument('--repo-files', action='append',
-        default=['/etc/qubes/repo-templates/qubes-templates.repo'],
+        default=['/etc/qubes/repo-templates/*.repo'],
         help=('Specify files containing DNF repository configuration.'
             ' Can be used more than once.'))
     parser_main.add_argument('--keyring',
@@ -1591,6 +1592,10 @@ def main(args: typing.Optional[typing.Sequence[str]] = None,
     if len(p_args.repo_files) > 1:
         # ...remove the default entry
         p_args.repo_files.pop(0)
+
+    # resolve wildcards
+    p_args.repo_files = list(itertools.chain(
+        *(glob.glob(path) for path in p_args.repo_files)))
 
     if app is None:
         app = qubesadmin.Qubes()

--- a/qubesadmin/tools/qvm_volume.py
+++ b/qubesadmin/tools/qvm_volume.py
@@ -145,6 +145,7 @@ def import_volume(args):
     if input_path == '-':
         input_file = sys.stdin.buffer
     else:
+        # pylint: disable=consider-using-with
         input_file = open(input_path, 'rb')
     try:
         if args.no_resize:

--- a/qubesadmin/utils.py
+++ b/qubesadmin/utils.py
@@ -178,6 +178,7 @@ class LockFile(object):
     def __init__(self, path, nonblock=False):
         """Open the file. Call *acquire* or enter the context to lock
         the file"""
+        # pylint: disable=consider-using-with
         self.file = open(path, "w")
         self.nonblock = nonblock
 


### PR DESCRIPTION
Use *.repo glob, instead of hardcoded repo-templates.repo file name.

Fixes QubesOS/qubes-issues#7354