### PR TITLE
Add missing GUI daemon options

### DIFF
--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -46,6 +46,7 @@ QUBES_ICON_DIR = '/usr/share/icons/hicolor/128x128/devices'
 GUI_DAEMON_OPTIONS = [
     ('allow_fullscreen', 'bool'),
     ('override_redirect_protection', 'bool'),
+    ('override_redirect', 'str'),
     ('allow_utf8_titles', 'bool'),
     ('secure_copy_sequence', 'str'),
     ('secure_paste_sequence', 'str'),


### PR DESCRIPTION
subwindows= was added in GUI daemon commit QubesOS/qubes-gui-daemon@5978391e54d99e44179b824dcaa2666e03a6e080 and override_redirect= was added in commit QubesOS/qubes-gui-daemon@cd6f30851b7654fe9543d0851ea6926f47a12480.  Allow them to be set via qvm-features.
