### PR TITLE
Make "multimedia" devices more detailed

### DIFF
--- a/qubesadmin/device_protocol.py
+++ b/qubesadmin/device_protocol.py
@@ -646,13 +646,14 @@ class DeviceCategory(Enum):
     Microphone = ("m******",)
     # Multimedia = Audio, Video, Displays etc.
     Multimedia = (
-        "u01****",
-        "u0e****",
         "u06****",
         "u10****",
         "p03****",
         "p04****",
     )
+    Audio = ("p0403**", "u01****")
+    Display = ("p0300**", "p0380**")
+    Video = ("p0400**", "u0e****")
     Wireless = ("ue0****", "p0d****")
     Bluetooth = ("ue00101", "p0d11**")
     Storage = ("b******", "u08****", "p01****")

--- a/qubesadmin/tests/tools/qvm_device.py
+++ b/qubesadmin/tests/tools/qvm_device.py
@@ -80,7 +80,7 @@ class TC_00_qvm_device(qubesadmin.tests.QubesTestCase):
                 ['testclass', 'list'], app=self.app)
             self.assertEqual(
                 [x.rstrip() for x in buf.getvalue().splitlines()],
-                ['test-vm1:dev1  Multimedia: itl test-device',
+                ['test-vm1:dev1  Audio: itl test-device',
                  'test-vm2:dev2  ?******: ? ` test-device']
             )
 
@@ -155,7 +155,7 @@ class TC_00_qvm_device(qubesadmin.tests.QubesTestCase):
                 ['testclass', 'list', 'test-vm3'], app=self.app)
             self.assertEqual(
                 buf.getvalue(),
-                'test-vm1:dev1  Multimedia: itl test-device  '
+                'test-vm1:dev1  Audio: itl test-device  '
                 'test-vm3 (attached)\n'
             )
 
@@ -573,7 +573,7 @@ class TC_00_qvm_device(qubesadmin.tests.QubesTestCase):
             qubesadmin.tools.qvm_device.main(
                 ['testclass', 'info', 'test-vm1:dev1'],
                 app=self.app)
-            self.assertIn('Multimedia: itl test-device\n'
+            self.assertIn('Audio: itl test-device\n'
                           'device ID: dead:beef:babe:u012345',
                           buf.getvalue())
         self.assertAllCalled()


### PR DESCRIPTION
Distinguish between audio, video and display adapters. This is
especially relevant when setting up sys-audio or sys-gui-gpu, otherwise
it's hard to find which "multimedia" device is the right one.