### PR TITLE
qvm-start-daemon: ignore self qube for starting audio/gui daemons

### DIFF
--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -704,6 +704,8 @@ class DAEMONLauncher:
         Should we watch this VM for changes
         """
 
+        if self.app.local_name == vm.name:
+            return False
         if self.vm_names is None:
             return True
         return vm.name in self.vm_names


### PR DESCRIPTION
Do not even consider starting audio/gui daemons for local domain (like
sys-gui's gui-daemon insider sys-gui itself), that doesn't make sense.
Skipping it early avoids also trying to access properties guivm/audiovm
doesn't have access to.

QubesOS/qubes-issues#1590