### PR TITLE
Avoid spaces in values for `admin.vm.Create` calls

### DIFF
--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -340,6 +340,8 @@ class QubesBase(qubesadmin.base.PropertyHolder):
         elif template is not None:
             template = str(template)
 
+        if ' ' in name:
+            raise ValueError(f'Qube name could not contain space: {name}')
         if pool and pools:
             raise ValueError('only one of pool= and pools= can be used')
 

--- a/qubesadmin/tests/app.py
+++ b/qubesadmin/tests/app.py
@@ -863,6 +863,10 @@ class TC_10_QubesBase(qubesadmin.tests.QubesTestCase):
         self.assertEqual(vm.get_power_state(), 'Halted')
         self.assertAllCalled()
 
+    def test_051_space_in_vmname(self):
+        with self.assertRaises(ValueError):
+            self.app.add_new_vm('AppVM', 'VM Name with spaces', 'red')
+
 
 class TC_20_QubesLocal(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
fixes: https://github.com/QubesOS/qubes-issues/issues/9558