### PR TITLE
Monitor and update keyboard layout only if the qube asked to be a guivm

### DIFF
--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -895,8 +895,15 @@ def main():
             lock_f.flush()
             lock_f.truncate()
             loop = asyncio.get_event_loop()
-            # pylint: disable=no-member
-            events = qubesadmin.events.EventsDispatcher(args.app)
+
+            if "guivm" in enabled_services:
+                # pylint: disable=no-member
+                events = qubesadmin.events.EventsDispatcher(args.app)
+            else:
+                # pylint: disable=no-member
+                events = qubesadmin.events.EventsDispatcher(args.app, enable_cache=False)
+
+            
             # pylint: enable=no-member
             launcher.register_events(events)
 


### PR DESCRIPTION
Before this patch, qvm_start_daemon try to read and update keyboard layout regardless if the qube is a audiovm or guivm. 
With this patch it read and update keyboard layout only if the qube is a guivm.

Should fix https://github.com/QubesOS/qubes-issues/issues/8109 

