### PR TITLE
Revert "Do not enable "low latency" mode for pipewire"

### DIFF
--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -547,14 +547,7 @@ class DAEMONLauncher:
 
         :param vm: VM for which start AUDIO daemon
         """
-        # pipewire with low latency causes a lot of underruns on some systems
-        low_latency = not vm.features.check_with_template(
-            'supported-service.pipewire', False)
-        low_latency = vm.features.check_with_template(
-            'audio-low-latency', low_latency)
-        pacat_cmd = [PACAT_DAEMON_PATH, self.pacat_domid(vm), vm.name]
-        if low_latency:
-            pacat_cmd.insert(1, "-l")
+        pacat_cmd = [PACAT_DAEMON_PATH, '-l', self.pacat_domid(vm), vm.name]
         vm.log.info('Starting AUDIO')
 
         await asyncio.create_subprocess_exec(*pacat_cmd)


### PR DESCRIPTION
The PipeWire agent [has been fixed][1], so this is no longer needed.

This reverts commit 02ecff74328f527040531332f3a2a6bf9dd585ba.

[1]: https://github.com/QubesOS/qubes-gui-agent-linux/commit/92a144bea7c198febfbdc9fb40e9fb318efe6343