### PR TITLE
Minor fix misspelling in docstring

### DIFF
--- a/qubesadmin/tools/qvm_tags.py
+++ b/qubesadmin/tools/qvm_tags.py
@@ -19,7 +19,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-'''qvm-features - Manage domain's tags'''
+'''qvm-tags - Manage domain's tags'''
 
 from __future__ import print_function
 


### PR DESCRIPTION
## Current

A _docstring_ that describes `qvm-features` in the `qvm-tags` file.

## Expected

A _docstring_ that describes `qvm-tags`. :slightly_smiling_face: 