### PR TITLE
Improve layout filtering of options for setxkbmap

### DIFF
--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -180,7 +180,7 @@ class KeyboardLayout:
         self.variants = split_string[3].decode().split(',')
         self.options = split_string[4].decode()
         self.options = ",".join(opt for opt in self.options.split(",")
-                                if not opt.endswith("_toggle"))
+                                if not opt.startswith("grp:"))
 
     def get_property(self, layout_num):
         """Return the selected keyboard layout as formatted for keyboard_layout


### PR DESCRIPTION
NOT TESTED.

Currently options like shift_caps_switch, lctrl_rctrl_switch and other first-last layout toggles are broken because they are not being filtered out. The provided code maybe does it better. Note, that solution was not tested by me! It is just an idea how it is possible to improve fc08f4e.

Docs: The list of options for keyboard layout switching is present in 'grp' chapter of `/usr/share/X11/xkb/rules`.
Note: I am not sure that "while pressed" shortcuts will work or if they even work now.