### PR TITLE
Fix: qvm-ls outputs to stderr for --help-* calls

### DIFF
--- a/qubesadmin/tools/qvm_ls.py
+++ b/qubesadmin/tools/qvm_ls.py
@@ -529,7 +529,8 @@ class _HelpColumnsAction(argparse.Action):
             for column in sorted(Column.columns.values()))
         text += '\n\nAdditionally any VM property may be used as a column, ' \
                 'see qvm-prefs --help-properties for available values'
-        parser.exit(message=text + '\n')
+        print(text + '\n')
+        sys.exit(0)
 
 
 class _HelpFormatsAction(argparse.Action):
@@ -553,7 +554,9 @@ class _HelpFormatsAction(argparse.Action):
             '  {fmt:{width}s}  {columns}\n'.format(
                 fmt=fmt, columns=','.join(formats[fmt]).upper(), width=width)
             for fmt in sorted(formats))
-        parser.exit(message=text)
+        print(text)
+        sys.exit(0)
+
 
 
 # common VM power states for easy command-line filtering


### PR DESCRIPTION
The problem is that ArgumentParser has no ability to provide output file for exit() calls. In the ArgumentParser documentation [1] there is even no information about output target file (stderr or stdout) for ArgumentParser.exit() functions, but from the source code of argparse [2] it is obvious that it always outputs message to stderr which is not desired in our case. [1]: https://docs.python.org/3/library/argparse.html#exiting-methods [2]: https://github.com/python/cpython/blob/3.11/Lib/argparse.py#L2612

I have tested this patch on my system, it works as expected.

Fixes QubesOS/qubes-issues#8408