### PR TITLE
Invalidate cache on domain add/delete

### DIFF
--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -50,9 +50,14 @@ class VMCollection(object):
         self._vm_list = None
         self._vm_objects = {}
 
-    def clear_cache(self):
-        """Clear cached list of VMs"""
+    def clear_cache(self, invalidate_name=None):
+        """Clear cached list of VMs
+        If *invalidate_name* is given, remove that object from cache
+        explicitly too.
+        """
         self._vm_list = None
+        if invalidate_name:
+            self._vm_objects.pop(invalidate_name, None)
 
     def refresh_cache(self, force=False):
         """Refresh cached list of VMs"""

--- a/qubesadmin/base.py
+++ b/qubesadmin/base.py
@@ -416,9 +416,14 @@ class WrapperObjectsCollection(object):
         #: returned objects cache
         self._objects = {}
 
-    def clear_cache(self):
-        '''Clear cached list of names'''
+    def clear_cache(self, invalidate_name=None):
+        """Clear cached list of names.
+        If *invalidate_name* is given, remove that object from cache
+        explicitly too.
+        """
         self._names_list = None
+        if invalidate_name:
+            self._objects.pop(invalidate_name, None)
 
     def refresh_cache(self, force=False):
         '''Refresh cached list of names'''

--- a/qubesadmin/events/__init__.py
+++ b/qubesadmin/events/__init__.py
@@ -225,7 +225,8 @@ class EventsDispatcher(object):
         else:
             # handle cache refreshing on best-effort basis
             if event in ['domain-add', 'domain-delete']:
-                self.app.domains.clear_cache()
+                vm = kwargs['vm']
+                self.app.domains.clear_cache(invalidate_name=str(vm))
             subject = None
         # deserialize known attributes
         if event.startswith('device-') and 'device' in kwargs:


### PR DESCRIPTION
When domain is removed, the VM names list cache was invalidated, but not
the actual objects. When same-named VM is later created, it might use
previously cached object that included properties cache. Fix this by
invalidating objects cache for specific object when domain is removed.
And for extra safety, when it's added too.

Fixes QubesOS/qubes-issues#7820