### PR TITLE
Fix title order when qvm-template output is piped to another command

### DIFF
--- a/qubesadmin/tools/qvm_template.py
+++ b/qubesadmin/tools/qvm_template.py
@@ -1312,7 +1312,7 @@ def list_templates(args: argparse.Namespace,
         elif command == 'list':
             tpl_list = list_to_human_output(tpl_list)
         for status, grp in tpl_list:
-            print(status.title())
+            print(status.title(), flush=True)
             qubesadmin.tools.print_table(grp)
 
 


### PR DESCRIPTION
When 'qvm-template list' is run it displays output:

$ qvm-template list
Installed Templates
template-1
template-2
Available Templates
template-1
template-2
template-3

If the output is piped to another command such as 'cat' the titles drop to the bottom:

$ qvm-template list | cat
template-1
template-2
template-1
template-2
template-3
Installed Templates
Available Templates

This change forces the status title to be flushed prior to working on the template list for human-readable output.

The release and repository information was not included in the examples for clarity.