### PR TITLE
backup: do not fail on removing non-existing file

### DIFF
--- a/qubesadmin/backup/restore.py
+++ b/qubesadmin/backup/restore.py
@@ -1170,7 +1170,8 @@ class BackupRestore(object):
         if hasattr(p, 'pty'):
             p.pty.close()
         if p.returncode != 0:
-            os.unlink(fulloutput)
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(fulloutput)
             raise QubesException('failed to decrypt {}: {}'.format(
                 fullname, stderr))
         # encrypted file is no longer needed


### PR DESCRIPTION
When restore fails, do not clobber actual error message with an
exception about removing non-existing file. This hides the reason why
the file wasn't created.