### PR TITLE
tests: Account for argparse bug fix in Python 3.13

### DIFF
--- a/qubesadmin/tests/tools/qvm_service.py
+++ b/qubesadmin/tests/tools/qvm_service.py
@@ -20,6 +20,7 @@
 
 # pylint: disable=missing-docstring
 
+import sys
 import unittest
 
 import qubesadmin.tests
@@ -100,7 +101,7 @@ class TC_00_qvm_service(qubesadmin.tests.QubesTestCase):
             0)
         self.assertAllCalled()
 
-    @unittest.expectedFailure
+    @unittest.skipIf(sys.version_info.minor < 13, reason="argparse bug")
     def test_004_enable_opt_mixed(self):
         self.app.expected_calls[
             ('dom0', 'admin.vm.List', None, None)] = \
@@ -109,6 +110,18 @@ class TC_00_qvm_service(qubesadmin.tests.QubesTestCase):
             ('some-vm', 'admin.vm.feature.Set',
              'service.service1', b'1')] = b'0\x00'
         with self.assertNotRaises(SystemExit):
+            self.assertEqual(
+                qubesadmin.tools.qvm_service.main(
+                    ['some-vm', '--enable', 'service1'],
+                    app=self.app),
+                0)
+        self.assertAllCalled()
+
+    @unittest.skipIf(
+        sys.version_info.minor >= 13, reason="argparse works correctly"
+    )
+    def test_004_enable_opt_mixed_broken(self):
+        with self.assertRaises(SystemExit):
             self.assertEqual(
                 qubesadmin.tools.qvm_service.main(
                     ['some-vm', '--enable', 'service1'],


### PR DESCRIPTION
Test test_004_enable_opt_mixed is marked as xfail because of an argparse bug, but the bug is fixed in Python 3.13 so the test unexpectedly succeeds.  Remove the @unittest.expectedFailure, skip it on Python<3.13, and add a new tests for older Python that checks for the previous buggy behavior.