### PR TITLE
Catch FileNotFoundError when download fails

### DIFF
--- a/qubesadmin/tools/qvm_template.py
+++ b/qubesadmin/tools/qvm_template.py
@@ -899,7 +899,10 @@ def download(
                     done = True
                     break
                 except ConnectionError:
-                    os.remove(target_temp)
+                    try:
+                        os.remove(target_temp)
+                    except FileNotFoundError:
+                        pass
                     if attempt + 1 < args.retries:
                         print(f"'{spec}' download failed, retrying...",
                               file=sys.stderr)


### PR DESCRIPTION
If the download fails, the target temporary file will probably not
exist.  Catch the FileNotFoundError to avoid crashing.

Fixes QubesOS/qubes-issues#7529.