### PR TITLE
Always pass a service argument

### DIFF
--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -861,8 +861,15 @@ class QubesLocal(QubesBase):
         kwargs.setdefault('stdout', subprocess.PIPE)
         kwargs.setdefault('stderr', subprocess.PIPE)
         proc = subprocess.Popen(
-            [qubesadmin.config.QREXEC_CLIENT] + qrexec_opts + [
-                '{}:QUBESRPC {} dom0'.format(user, service)], **kwargs)
+            [qubesadmin.config.QREXEC_CLIENT]
+            + qrexec_opts
+            + [
+                "{}:QUBESRPC {}{} dom0".format(
+                    user, service, "" if "+" in service else "+"
+                )
+            ],
+            **kwargs,
+        )
         return proc
 
 

--- a/qubesadmin/tests/app.py
+++ b/qubesadmin/tests/app.py
@@ -999,7 +999,7 @@ class TC_20_QubesLocal(unittest.TestCase):
             self.app.run_service('some-vm', 'service.name')
             mock_proc.assert_called_once_with([
                 qubesadmin.config.QREXEC_CLIENT,
-                '-d', 'some-vm', '-T', 'DEFAULT:QUBESRPC service.name dom0'],
+                '-d', 'some-vm', '-T', 'DEFAULT:QUBESRPC service.name+ dom0'],
                 stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
 
@@ -1013,7 +1013,7 @@ class TC_20_QubesLocal(unittest.TestCase):
             mock_proc.assert_called_once_with([
                 qubesadmin.config.QREXEC_CLIENT,
                 '-d', 'some-vm', '-t', '-T',
-                'DEFAULT:QUBESRPC service.name dom0'],
+                'DEFAULT:QUBESRPC service.name+ dom0'],
                 stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
 
@@ -1028,7 +1028,7 @@ class TC_20_QubesLocal(unittest.TestCase):
             mock_proc.assert_called_once_with([
                 qubesadmin.config.QREXEC_CLIENT,
                 '-d', 'some-vm', '-T',
-                'user:QUBESRPC service.name dom0'],
+                'user:QUBESRPC service.name+ dom0'],
                 stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
 


### PR DESCRIPTION
The argument is not really optional, and not passing one leads to bugs on the VM side.