### PR TITLE
Allow vm class to be given as positional argument to clone_vm

### DIFF
--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -359,7 +359,7 @@ class QubesBase(qubesadmin.base.PropertyHolder):
         self.domains.clear_cache()
         return self.domains[name]
 
-    def clone_vm(self, src_vm, new_name, *, new_cls=None, pool=None, pools=None,
+    def clone_vm(self, src_vm, new_name, new_cls=None, *, pool=None, pools=None,
                  ignore_errors=False, ignore_volumes=None,
                  ignore_devices=False):
         # pylint: disable=too-many-statements


### PR DESCRIPTION
Create qube dialog uses it this way.

Fixess QubesOS/qubes-issues#9574