### PR TITLE
Fix misparsing of literal `--` by `qvm-run`

### DIFF
--- a/qubesadmin/tests/tools/qvm_run.py
+++ b/qubesadmin/tests/tools/qvm_run.py
@@ -769,7 +769,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
              'vmexec', None)] = \
             b'0\x001'
         ret = qubesadmin.tools.qvm_run.main(
-            ['--no-gui', '--dispvm', 'test-vm', 'command', '--', 'arg'],
+            ['--no-gui', '--dispvm=test-vm', 'command', '--', 'arg'],
             app=self.app)
         self.assertEqual(ret, 0)
         self.assertEqual(self.app.service_calls, [
@@ -788,7 +788,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
              'vmexec', None)] = \
             b'0\x001'
         ret = qubesadmin.tools.qvm_run.main(
-            ['--no-gui', '--dispvm', 'test-vm', 'command', '--', '--'],
+            ['--no-gui', '--dispvm=test-vm', 'command', '--', '--'],
             app=self.app)
         self.assertEqual(ret, 0)
         self.assertEqual(self.app.service_calls, [
@@ -807,7 +807,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
              'vmexec', None)] = \
             b'0\x001'
         ret = qubesadmin.tools.qvm_run.main(
-            ['--no-gui', '--dispvm', 'test-vm', '--no-shell', '--', '--'],
+            ['--no-gui', '--dispvm=test-vm', '--no-shell', '--', '--'],
             app=self.app)
         self.assertEqual(ret, 0)
         self.assertEqual(self.app.service_calls, [
@@ -817,5 +817,63 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                 'user': None,
             }),
             ('$dispvm:test-vm', 'qubes.VMExec+----', b'')
+        ])
+        self.assertAllCalled()
+
+    def test_030_no_shell_dispvm(self):
+        self.app.expected_calls[
+            ('$dispvm', 'admin.vm.feature.CheckWithTemplate',
+             'vmexec', None)] = \
+            b'0\x001'
+        ret = qubesadmin.tools.qvm_run.main(
+            ['--no-gui', '--dispvm', '--', 'test-vm', 'command', 'arg'],
+            app=self.app)
+        self.assertEqual(ret, 0)
+        self.assertEqual(self.app.service_calls, [
+            ('$dispvm', 'qubes.VMExec+test--vm+command+arg', {
+                'stdout': subprocess.DEVNULL,
+                'stderr': subprocess.DEVNULL,
+                'user': None,
+            }),
+            ('$dispvm', 'qubes.VMExec+test--vm+command+arg', b'')
+        ])
+        self.assertAllCalled()
+
+    def test_031_argparse_bug_workaround(self):
+        self.app.expected_calls[
+            ('$dispvm', 'admin.vm.feature.CheckWithTemplate',
+             'vmexec', None)] = \
+            b'0\x001'
+        ret = qubesadmin.tools.qvm_run.main(
+            ['--no-gui', '--dispvm', '--', 'test-vm', 'command', '--'],
+            app=self.app)
+        self.assertEqual(ret, 0)
+        self.assertEqual(self.app.service_calls, [
+            ('$dispvm', 'qubes.VMExec+test--vm+command+----', {
+                'stdout': subprocess.DEVNULL,
+                'stderr': subprocess.DEVNULL,
+                'user': None,
+            }),
+            ('$dispvm', 'qubes.VMExec+test--vm+command+----', b'')
+        ])
+        self.assertAllCalled()
+
+    @unittest.expectedFailure
+    def test_032_argparse_bug_workaround_unnamed_dispvm(self):
+        self.app.expected_calls[
+            ('$dispvm', 'admin.vm.feature.CheckWithTemplate',
+             'vmexec', None)] = \
+            b'0\x001'
+        ret = qubesadmin.tools.qvm_run.main(
+            ['--no-gui', '--dispvm', 'test-vm', 'command', '--'],
+            app=self.app)
+        self.assertEqual(ret, 0)
+        self.assertEqual(self.app.service_calls, [
+            ('$dispvm', 'qubes.VMExec+test--vm+command+----', {
+                'stdout': subprocess.DEVNULL,
+                'stderr': subprocess.DEVNULL,
+                'user': None,
+            }),
+            ('$dispvm', 'qubes.VMExec+test--vm+command+----', b'')
         ])
         self.assertAllCalled()

--- a/qubesadmin/tests/tools/qvm_run.py
+++ b/qubesadmin/tests/tools/qvm_run.py
@@ -643,3 +643,179 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             ('test-vm', 'qubes.VMShell', b'command; exit\n')
         ])
         self.assertAllCalled()
+
+    def test_022_no_shell(self):
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.List', None, None)] = \
+            b'0\x00test-vm class=AppVM state=Paused\n'
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.feature.CheckWithTemplate',
+             'vmexec', None)] = \
+            b'0\x001'
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.CurrentState', None, None)] = \
+            b'0\x00power_state=Running'
+        ret = qubesadmin.tools.qvm_run.main(
+            ['--no-gui', '--no-shell', 'test-vm', 'command'],
+            app=self.app)
+        self.assertEqual(ret, 0)
+        self.assertEqual(self.app.service_calls, [
+            ('test-vm', 'qubes.VMExec+command', {
+                'stdout': subprocess.DEVNULL,
+                'stderr': subprocess.DEVNULL,
+                'user': None,
+            }),
+            ('test-vm', 'qubes.VMExec+command', b'')
+        ])
+        self.assertAllCalled()
+
+    def test_023_dispvm_no_shell(self):
+        self.app.expected_calls[
+            ('$dispvm:test-vm', 'admin.vm.feature.CheckWithTemplate',
+             'vmexec', None)] = \
+            b'0\x001'
+        ret = qubesadmin.tools.qvm_run.main(
+            ['--no-gui', '--no-shell', '--dispvm=test-vm', 'command'],
+            app=self.app)
+        self.assertEqual(ret, 0)
+        self.assertEqual(self.app.service_calls, [
+            ('$dispvm:test-vm', 'qubes.VMExec+command', {
+                'stdout': subprocess.DEVNULL,
+                'stderr': subprocess.DEVNULL,
+                'user': None,
+            }),
+            ('$dispvm:test-vm', 'qubes.VMExec+command', b'')
+        ])
+        self.assertAllCalled()
+
+    def test_024_no_shell_dashdash(self):
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.List', None, None)] = \
+            b'0\x00test-vm class=AppVM state=Paused\n'
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.feature.CheckWithTemplate',
+             'vmexec', None)] = \
+            b'0\x001'
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.CurrentState', None, None)] = \
+            b'0\x00power_state=Running'
+        ret = qubesadmin.tools.qvm_run.main(
+            ['--no-gui', '--no-shell', 'test-vm', 'command', '--', 'arg'],
+            app=self.app)
+        self.assertEqual(ret, 0)
+        self.assertEqual(self.app.service_calls, [
+            ('test-vm', 'qubes.VMExec+command+arg', {
+                'stdout': subprocess.DEVNULL,
+                'stderr': subprocess.DEVNULL,
+                'user': None,
+            }),
+            ('test-vm', 'qubes.VMExec+command+arg', b'')
+        ])
+        self.assertAllCalled()
+
+    def test_025_no_shell_double_dashdash(self):
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.List', None, None)] = \
+            b'0\x00test-vm class=AppVM state=Paused\n'
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.feature.CheckWithTemplate',
+             'vmexec', None)] = \
+            b'0\x001'
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.CurrentState', None, None)] = \
+            b'0\x00power_state=Running'
+        ret = qubesadmin.tools.qvm_run.main(
+            ['--no-gui', '--no-shell', 'test-vm', 'command', '--', '--', 'arg'],
+            app=self.app)
+        self.assertEqual(ret, 0)
+        self.assertEqual(self.app.service_calls, [
+            ('test-vm', 'qubes.VMExec+command+----+arg', {
+                'stdout': subprocess.DEVNULL,
+                'stderr': subprocess.DEVNULL,
+                'user': None,
+            }),
+            ('test-vm', 'qubes.VMExec+command+----+arg', b'')
+        ])
+        self.assertAllCalled()
+
+    def test_026_no_shell_double_dashdash(self):
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.List', None, None)] = \
+            b'0\x00test-vm class=AppVM state=Paused\n'
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.feature.CheckWithTemplate',
+             'vmexec', None)] = \
+            b'0\x001'
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.CurrentState', None, None)] = \
+            b'0\x00power_state=Running'
+        ret = qubesadmin.tools.qvm_run.main(
+            ['--no-gui', '--no-shell', '--', 'test-vm', 'command', '--', 'arg'],
+            app=self.app)
+        self.assertEqual(ret, 0)
+        self.assertEqual(self.app.service_calls, [
+            ('test-vm', 'qubes.VMExec+command+----+arg', {
+                'stdout': subprocess.DEVNULL,
+                'stderr': subprocess.DEVNULL,
+                'user': None,
+            }),
+            ('test-vm', 'qubes.VMExec+command+----+arg', b'')
+        ])
+        self.assertAllCalled()
+
+    def test_027_no_shell_dispvm(self):
+        self.app.expected_calls[
+            ('$dispvm:test-vm', 'admin.vm.feature.CheckWithTemplate',
+             'vmexec', None)] = \
+            b'0\x001'
+        ret = qubesadmin.tools.qvm_run.main(
+            ['--no-gui', '--dispvm', 'test-vm', 'command', '--', 'arg'],
+            app=self.app)
+        self.assertEqual(ret, 0)
+        self.assertEqual(self.app.service_calls, [
+            ('$dispvm:test-vm', 'qubes.VMExec+command+arg', {
+                'stdout': subprocess.DEVNULL,
+                'stderr': subprocess.DEVNULL,
+                'user': None,
+            }),
+            ('$dispvm:test-vm', 'qubes.VMExec+command+arg', b'')
+        ])
+        self.assertAllCalled()
+
+    def test_028_argparse_bug_workaround(self):
+        self.app.expected_calls[
+            ('$dispvm:test-vm', 'admin.vm.feature.CheckWithTemplate',
+             'vmexec', None)] = \
+            b'0\x001'
+        ret = qubesadmin.tools.qvm_run.main(
+            ['--no-gui', '--dispvm', 'test-vm', 'command', '--', '--'],
+            app=self.app)
+        self.assertEqual(ret, 0)
+        self.assertEqual(self.app.service_calls, [
+            ('$dispvm:test-vm', 'qubes.VMExec+command+----', {
+                'stdout': subprocess.DEVNULL,
+                'stderr': subprocess.DEVNULL,
+                'user': None,
+            }),
+            ('$dispvm:test-vm', 'qubes.VMExec+command+----', b'')
+        ])
+        self.assertAllCalled()
+
+    def test_029_command_is_dashdash(self):
+        self.app.expected_calls[
+            ('$dispvm:test-vm', 'admin.vm.feature.CheckWithTemplate',
+             'vmexec', None)] = \
+            b'0\x001'
+        ret = qubesadmin.tools.qvm_run.main(
+            ['--no-gui', '--dispvm', 'test-vm', '--no-shell', '--', '--'],
+            app=self.app)
+        self.assertEqual(ret, 0)
+        self.assertEqual(self.app.service_calls, [
+            ('$dispvm:test-vm', 'qubes.VMExec+----', {
+                'stdout': subprocess.DEVNULL,
+                'stderr': subprocess.DEVNULL,
+                'user': None,
+            }),
+            ('$dispvm:test-vm', 'qubes.VMExec+----', b'')
+        ])
+        self.assertAllCalled()

--- a/qubesadmin/tools/__init__.py
+++ b/qubesadmin/tools/__init__.py
@@ -164,6 +164,8 @@ class VmNameAction(QubesAction):
                 parser.error('--exclude can only be used with --all')
 
             if self.nargs == argparse.OPTIONAL:
+                if getattr(namespace, 'dispvm', None) is not None:
+                    return
                 vm_name = getattr(namespace, self.dest, None)
                 if vm_name is not None:
                     try:


### PR DESCRIPTION
`qvm-run` misparsed a COMMAND argument that is literally `--`, causing
it to crash with an uncaught exception.  Additionally, the first `--` in
the arguments is swallowed, leading to option injection.