### PR TITLE
ci: make git happy about source clone owned by a different user

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,7 @@ checks:tests:
   before_script:
     - sudo dnf install -y openssl python3-rpm
     - pip3 install --quiet -r ci/requirements.txt
+    - git config --global --add safe.directory "$PWD"
   script:
     - python3 setup.py build
     - ./run-tests


### PR DESCRIPTION
Different docker images may have different UID of gitlab-runner user.
Workaround this, to make 'git' calls in ci/codecov-wrapper happy.