### PR TITLE
minor cleanup of rpm2cpio usage leftover in var name

### DIFF
--- a/qubesadmin/tools/qvm_template.py
+++ b/qubesadmin/tools/qvm_template.py
@@ -743,13 +743,13 @@ def extract_rpm(name: str, path: str, target: str) -> bool:
     with open(path, 'rb') as pkg_f:
         with subprocess.Popen(['rpm2archive', "-"],
                 stdin=pkg_f,
-                stdout=subprocess.PIPE) as rpm2cpio:
+                stdout=subprocess.PIPE) as rpm2archive:
             # `-D` is GNUism
             with subprocess.Popen([
                     'tar', 'xz', '-C', target, f'.{PATH_PREFIX}/{name}/'
-                    ], stdin=rpm2cpio.stdout, stdout=subprocess.DEVNULL) as tar:
+                    ], stdin=rpm2archive.stdout, stdout=subprocess.DEVNULL) as tar:
                 pass
-    return rpm2cpio.returncode == 0 and tar.returncode == 0
+    return rpm2archive.returncode == 0 and tar.returncode == 0
 
 
 def filter_version(

--- a/qubesadmin/tools/qvm_template.py
+++ b/qubesadmin/tools/qvm_template.py
@@ -745,9 +745,9 @@ def extract_rpm(name: str, path: str, target: str) -> bool:
                 stdin=pkg_f,
                 stdout=subprocess.PIPE) as rpm2archive:
             # `-D` is GNUism
-            with subprocess.Popen([
-                    'tar', 'xz', '-C', target, f'.{PATH_PREFIX}/{name}/'
-                    ], stdin=rpm2archive.stdout, stdout=subprocess.DEVNULL) as tar:
+            with subprocess.Popen(
+                    ['tar', 'xz', '-C', target, f'.{PATH_PREFIX}/{name}/'],
+                    stdin=rpm2archive.stdout, stdout=subprocess.DEVNULL) as tar:
                 pass
     return rpm2archive.returncode == 0 and tar.returncode == 0
 


### PR DESCRIPTION
In https://github.com/QubesOS/qubes-core-admin-client/commit/2ac29639a3382ea3d518d87b4df5e74e87ec0053, a call to `rpm2cpio` was replaced with a call to `rpm2archive`. However, one variable is still named `rpm2cpio` around that location. This PR just renames that var to avoid misleading the reader.

Well, nothing worth a separate PR - just wanted to confirm that I'm looking into https://github.com/QubesOS/qubes-issues/issues/8876