### PR TITLE
qvm-start-daemon: expect gui-window-background-color, gui-default-window-background-color

### DIFF
--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -52,6 +52,7 @@ GUI_DAEMON_OPTIONS = [
     ('secure_paste_sequence', 'str'),
     ('windows_count_limit', 'int'),
     ('trayicon_mode', 'str'),
+    ('window_background_color', 'str'),
     ('startup_timeout', 'int'),
 ]
 


### PR DESCRIPTION
Look for these features as settable by `qvm-features`:
- `gui-window-background-color`
- `gui-default-window-background-color`

Translate them into the `window_background_color` setting in the configuration file generated for `qubes-guid`.

See also: QubesOS/qubes-gui-daemon/pull/144
Fixes QubesOS/qubes-issues#9304