### PR TITLE
Filter-out keyboard layout switching options

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,7 @@ checks:pylint:
   - sudo dnf install -y python3-rpm
   - pip3 install --quiet -r ci/requirements.txt
   script:
+  - export PATH="$HOME/.local/bin:$PATH"
   - PYTHONPATH=test-packages pylint --extension-pkg-whitelist=rpm,lxml qubesadmin
   stage: checks
   tags:

--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -179,6 +179,8 @@ class KeyboardLayout:
         self.languages = split_string[2].decode().split(',')
         self.variants = split_string[3].decode().split(',')
         self.options = split_string[4].decode()
+        self.options = ",".join(opt for opt in self.options.split(",")
+                                if not opt.endswith("_toggle"))
 
     def get_property(self, layout_num):
         """Return the selected keyboard layout as formatted for keyboard_layout


### PR DESCRIPTION
When switching layout with a key combo, do not let VM to switch the
layout again (once as instructed by qvm-start-daemon, and then on its
own due to the key combo).

Fixes QubesOS/qubes-issues#8035