### PR TITLE
Add symlinks to qvm-device

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ install:
 	install -m 0644 etc/qvm-start-daemon-kde.desktop $(DESTDIR)/etc/xdg/autostart/
 	install -d $(DESTDIR)/usr/bin
 	ln -sf qvm-start-daemon $(DESTDIR)/usr/bin/qvm-start-gui
+	for i in block usb pci; do ln -sf qvm-device $(DESTDIR)/usr/bin/"qvm-$$i"; done
 	install -m 0755 scripts/qubes-guivm-session $(DESTDIR)/usr/bin/
 	install -d $(DESTDIR)/etc/qubes/post-install.d
 	install -m 0755 scripts/30-keyboard-layout-service.sh \

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -228,4 +228,5 @@ dummy:
 install: man
 	mkdir -p $(DESTDIR)/usr/share/man/man1
 	cp $(BUILDDIR)/man/* $(DESTDIR)/usr/share/man/man1/
+	for i in block usb pci; do ln -sf -- qvm-device.1 $(DESTDIR)/"usr/share/man/man1/qvm-$$i.1"; done
 


### PR DESCRIPTION
These were only in dom0, which is inconsistent.

Fixes: QubesOS/qubes-issues#8786