### PR TITLE
qvm_shutdown: add --dry-run

### DIFF
--- a/doc/manpages/qvm-shutdown.rst
+++ b/doc/manpages/qvm-shutdown.rst
@@ -46,6 +46,10 @@ Options
    force qube shutdown, regardless of whether there exist any connected domains
    (such as those using it as network VM)
 
+.. option:: --dry-run
+
+   don't really shutdown or kill the domains; useful with :option:`--wait`
+
 
 Authors
 -------


### PR DESCRIPTION
> --dry-run: don't really shutdown or kill the domains; useful with --wait

I often want to wait for a qube to shutdown, such as when I want the whole system to shutdown unattended. With this patch, it's easy:
`qvm-shutdown --dry-run --wait --timeout 999999 myqube; sudo init 0`

Furthermore, this patch corrects a minor bug that can occur when `have_events == False`, in which a DispVM may shut down and be removed within a single second, causing the loop at L112 to miss the shutdown and finish the timeout. Under prior usage, this would only be a minor issue, but it's a problem when the whole point is to wait for the shutdown.