### PR TITLE
Update qvm-create.rst to fix markup issue `*NAME*=*VALUE*` (#7982)

### DIFF
--- a/doc/manpages/qvm-create.rst
+++ b/doc/manpages/qvm-create.rst
@@ -6,7 +6,7 @@
 Synopsis
 --------
 
-:command:`qvm-create` [-h] [--verbose] [--quiet] [--force-root] [--class *CLS*] [--property *NAME*=*VALUE*] [--pool *POOL_NAME:VOLUME_NAME*] [--template *VALUE*] --label *VALUE* [--root-copy-from *FILENAME* | --root-move-from *FILENAME*] *VMNAME*
+:command:`qvm-create` [-h] [--verbose] [--quiet] [--force-root] [--class *CLS*] [--property *NAME*\ =\ *VALUE*] [--pool *POOL_NAME:VOLUME_NAME*] [--template *VALUE*] --label *VALUE* [--root-copy-from *FILENAME* | --root-move-from *FILENAME*] *VMNAME*
 :command:`qvm-create` --help-classes
 
 Options


### PR DESCRIPTION
The used technique is described in reStructuredText Markup Specification, chapter Character-Level Inline Markup: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#character-level-inline-markup-1
Note, that according to docs this solution should be used only when absolutely necessary.  I think it is exactly our case, because, it seems, there is no other proper way to separate equal sign out of emphasis of the NAME and VALUE. 
Github preview of `qvm-create.rst` file is now correct, too.
Alternative solutions would be to use `*NAME=VALUE*` or NAME=VALUE instead, but the result will not be completely right.
