### PR TITLE
qvm-prefs: Don't falsely report 'no such property'

### DIFF
--- a/qubesadmin/tests/tools/qubes_prefs.py
+++ b/qubesadmin/tests/tools/qubes_prefs.py
@@ -55,7 +55,7 @@ class TC_00_qubes_prefs(qubesadmin.tests.QubesTestCase):
     def test_003_invalid_property(self):
         self.app.expected_calls[
             ('dom0', 'admin.property.Get', 'no_such_property', None)] = \
-            b'2\x00AttributeError\x00\x00no_such_property\x00'
+            b'2\x00QubesNoSuchPropertyError\x00\x00no_such_property\x00'
         with self.assertRaises(SystemExit):
             with qubesadmin.tests.tools.StderrBuffer() as stderr:
                 qubesadmin.tools.qubes_prefs.main([
@@ -67,7 +67,7 @@ class TC_00_qubes_prefs(qubesadmin.tests.QubesTestCase):
     def test_004_set_invalid_property(self):
         self.app.expected_calls[
             ('dom0', 'admin.property.Set', 'no_such_property', b'value')]\
-            = b'2\x00AttributeError\x00\x00no_such_property\x00'
+            = b'2\x00QubesNoSuchPropertyError\x00\x00no_such_property\x00'
         with self.assertRaises(SystemExit):
             with qubesadmin.tests.tools.StderrBuffer() as stderr:
                 qubesadmin.tools.qubes_prefs.main([

--- a/qubesadmin/tests/tools/qvm_prefs.py
+++ b/qubesadmin/tests/tools/qvm_prefs.py
@@ -77,7 +77,7 @@ class TC_00_qvm_prefs(qubesadmin.tests.QubesTestCase):
             b'0\x00dom0 class=AdminVM state=Running\n'
         self.app.expected_calls[
             ('dom0', 'admin.vm.property.Get', 'no_such_property', None)] = \
-            b'2\x00AttributeError\x00\x00no_such_property\x00'
+            b'2\x00QubesNoSuchPropertyError\x00\x00no_such_property\x00'
         with self.assertRaises(SystemExit):
             with qubesadmin.tests.tools.StderrBuffer() as stderr:
                 qubesadmin.tools.qvm_prefs.main([
@@ -92,7 +92,7 @@ class TC_00_qvm_prefs(qubesadmin.tests.QubesTestCase):
             b'0\x00dom0 class=AdminVM state=Running\n'
         self.app.expected_calls[
             ('dom0', 'admin.vm.property.Set', 'no_such_property', b'value')] = \
-            b'2\x00AttributeError\x00\x00no_such_property\x00'
+            b'2\x00QubesNoSuchPropertyError\x00\x00no_such_property\x00'
         with self.assertRaises(SystemExit):
             with qubesadmin.tests.tools.StderrBuffer() as stderr:
                 qubesadmin.tools.qvm_prefs.main([

--- a/qubesadmin/tools/qvm_prefs.py
+++ b/qubesadmin/tools/qvm_prefs.py
@@ -125,7 +125,7 @@ def process_actions(parser, args, target):
                 args.value = ''
         try:
             setattr(target, args.property, args.value)
-        except AttributeError:
+        except qubesadmin.exc.QubesNoSuchPropertyError:
             parser.error('no such property: {!r}'.format(args.property))
         except qubesadmin.exc.QubesException as e:
             parser.error_runtime(e)
@@ -134,7 +134,7 @@ def process_actions(parser, args, target):
     if args.delete:
         try:
             delattr(target, args.property)
-        except AttributeError:
+        except qubesadmin.exc.QubesNoSuchPropertyError:
             parser.error('no such property: {!r}'.format(args.property))
         except qubesadmin.exc.QubesException as e:
             parser.error_runtime(e)
@@ -144,7 +144,7 @@ def process_actions(parser, args, target):
         value = getattr(target, args.property)
         if value is not None:
             print(str(value))
-    except AttributeError:
+    except qubesadmin.exc.QubesNoSuchPropertyError:
         parser.error('no such property: {!r}'.format(args.property))
     except qubesadmin.exc.QubesException as e:
         parser.error_runtime(e)


### PR DESCRIPTION
Previously we printed a 'no such property' error for all exceptions that are an instance of AttributeError which includes
QubesPropertyAccessError and therefore generated confusing error messages. Print them only in case of QubesNoSuchPropertyError.

Fixes QubesOS/qubes-issues#8666
Related to QubesOS/qubes-issues#5005