### PR TITLE
qvm-volume related minor cleanups

### DIFF
--- a/doc/manpages/qvm-volume.rst
+++ b/doc/manpages/qvm-volume.rst
@@ -1,6 +1,6 @@
 .. program:: qvm-volume
 
-:program:`qvm-volume` -- Qubes volume and block device managment
+:program:`qvm-volume` -- Qubes volume and block device management
 ================================================================
 
 Synopsis

--- a/qubesadmin/tools/qvm_volume.py
+++ b/qubesadmin/tools/qvm_volume.py
@@ -229,7 +229,7 @@ def revert_volume(args):
 
 
 def extend_volumes(args):
-    """ Called by the parser to execute the :program:`qvm-block extend`
+    """ Called by the parser to execute the :program:`qvm-volume extend`
         subcommand
     """
     volume = args.volume
@@ -245,7 +245,7 @@ def extend_volumes(args):
 
 
 def init_list_parser(sub_parsers):
-    """ Configures the parser for the :program:`qvm-block list` subcommand """
+    """ Configures the parser for the :program:`qvm-volume list` subcommand """
     # pylint: disable=protected-access
     list_parser = sub_parsers.add_parser('list', aliases=('ls', 'l'),
                                          help='list storage volumes')

--- a/qubesadmin/tools/qvm_volume.py
+++ b/qubesadmin/tools/qvm_volume.py
@@ -249,8 +249,8 @@ def init_list_parser(sub_parsers):
     # pylint: disable=protected-access
     list_parser = sub_parsers.add_parser('list', aliases=('ls', 'l'),
                                          help='list storage volumes')
-    list_parser.add_argument('-p', '--pool', dest='pools',
-                             action=qubesadmin.tools.PoolsAction)
+    list_parser.add_argument('-p', '--pool', metavar="POOL_NAME",
+                             dest='pools', action=qubesadmin.tools.PoolsAction)
     list_parser.add_argument(
         '--full', action='store_true',
         help='print full line for each POOL_NAME:VOLUME_ID & vm combination')


### PR DESCRIPTION
The comments in `qvm_volume.py` have been referencing commands regarding `qvm-block`. Not only they don't seem to fit contextually, but the `qvm-block extend` one doesn't exist. These were most likely typos.

While the script does account for `args.pools` (plural), the printed help for `qvm-volume list` is wrong with saying: `-p POOLS, --pool POOLS`, as only one can be provided per one option usage. The displayed variable name has been changed, so the help reflects what happens in reality.

Plus one typo has been fixed.