### PR TITLE
Fix man page about qvm-run --all

### DIFF
--- a/doc/manpages/qvm-run.rst
+++ b/doc/manpages/qvm-run.rst
@@ -46,8 +46,8 @@ Options
 
 .. option:: --all
 
-   Run the command on all qubes. You can use :option:`--exclude` to limit the
-   qubes set. Command is never run on the dom0.
+   Run the command on all running qubes. You can use :option:`--exclude` to limit the
+   qubes set. Command is never run on dom0.
 
 .. option:: --exclude
 


### PR DESCRIPTION
qvm-run --help correctly says --all is about just running qubes, but man
page didn't include the "running" part. Fix that.

Fixes QubesOS/qubes-issues#8755