### PR TITLE
Apply "fix: do not crash on pool with no volumes"

### DIFF
--- a/qubesadmin/storage.py
+++ b/qubesadmin/storage.py
@@ -430,6 +430,8 @@ class Pool(object):
                 'dom0', 'admin.pool.volume.List', self.name, None)
         except qubesadmin.exc.QubesDaemonAccessError:
             raise qubesadmin.exc.QubesPropertyAccessError('volumes')
+        if volumes_data == b'':
+            return
         assert volumes_data.endswith(b'\n')
         volumes_data = volumes_data[:-1].decode('ascii')
         for vid in volumes_data.splitlines():


### PR DESCRIPTION
Submitted by @ethnh
Authored by @CertainLach
Fixes QubesOS/qubes-issues#9504

I don't know what exactly was crashing there. But the patch LGTM, and I've checked that `list(qubesadmin.Qubes().pools['my-empty-pool'].volumes)` now correctly results in `[]` instead of raising `AssertionError`.