### PR TITLE
Add events_max_delay setting for qubes-gui-daemon

### DIFF
--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -110,6 +110,7 @@ GUI_DAEMON_OPTIONS = [
     ('startup_timeout', 'int', (lambda x: isinstance(x, int) and x >= 0)),
     ('max_clipboard_size', 'int', \
             (lambda x: isinstance(x, int) and 256 <= x <= 256000)),
+    ('events_max_delay', 'int', (lambda x: isinstance(x, int) and x >= 0)),
 ]
 
 formatter = logging.Formatter(


### PR DESCRIPTION
Allows gubes-gui-daemon X event buffering delay to be configured. Prerequisite for https://github.com/QubesOS/qubes-gui-daemon/pull/149