### PR TITLE
Supress legacy help text

### DIFF
--- a/qubesadmin/tools/qvm_pool.py
+++ b/qubesadmin/tools/qvm_pool.py
@@ -183,7 +183,8 @@ def get_parser():
 def uses_legacy_options(args, app):
     ''' Checks if legacy options and used, and invokes the legacy tool '''
     parser = argparse.ArgumentParser(description=__doc__,
-                                     usage=argparse.SUPPRESS)
+                                     usage=argparse.SUPPRESS,
+                                     add_help=False)
 
     parser.add_argument('-a', '--add',
                         dest='has_legacy_options', action='store_true',


### PR DESCRIPTION
Without `add_help=False` the legacy parser will eat a `--help` flag and exit, meaning qvm-pool's actual help text is never printed.

before:

```
$ python3 -m qubesadmin.tools.qvm_pool --help
Manages Qubes pools and their options

optional arguments:
  -h, --help  show this help message and exit
```

after:

```
$ python3 -m qubesadmin.tools.qvm_pool --help
usage: qvm_pool.py [--verbose] [--quiet] [--help] [-o options] [-l | -i POOLNAME | -a NAME DRIVER | -r NAME | -s POOLNAME | --help-drivers]

Manages Qubes pools and their options

optional arguments:
  --verbose, -v         increase verbosity
  --quiet, -q           decrease verbosity
  --help, -h            show this help message and exit
  -o options            comma-separated list of driver options
  -l, --list            list all pools and exit (default action)
  -i POOLNAME, --info POOLNAME
                        print pool info and exit
  -a NAME DRIVER, --add NAME DRIVER
                        add pool
  -r NAME, --remove NAME
                        remove pool
  -s POOLNAME, --set POOLNAME
                        modify pool (use -o to specify modifications)
  --help-drivers        list all drivers with their options and exit
```