### PR TITLE
Update tests for Python 3.12

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ checks:tests:
   after_script:
   - ci/codecov-wrapper
   before_script:
-  - sudo dnf install -y openssl python3-rpm
+  - sudo dnf install -y openssl python3-rpm sequoia-sqv
   - pip3 install --quiet -r ci/requirements.txt
   - git config --global --add safe.directory "$PWD"
   script:

--- a/ci/codecov-wrapper
+++ b/ci/codecov-wrapper
@@ -2,13 +2,11 @@
 
 set -xe
 
-gpg --no-default-keyring --keyring trustedkeys.gpg --import ci/codecov-keys.asc
-
 curl -Os https://uploader.codecov.io/latest/linux/codecov
 curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
 curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
 
-gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+sqv --keyring ci/codecov-keys.asc codecov.SHA256SUM.sig codecov.SHA256SUM
 shasum -a 256 -c codecov.SHA256SUM
 
 chmod +x codecov

--- a/qubesadmin/tests/tools/init.py
+++ b/qubesadmin/tests/tools/init.py
@@ -32,8 +32,8 @@ class TC_00_PropertyAction(qubesadmin.tests.QubesTestCase):
         parser.set_defaults(properties={'defaultprop': 'defaultvalue'})
 
         args = parser.parse_args([])
-        self.assertDictContainsSubset(
-            {'defaultprop': 'defaultvalue'}, args.properties)
+        self.assertIn(
+            ('defaultprop', 'defaultvalue'), args.properties.items())
 
     def test_001_set_prop(self):
         parser = argparse.ArgumentParser()
@@ -41,8 +41,8 @@ class TC_00_PropertyAction(qubesadmin.tests.QubesTestCase):
             action=qubesadmin.tools.PropertyAction)
 
         args = parser.parse_args(['-p', 'testprop=testvalue'])
-        self.assertDictContainsSubset(
-            {'testprop': 'testvalue'}, args.properties)
+        self.assertIn(
+            ('testprop', 'testvalue'), args.properties.items())
 
     def test_002_set_prop_2(self):
         parser = argparse.ArgumentParser()
@@ -52,8 +52,8 @@ class TC_00_PropertyAction(qubesadmin.tests.QubesTestCase):
 
         args = parser.parse_args(
             ['-p', 'testprop=testvalue', '-p', 'testprop2=testvalue2'])
-        self.assertDictContainsSubset(
-            {'testprop': 'testvalue', 'testprop2': 'testvalue2'},
+        self.assertEqual(
+            {'testprop': 'testvalue', 'testprop2': 'testvalue2'} | args.properties,
             args.properties)
 
     def test_003_set_prop_with_default(self):
@@ -63,8 +63,8 @@ class TC_00_PropertyAction(qubesadmin.tests.QubesTestCase):
         parser.set_defaults(properties={'defaultprop': 'defaultvalue'})
 
         args = parser.parse_args(['-p', 'testprop=testvalue'])
-        self.assertDictContainsSubset(
-            {'testprop': 'testvalue', 'defaultprop': 'defaultvalue'},
+        self.assertEqual(
+            {'testprop': 'testvalue', 'defaultprop': 'defaultvalue'} | args.properties,
             args.properties)
 
     def test_003_set_prop_override_default(self):
@@ -75,9 +75,9 @@ class TC_00_PropertyAction(qubesadmin.tests.QubesTestCase):
         parser.set_defaults(properties={'testprop': 'defaultvalue'})
 
         args = parser.parse_args(['-p', 'testprop=testvalue'])
-        self.assertDictContainsSubset(
-            {'testprop': 'testvalue'},
-            args.properties)
+        self.assertIn(
+            ('testprop', 'testvalue'),
+            args.properties.items())
 
 
 class TC_01_SinglePropertyAction(qubesadmin.tests.QubesTestCase):
@@ -101,24 +101,24 @@ class TC_01_SinglePropertyAction(qubesadmin.tests.QubesTestCase):
         parser.set_defaults(properties={'testprop': 'defaultvalue'})
 
         args = parser.parse_args([])
-        self.assertDictContainsSubset(
-            {'testprop': 'defaultvalue'}, args.properties)
+        self.assertIn(
+            ('testprop', 'defaultvalue'), args.properties.items())
 
     def test_101_set_prop(self):
         parser = argparse.ArgumentParser()
         parser.add_argument('--testprop', '-T',
             action=qubesadmin.tools.SinglePropertyAction)
         args = parser.parse_args(['-T', 'testvalue'])
-        self.assertDictContainsSubset(
-            {'testprop': 'testvalue'}, args.properties)
+        self.assertIn(
+            ('testprop', 'testvalue'), args.properties.items())
 
     def test_102_set_prop_dest(self):
         parser = argparse.ArgumentParser()
         parser.add_argument('--testprop', '-T', dest='otherprop',
             action=qubesadmin.tools.SinglePropertyAction)
         args = parser.parse_args(['-T', 'testvalue'])
-        self.assertDictContainsSubset(
-            {'otherprop': 'testvalue'}, args.properties)
+        self.assertIn(
+            ('otherprop', 'testvalue'), args.properties.items())
 
     def test_103_set_prop_const(self):
         parser = argparse.ArgumentParser()
@@ -126,13 +126,13 @@ class TC_01_SinglePropertyAction(qubesadmin.tests.QubesTestCase):
             action=qubesadmin.tools.SinglePropertyAction,
             const='testvalue')
         args = parser.parse_args(['-T'])
-        self.assertDictContainsSubset(
-            {'testprop': 'testvalue'}, args.properties)
+        self.assertIn(
+            ('testprop', 'testvalue'), args.properties.items())
 
     def test_104_set_prop_positional(self):
         parser = argparse.ArgumentParser()
         parser.add_argument('testprop',
             action=qubesadmin.tools.SinglePropertyAction)
         args = parser.parse_args(['testvalue'])
-        self.assertDictContainsSubset(
-            {'testprop': 'testvalue'}, args.properties)
+        self.assertIn(
+            ('testprop', 'testvalue'), args.properties.items())

--- a/qubesadmin/tests/tools/qvm_shutdown.py
+++ b/qubesadmin/tests/tools/qvm_shutdown.py
@@ -212,7 +212,7 @@ class TC_00_qvm_shutdown(qubesadmin.tests.QubesTestCase):
         self.app.expected_calls[
             ('sys-net', 'admin.vm.CurrentState', None, None)] = \
             b'0\x00power_state=Halted'
-        with self.assertRaisesRegexp(SystemExit, '2'):
+        with self.assertRaisesRegex(SystemExit, '2'):
             qubesadmin.tools.qvm_shutdown.main(
                 ['--wait', '--all', '--timeout=1'], app=self.app)
         self.assertAllCalled()

--- a/qubesadmin/tools/__init__.py
+++ b/qubesadmin/tools/__init__.py
@@ -575,7 +575,7 @@ def print_table(table, stream=None):
 
     # for tests...
     if stream != sys.__stdout__:
-        with subprocess.Popen(cmd + ['-c', '80'], stdin=subprocess.PIPE,
+        with subprocess.Popen(cmd + ['-c', '88'], stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE) as p:
             p.stdin.write(text_table.encode())
             (out, _) = p.communicate()


### PR DESCRIPTION
- do not use assertDictContainsSubset (replace with either assertIn on
  items(), or assertEqual on dict union)
- replace assertRaisesRegexp with assertRaisesRegex