### PR TITLE
Fix markup issue in qvm-create.rst: *NAME*=*VALUE*

### DIFF
--- a/doc/manpages/qvm-create.rst
+++ b/doc/manpages/qvm-create.rst
@@ -6,7 +6,7 @@
 Synopsis
 --------
 
-:command:`qvm-create` [-h] [--verbose] [--quiet] [--force-root] [--class *CLS*] [--property *NAME*=*VALUE*] [--pool *POOL_NAME:VOLUME_NAME*] [--template *VALUE*] --label *VALUE* [--root-copy-from *FILENAME* | --root-move-from *FILENAME*] *VMNAME*
+:command:`qvm-create` [-h] [--verbose] [--quiet] [--force-root] [--class *CLS*] [--property *NAME*\ =\ *VALUE*] [--pool *POOL_NAME:VOLUME_NAME*] [--template *VALUE*] --label *VALUE* [--root-copy-from *FILENAME* | --root-move-from *FILENAME*] *VMNAME*
 :command:`qvm-create` --help-classes
 
 Options

--- a/qubesadmin/tools/qvm_ls.py
+++ b/qubesadmin/tools/qvm_ls.py
@@ -529,7 +529,8 @@ class _HelpColumnsAction(argparse.Action):
             for column in sorted(Column.columns.values()))
         text += '\n\nAdditionally any VM property may be used as a column, ' \
                 'see qvm-prefs --help-properties for available values'
-        parser.exit(message=text + '\n')
+        print(text + '\n')
+        sys.exit(0)
 
 
 class _HelpFormatsAction(argparse.Action):
@@ -553,7 +554,9 @@ class _HelpFormatsAction(argparse.Action):
             '  {fmt:{width}s}  {columns}\n'.format(
                 fmt=fmt, columns=','.join(formats[fmt]).upper(), width=width)
             for fmt in sorted(formats))
-        parser.exit(message=text)
+        print(text)
+        sys.exit(0)
+
 
 
 # common VM power states for easy command-line filtering


### PR DESCRIPTION
The used technique is described in reStructuredText Markup Specification, chapter Character-Level Inline Markup: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#character-level-inline-markup-1 
Note, that according to docs this solution should be used only when absolutely necessary.  I think it is exactly our case, because, it seems, there is no other proper way to separate equal sign out of emphasis of the NAME and VALUE. 
Github preview of `qvm-create.rst` file is now correct, too. 
Alternative solutions would be to use `*NAME=VALUE*` or NAME=VALUE instead, but the result will not be completely right.