### PR TITLE
Add top-like monitoring tool

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -61,10 +61,10 @@ method-rgx=([a-z_][a-z0-9_]{2,60}|assert([A-Z][a-z0-9]*)*)$
 attr-rgx=([a-z_][a-z0-9_]{2,40}|maxDiff)$
 
 # Regular expression which should only match correct argument names
-argument-rgx=[a-z_][a-z0-9_]{2,30}$
+argument-rgx=[a-z_][a-z0-9_]{2,40}$
 
 # Regular expression which should only match correct variable names
-variable-rgx=[a-z_][a-z0-9_]{2,30}$
+variable-rgx=[a-z_][a-z0-9_]{2,40}$
 
 # Regular expression which should only match correct list comprehension /
 # generator expression variable names

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -401,6 +401,8 @@ man_pages = [
         u'Manage tags on a qube', _man_pages_author, 1),
     ('manpages/qvm-template', 'qvm-template',
         u'Manage templates', _man_pages_author, 1),
+    ('manpages/qvm-top', 'qvm-top',
+        u'Top-like monitoring tool', _man_pages_author, 1),
     ('manpages/qvm-unpause', 'qvm-unpause',
         u'Pause a qube', _man_pages_author, 1),
     ('manpages/qvm-volume', 'qvm-volume',

--- a/doc/manpages/qvm-top.rst
+++ b/doc/manpages/qvm-top.rst
@@ -1,0 +1,298 @@
+.. program:: qvm-top
+
+:program:`qvm-top` -- top-like monitoring tool
+==============================================
+
+Synopsis
+--------
+
+:command:`qvm-top` [--verbose] [--quiet] [--help] [--version] [--all] [--exclude *EXCLUDE*] [--show-halted] [--filter *FILTER*,...] [--columns *COLUMN*,... | --format *FORMAT*] [--help-columns] [--help-formats] [--sort-column *COLUMN*] [--reverse] [--no-color] [*VMNAME* ...]
+
+Top-like info for Qubes. Defaults is to show all non-halted qubes.
+
+Positional arguments
+--------------------
+
+.. option:: VMNAME ...
+
+   Zero or more domain names. If none spcified, the default is to show all.
+
+General Options
+---------------
+
+.. option:: --verbose, -v
+
+   Increase verbosity.
+
+.. option:: --quiet, -q
+
+   Decrease verbosity.
+
+.. option:: --help, -h
+
+   Show this help message and exit.
+
+.. option:: --version
+
+   Show program's version number and exit.
+
+.. option:: --all
+
+   Perform the action on all qubes
+
+.. option:: --exclude EXCLUDE
+
+   Exclude the qube from ``--all``.
+
+.. option:: --show-halted, -S
+
+   Don't hide halted qubes.
+
+.. option:: --filter, -f FILTER,...
+
+   Filter domains name matching each fixed string separated by comma.
+
+.. option:: --no-color
+
+   Do not colorize the screen. If this option is not provided, but environment
+   variable `NO_COLOR` is set, the screen will not be colorized.
+
+Formatting Options
+------------------
+
+.. option:: --columns, -C COLUMN,...
+
+   Show only specified columns.
+
+.. option:: --format, -F FORMAT
+
+   Show only columns declared by format: `min`, `default, `max-no-internal`,
+   `max`.
+
+.. option:: --help-columns
+
+   List all available columns with short descriptions and exit.
+
+.. option:: --help-formats
+
+   List all available formats with short descriptions and exit.
+
+Sorting Options
+---------------
+
+.. option:: --sort-column, -k COLUMN
+
+   Sort by specified column.
+
+.. option:: --reverse, -r
+
+   Reverse sorting.
+
+Interaction - Navigation
+------------------------
+
+.. option:: Up, k, ^N
+
+   Scroll one row up.
+
+.. option:: Down, j, ^P
+
+   Scroll one row down.
+
+.. option:: ^B, ^F
+
+   Scroll one page up or down.
+
+.. option:: ^U, ^D
+
+   Scroll half page up or down.
+
+.. option:: Home, ^A
+
+   Scroll to the first page.
+
+.. option:: End, ^E
+
+   Scroll to the last page.
+
+Interaction - Visualization
+---------------------------
+
+.. option:: Left, h
+
+   Sort the column to the left.
+
+.. option:: Right, l
+
+   Sort the column to the right.
+
+.. option:: r
+
+   Reverse sorting order.
+
+.. option:: /
+
+   Filter by qube name, CSV.
+
+.. option:: S
+
+   Toggle showing halted qubes.
+
+.. option:: Enter
+
+   Apply filter and return to main screen.
+
+.. option:: ^L
+
+   Redraw the screen on the next refresh.
+
+.. option:: q, Q, ESC, ^C
+
+   Quit filter mode.
+
+Interaction - Execution
+-----------------------
+
+.. option:: Double-Left-Click, Space
+
+   Tag a row and move one line, down if row was not previously selected, else
+   up.
+
+.. option:: T
+
+   Toggle tag all visible rows.
+
+.. option:: U
+
+   Untag all rows.
+
+.. option:: a
+
+   Toggle action column, which shows only actions that can be executed to all
+   tagged qubes. If none is tagged, act based on the current selection.
+
+.. option:: Numbers
+
+   If action column is active, typing a number will select the corresponding
+   action.
+
+.. option:: Enter
+
+   If action column is active, apply action and return to main screen.
+
+.. option:: q, Q, ESC, ^C
+
+   Quit action mode.
+
+Columns
+-------
+
+Columns are identified by a machine header followed by a pretty header if
+necessary.
+
+.. option:: name - NAME
+
+   Qube name.
+
+.. option:: state - STATE
+
+   Current power state.
+
+.. option:: memory_used - MU
+
+   How much memory the domain is using.
+
+.. option:: memory_used_with_swap - MSU
+
+   How much memory including swap the domain is using.
+
+.. option:: memory_assigned - MS
+
+   How much memory the domain is allowed to claim at any time.
+
+.. option:: memory_max - MM
+
+   How much memory the domain can try to scale up to.
+
+.. option:: memory_usage_used - MU/MM
+
+   How much memory the domain is using in percentage.
+
+.. option:: memory_usage_used_with_swap - MSU/MU
+
+   How much memory the domain is swapping over what it is using.
+
+.. option:: memory_usage_assigned - MS/MM
+
+   How much memory the domain has assigned in percentage.
+
+.. option:: memory_usage_used_assigned - MU/MS
+
+   How much memory the domain is using from the assigned amount, in percentage.
+
+.. option:: cpu_time - CPUsec
+
+   How many seconds the domain has used from the CPU.
+
+.. option:: cpu_usage - CPU%
+
+   How much CPU the domain is using in percentage.
+
+.. option:: online_vcpus - VC
+
+   How many VCPUs are online.
+
+.. option:: memory_used_internal - MUi
+
+   How much memory the domain is using indirectly.
+
+.. option:: memory_assigned_internal - MSi
+
+   How much memory the domain is allowed to claim at any time.
+
+.. option:: cpu_time_internal - CPUisec
+
+   How many seconds the domain has used indirectly from the CPU.
+
+.. option:: cpu_usage_internal - CPUi%
+
+   How much CPU the domain is using indirectly in percentage.
+
+.. option:: online_vcpus_internal - VCi
+
+   How many VCPUs are online indirectly.
+
+.. option:: memory_used_total - MUT
+
+   How much memory the domain is using in total.
+
+.. option:: memory_assigned_total - MST
+
+   How much memory the domain is allowed to claim at any time.
+
+.. option:: cpu_time_total - CPU(s)T
+
+   How many seconds the domain has used in total from the CPU.
+
+.. option:: online_vcpus_total - VCT
+
+   How many VCPUs are online in total.
+
+Notes
+-----
+
+Time printed represents the last moment the screen was refreshed. It only
+happens when information is outdated.
+
+Values for HVMs are aggregated with its companion device model stub domain,
+therefore a HVM such as `sys-net` which has 2 VCPUs, with it's device model
+having 1 VCPU, will show 3 VCPUs. Same process is done for other properties when
+applicable.
+
+Authors
+-------
+
+| Benjamin Grande <ben.grande.b at gmail dot com>
+| For complete author list see: https://github.com/QubesOS/qubes-core-admin-client.git
+
+.. vim: ts=3 sw=3 et tw=80

--- a/doc/manpages/qvm-top.rst
+++ b/doc/manpages/qvm-top.rst
@@ -130,21 +130,28 @@ Interaction - Visualization
 
    Reverse sorting order.
 
-.. option:: /
-
-   Filter by qube name, CSV.
-
 .. option:: S
 
    Toggle showing halted qubes.
 
-.. option:: Enter
-
-   Apply filter and return to main screen.
-
 .. option:: ^L
 
    Redraw the screen on the next refresh.
+
+.. option:: q, Q, ESC, ^C
+
+   Quit the application.
+
+Interaction - Filter
+--------------------
+
+.. option:: /
+
+   Filter by qube name, CSV.
+
+.. option:: Enter
+
+   Apply filter and return to main screen.
 
 .. option:: q, Q, ESC, ^C
 
@@ -160,7 +167,7 @@ Interaction - Execution
 
 .. option:: T
 
-   Toggle tag all visible rows.
+   Toggle tag all visible rows. Great when used with filter.
 
 .. option:: U
 
@@ -192,102 +199,97 @@ necessary.
 
 .. option:: name - NAME
 
-   Qube name.
+   Qube's name.
 
 .. option:: state - STATE
 
-   Current power state.
+   Qube's power state.
 
-.. option:: memory_used - MU
+.. option:: memory_used -> MU
 
-   How much memory the domain is using.
+   How much memory the qube alleges to use. This value or part of it is broadcast by the qube, it can be a lie.
 
-.. option:: memory_used_with_swap - MSU
+.. option:: memory_used_with_swap -> MSU
 
-   How much memory including swap the domain is using.
+   How much memory including swap the qube alleges to use. This value or part of it is broadcast by the qube, it can be a lie.
 
-.. option:: memory_assigned - MS
+.. option:: memory_assigned -> MS
 
-   How much memory the domain is allowed to claim at any time.
+   How much memory has been assigned to the qube, including videoram. A qube is allowed to claim this amount at any time, and it cannot use more memory than what has been assigned to it. When the system is under no memory pressure, this value is close to ``MM``, while when the system isunder memory pressure, the value can be as low as enough for the qube to survive.
 
-.. option:: memory_max - MM
+.. option:: memory_max -> MM
 
-   How much memory the domain can try to scale up to.
+   How much memory the qube can use from the system. Part of this value is reserved to videoram, while the rest is up to qmemman to balloon up this qube when there is enough free memory on the host.
 
-.. option:: memory_usage_used - MU/MM
+.. option:: memory_usage_used -> MU/MM
 
-   How much memory the domain is using in percentage.
+   How much memory the qube alleges to use compared to the maximum it canuse from the system, in percentage.
 
-.. option:: memory_usage_used_with_swap - MSU/MU
+.. option:: memory_usage_assigned -> MS/MM
 
-   How much memory the domain is swapping over what it is using.
+   How much memory the qube has assigned compared to the maximum it can use from the system, in percentage. A high percentage means the system is not pressuring the qube to release memory.
 
-.. option:: memory_usage_assigned - MS/MM
+.. option:: memory_usage_used_assigned -> MU/MS
 
-   How much memory the domain has assigned in percentage.
+   How much memory the qube alleges to use from the assigned amount, in percentage. A high percentage on non-memory-balanced qubes is irrelevant. On memory balanced qubes, a higher value indicates the qube is using a lot of the memory it has assigned, which might be near exhaustion, if ``MS`` can't be ballooned up anymore.
 
-.. option:: memory_usage_used_assigned - MU/MS
+.. option:: memory_usage_used_with_swap -> MSU/MU
 
-   How much memory the domain is using from the assigned amount, in percentage.
+   How much memory the qube alleges to be swaping from what it alleges touse, in percentage. When it is over 10%, the qube might be swaping too much.
 
-.. option:: cpu_time - CPUsec
+.. option:: cpu_time -> CPUsec
 
-   How many seconds the domain has used from the CPU.
+   How many seconds the qube has used from the CPU.
 
-.. option:: cpu_usage - CPU%
+.. option:: cpu_usage -> CPU%
 
-   How much CPU the domain is using in percentage.
+   How much CPU the qube is using, in percentage.
 
-.. option:: online_vcpus - VC
+.. option:: online_vcpus -> VC
 
-   How many VCPUs are online.
+   How many Virtual CPUs are online.
 
-.. option:: memory_used_internal - MUi
+.. option:: memory_used_internal -> MUi
 
-   How much memory the domain is using indirectly.
+   Same as MU, but internal usage.
 
-.. option:: memory_assigned_internal - MSi
+.. option:: memory_assigned_internal -> MSi
 
-   How much memory the domain is allowed to claim at any time.
+   Same as ``MS``, but internal usage.
 
-.. option:: cpu_time_internal - CPUisec
+.. option:: cpu_time_internal -> CPUisec
 
-   How many seconds the domain has used indirectly from the CPU.
+   Same as ``CPUsec``, but internal usage.
 
-.. option:: cpu_usage_internal - CPUi%
+.. option:: cpu_usage_internal -> CPUi%
 
-   How much CPU the domain is using indirectly in percentage.
+   Same as ``CPU%``, but internal usage.
 
-.. option:: online_vcpus_internal - VCi
+.. option:: online_vcpus_internal -> VCi
 
-   How many VCPUs are online indirectly.
+   Same as ``VC``, but internal usage.
 
-.. option:: memory_used_total - MUT
+.. option:: memory_used_total -> MUT
 
-   How much memory the domain is using in total.
+   ``MU`` + ``MUi``.
 
-.. option:: memory_assigned_total - MST
+.. option:: memory_assigned_total -> MST
 
-   How much memory the domain is allowed to claim at any time.
+   ``MS`` + ``MSi``.
 
-.. option:: cpu_time_total - CPU(s)T
+.. option:: cpu_time_total -> CPUsecT
 
-   How many seconds the domain has used in total from the CPU.
+   ``CPUsec`` + ``CPUisec``.
 
-.. option:: online_vcpus_total - VCT
+.. option:: online_vcpus_total -> VCT
 
-   How many VCPUs are online in total.
+   ``VC`` + ``VCi``.
 
 Notes
 -----
 
-Time printed represents the last moment the screen was refreshed. It only
-happens when information is outdated.
-
-Values for HVMs are aggregated with its companion device model stub domain,
-therefore a HVM such as `sys-net` which has 2 VCPUs, with it's device model
-having 1 VCPU, will show 3 VCPUs. Same process is done for other properties when
-applicable.
+The clock shows the last time the screen was refreshed. It only happens when
+information is outdated.
 
 Authors
 -------

--- a/doc/manpages/qvm-top.rst
+++ b/doc/manpages/qvm-top.rst
@@ -52,6 +52,12 @@ General Options
 
    Filter domains name matching each fixed string separated by comma.
 
+.. option:: --thin-columns
+
+    Columns will to be as large as the its header or current lengthiest data. It
+    is not the default because columns will move every time the length of the
+    lengthiest data change.
+
 .. option:: --memory-unit UNIT
 
    Unit to use for displaying memory. The digit after the dot is the precision.

--- a/doc/manpages/qvm-top.rst
+++ b/doc/manpages/qvm-top.rst
@@ -191,6 +191,31 @@ Interaction - Execution
 
    Quit action mode.
 
+Headers
+-------
+
+.. option:: qvm-top
+
+   The clock shows the last time the screen was refreshed.
+
+.. option:: Domains
+
+   Indicates the state of all filtered qubes, and if there are any selected
+   qube.
+
+.. option:: Memory
+
+   - Host indicators:
+
+      - ``total``: How much memory the host has.
+      - ``assigned``: How much memory is made available from the host to the
+        domains.
+
+   - Domain indicators (qubes can lie):
+
+      - ``used``: How much memory the domains allege to use.
+      - ``swap``: How much swap the the domains allege to do.
+
 Columns
 -------
 
@@ -205,37 +230,78 @@ necessary.
 
    Qube's power state.
 
-.. option:: memory_used -> MU
+.. option:: memory_init -> MI
 
-   How much memory the qube alleges to use. This value or part of it is broadcast by the qube, it can be a lie.
-
-.. option:: memory_used_with_swap -> MSU
-
-   How much memory including swap the qube alleges to use. This value or part of it is broadcast by the qube, it can be a lie.
-
-.. option:: memory_assigned -> MS
-
-   How much memory has been assigned to the qube, including videoram. A qube is allowed to claim this amount at any time, and it cannot use more memory than what has been assigned to it. When the system is under no memory pressure, this value is close to ``MM``, while when the system isunder memory pressure, the value can be as low as enough for the qube to survive.
+   How much memory the system must reserve for the qube to be able to
+   initialize. On non-memory-balanced qubes, this is the maximum amount of
+   memory a domain will ever have while it is running.
 
 .. option:: memory_max -> MM
 
-   How much memory the qube can use from the system. Part of this value is reserved to videoram, while the rest is up to qmemman to balloon up this qube when there is enough free memory on the host.
+   How much memory the qube can use from the system. Part of this value is
+   reserved to videoram, while the rest is up to qmemman to balloon up this qube
+   when there is enough free memory on the host.
 
-.. option:: memory_usage_used -> MU/MM
+.. option:: memory_assigned_max_total -> MAMT
 
-   How much memory the qube alleges to use compared to the maximum it canuse from the system, in percentage.
+   ``MAM`` + ``MAMi``.
 
-.. option:: memory_usage_assigned -> MS/MM
+.. option:: memory_assigned_usable_total -> MAUT
 
-   How much memory the qube has assigned compared to the maximum it can use from the system, in percentage. A high percentage means the system is not pressuring the qube to release memory.
+   ``MAU`` + ``MAUi``.
 
-.. option:: memory_usage_used_assigned -> MU/MS
+.. option:: memory_used_total -> MUT
 
-   How much memory the qube alleges to use from the assigned amount, in percentage. A high percentage on non-memory-balanced qubes is irrelevant. On memory balanced qubes, a higher value indicates the qube is using a lot of the memory it has assigned, which might be near exhaustion, if ``MS`` can't be ballooned up anymore.
+   ``MU`` + ``MUi``.
 
-.. option:: memory_usage_used_with_swap -> MSU/MU
+.. option:: cpu_time_total -> CPUsecT
 
-   How much memory the qube alleges to be swaping from what it alleges touse, in percentage. When it is over 10%, the qube might be swaping too much.
+   ``CPUsec`` + ``CPUisec``.
+
+.. option:: online_vcpus_total -> VCT
+
+   ``VC`` + ``VCi``.
+
+.. option:: memory_assigned_max -> MAM
+
+   How much memory has been assigned to the qube, including overhead.
+
+.. option:: memory_assigned_usable -> MAU
+
+   How much memory has been assigned to the qube and can be used. A qube is
+   allowed to claim this amount at any time, and it cannot use more memory than
+   what has been assigned to it. When the system is under no memory pressure,
+   this value is close to ``MM``, while when the system is under memory
+   pressure, the value can be as low as enough for the qube to survive.
+
+.. option:: memory_used_noswap -> MU
+
+   How much memory the qube alleges to use. This value or part of it is
+   broadcast by the qube, it can be a lie.
+
+.. option:: memory_used_swap -> MUS
+
+   How much memory the qube alleges to use for swap. This value or part of it is
+   broadcast by the qube, it can be a lie.
+
+.. option:: memory_usage_assigned -> MAM/MM
+
+   How much memory the qube has assigned compared to the maximum it can have
+   assigned, in percentage. A high percentage means the system is not pressuring
+   the qube to release memory.
+
+.. option:: memory_usage_used -> MU/MAU
+
+   How much memory the qube alleges to use from the assigned amount, in
+   percentage. A high percentage on non-memory-balanced qubes is irrelevant. On
+   memory balanced qubes, a higher value indicates the qube is using a lot of
+   the memory it has assigned, which might be near exhaustion, if ``MAU`` can't
+   be ballooned up anymore.
+
+.. option:: memory_usage_swap_over_used -> MUS/MU
+
+   How much memory the qube alleges to be swaping from what it alleges touse, in
+   percentage. When it is over 10%, the qube might be swaping too much.
 
 .. option:: cpu_time -> CPUsec
 
@@ -249,13 +315,17 @@ necessary.
 
    How many Virtual CPUs are online.
 
-.. option:: memory_used_internal -> MUi
+.. option:: memory_assigned_max_internal -> MAMi
 
-   Same as MU, but internal usage.
+   Same as ``MAM``, but internal usage.
 
-.. option:: memory_assigned_internal -> MSi
+.. option:: memory_assigned_usable_internal -> MAUi
 
-   Same as ``MS``, but internal usage.
+   Same as ``MAU``, but internal usage.
+
+.. option:: memory_used_noswap_internal -> MUi
+
+   Same as ``MU``, but internal usage.
 
 .. option:: cpu_time_internal -> CPUisec
 
@@ -268,28 +338,6 @@ necessary.
 .. option:: online_vcpus_internal -> VCi
 
    Same as ``VC``, but internal usage.
-
-.. option:: memory_used_total -> MUT
-
-   ``MU`` + ``MUi``.
-
-.. option:: memory_assigned_total -> MST
-
-   ``MS`` + ``MSi``.
-
-.. option:: cpu_time_total -> CPUsecT
-
-   ``CPUsec`` + ``CPUisec``.
-
-.. option:: online_vcpus_total -> VCT
-
-   ``VC`` + ``VCi``.
-
-Notes
------
-
-The clock shows the last time the screen was refreshed. It only happens when
-information is outdated.
 
 Authors
 -------

--- a/doc/manpages/qvm-top.rst
+++ b/doc/manpages/qvm-top.rst
@@ -216,6 +216,10 @@ Headers
       - ``used``: How much memory the domains allege to use.
       - ``swap``: How much swap the the domains allege to do.
 
+.. option:: CPUs
+
+   How many cores the CPU has.
+
 Columns
 -------
 

--- a/doc/manpages/qvm-top.rst
+++ b/doc/manpages/qvm-top.rst
@@ -107,11 +107,11 @@ Interaction - Navigation
 
    Scroll half page up or down.
 
-.. option:: Home, ^A
+.. option:: Home, ^A, g
 
    Scroll to the first page.
 
-.. option:: End, ^E
+.. option:: End, ^E, G
 
    Scroll to the last page.
 

--- a/doc/manpages/qvm-top.rst
+++ b/doc/manpages/qvm-top.rst
@@ -66,7 +66,7 @@ Formatting Options
 
 .. option:: --format, -F FORMAT
 
-   Show only columns declared by format: `min`, `default, `max-no-internal`,
+   Show only columns declared by format: `min`, `default`, `max-no-internal`,
    `max`.
 
 .. option:: --help-columns

--- a/doc/manpages/qvm-top.rst
+++ b/doc/manpages/qvm-top.rst
@@ -52,6 +52,11 @@ General Options
 
    Filter domains name matching each fixed string separated by comma.
 
+.. option:: --memory-unit UNIT
+
+   Unit to use for displaying memory. The digit after the dot is the precision.
+   Available: KiB, MiB, GiB.0, GiB.1, GiB.2, GiB.3.
+
 .. option:: --no-color
 
    Do not colorize the screen. If this option is not provided, but environment

--- a/doc/manpages/qvm-top.rst
+++ b/doc/manpages/qvm-top.rst
@@ -237,37 +237,53 @@ Columns
 Columns are identified by a machine header followed by a pretty header if
 necessary.
 
-.. option:: name - NAME
+.. option:: name -> NAME
 
    Qube's name.
 
-.. option:: state - STATE
+.. option:: state -> STATE
 
    Qube's power state.
 
 .. option:: memory_init -> MI
 
-   How much memory the system must reserve for the qube to be able to
-   initialize. On non-memory-balanced qubes, this is the maximum amount of
-   memory a domain will ever have while it is running.
+   How much memory the system must reserve for the qube to be able to initialize. On non-memory-balanced qubes, this is the maximum amount of memory a domain will ever have while it is running.
 
 .. option:: memory_max -> MM
 
-   How much memory the qube can use from the system. Part of this value is
-   reserved to videoram, while the rest is up to qmemman to balloon up this qube
-   when there is enough free memory on the host.
+   How much memory the qube can use from the system. Part of this value is reserved to videoram, while the rest is up to qmemman to balloon up this qube when there is enough free memory on the host.
 
-.. option:: memory_assigned_max_total -> MAMT
+.. option:: memory_assigned_max -> MAM
 
-   ``MAM`` + ``MAMi``.
+   How much memory has been assigned to the qube, including overhead of videoram and internal usage.
 
-.. option:: memory_assigned_usable_total -> MAUT
+.. option:: memory_assigned_usable -> MAU
 
-   ``MAU`` + ``MAUi``.
+   How much memory has been assigned to the qube and can be used. A qube is allowed to claim this amount at any time, and it cannot use more memory than what has been assigned to it. When the system is under memory pressure, the value can be just low enough for the qube to survive.
 
 .. option:: memory_used_total -> MUT
 
    ``MU`` + ``MUi``.
+
+.. option:: memory_used_noswap -> MU
+
+   How much memory the qube alleges to use. This value or part of it is broadcast by the qube, it can be a lie.
+
+.. option:: swap_used -> SU
+
+   How much swap the qube alleges to use. This value or part of it is broadcast by the qube, it can be a lie.
+
+.. option:: memory_usage_assigned -> MAM/MM
+
+   How much memory the qube has assigned compared to the maximum it can have assigned, in percentage. A high percentage means the system is not pressuring the qube to release memory.
+
+.. option:: memory_usage_used -> MU/MAU
+
+   How much memory the qube alleges to use from the assigned amount, in percentage. A high percentage on non-memory-balanced qubes is irrelevant. On memory balanced qubes, a higher value indicates the qube is using a lot of the memory it has assigned, which might be near exhaustion, if ``MAU`` can't be ballooned up anymore.
+
+.. option:: memory_usage_swap_over_used -> SU/MU
+
+   How much swap the qube alleges to do from how much memory it alleges to use, in percentage. When it is over 10%, the qube might be swaping too much.
 
 .. option:: cpu_time_total -> CPUsecT
 
@@ -276,47 +292,6 @@ necessary.
 .. option:: online_vcpus_total -> VCT
 
    ``VC`` + ``VCi``.
-
-.. option:: memory_assigned_max -> MAM
-
-   How much memory has been assigned to the qube, including overhead.
-
-.. option:: memory_assigned_usable -> MAU
-
-   How much memory has been assigned to the qube and can be used. A qube is
-   allowed to claim this amount at any time, and it cannot use more memory than
-   what has been assigned to it. When the system is under no memory pressure,
-   this value is close to ``MM``, while when the system is under memory
-   pressure, the value can be as low as enough for the qube to survive.
-
-.. option:: memory_used_noswap -> MU
-
-   How much memory the qube alleges to use. This value or part of it is
-   broadcast by the qube, it can be a lie.
-
-.. option:: memory_used_swap -> MUS
-
-   How much memory the qube alleges to use for swap. This value or part of it is
-   broadcast by the qube, it can be a lie.
-
-.. option:: memory_usage_assigned -> MAM/MM
-
-   How much memory the qube has assigned compared to the maximum it can have
-   assigned, in percentage. A high percentage means the system is not pressuring
-   the qube to release memory.
-
-.. option:: memory_usage_used -> MU/MAU
-
-   How much memory the qube alleges to use from the assigned amount, in
-   percentage. A high percentage on non-memory-balanced qubes is irrelevant. On
-   memory balanced qubes, a higher value indicates the qube is using a lot of
-   the memory it has assigned, which might be near exhaustion, if ``MAU`` can't
-   be ballooned up anymore.
-
-.. option:: memory_usage_swap_over_used -> MUS/MU
-
-   How much memory the qube alleges to be swaping from what it alleges touse, in
-   percentage. When it is over 10%, the qube might be swaping too much.
 
 .. option:: cpu_time -> CPUsec
 
@@ -329,18 +304,6 @@ necessary.
 .. option:: online_vcpus -> VC
 
    How many Virtual CPUs are online.
-
-.. option:: memory_assigned_max_internal -> MAMi
-
-   Same as ``MAM``, but internal usage.
-
-.. option:: memory_assigned_usable_internal -> MAUi
-
-   Same as ``MAU``, but internal usage.
-
-.. option:: memory_used_noswap_internal -> MUi
-
-   Same as ``MU``, but internal usage.
 
 .. option:: cpu_time_internal -> CPUisec
 

--- a/doc/qubesadmin.tools.rst
+++ b/doc/qubesadmin.tools.rst
@@ -196,6 +196,14 @@ qubesadmin\.tools\.qvm\_template\_postprocess module
     :undoc-members:
     :show-inheritance:
 
+qubesadmin\.tools\.qvm\_top module
+----------------------------------------------------
+
+.. automodule:: qubesadmin.tools.qvm_top
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 qubesadmin\.tools\.qvm\_unpause module
 --------------------------------------
 

--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -784,13 +784,8 @@ class QubesBase(qubesadmin.base.PropertyHolder):
                                   event: str, **kwargs) -> None:
         """Update cached VM power state.
 
-        This method is designed to be hooked as an event handler for:
-        - domain-pre-start
-        - domain-start
-        - domain-shutdown
-        - domain-paused
-        - domain-unpaused
-        - domain-start-failed
+        This method is designed to be hooked as an event handler for
+        :py:data:`qubesadmin.events.POWER_EVENTS`.
 
         This is done in :py:class:`qubesadmin.events.EventsDispatcher` class
         directly, before calling other handlers.
@@ -806,16 +801,27 @@ class QubesBase(qubesadmin.base.PropertyHolder):
 
         if event == "domain-pre-start":
             power_state = "Transient"
+        elif event == "domain-start-failed":
+            power_state = "Halted"
         elif event == "domain-start":
             power_state = "Running"
-        elif event == "domain-shutdown":
-            power_state = "Halted"
+
         elif event == "domain-paused":
             power_state = "Paused"
         elif event == "domain-unpaused":
             power_state = "Running"
-        elif event == "domain-start-failed":
+        elif event == "domain-suspended":
+            power_state = "Suspended"
+        elif event == "domain-resumed":
+            power_state = "Running"
+
+        elif event == "domain-pre-shutdown":
+            power_state = "Transient"
+        elif event == "domain-shutdown-failed":
+            power_state = "Running"
+        elif event == "domain-shutdown":
             power_state = "Halted"
+
         else:
             # unknown power state change, drop cached power state
             power_state = None

--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -816,7 +816,7 @@ class QubesBase(qubesadmin.base.PropertyHolder):
             power_state = "Running"
 
         elif event == "domain-pre-shutdown":
-            power_state = "Transient"
+            power_state = "Halting"
         elif event == "domain-shutdown-failed":
             power_state = "Running"
         elif event == "domain-shutdown":

--- a/qubesadmin/events/__init__.py
+++ b/qubesadmin/events/__init__.py
@@ -36,6 +36,20 @@ from qubesadmin.vm import QubesVM
 Handler: typing.TypeAlias\
     = Callable[[QubesVM | None, str, ...], Any]  # noqa: ANN401
 
+POWER_EVENTS = [
+    "domain-pre-start",
+    "domain-start-failed",
+    "domain-start",
+    "domain-paused",
+    "domain-unpaused",
+    "domain-suspended",
+    "domain-resumed",
+    "domain-pre-shutdown",
+    "domain-shutdown-failed",
+    "domain-shutdown",
+]
+
+
 class EventsDispatcher:
     ''' Events dispatcher, responsible for receiving events and calling
     appropriate handlers'''
@@ -243,9 +257,7 @@ class EventsDispatcher:
         if event.startswith('property-set:') or \
                 event.startswith('property-reset:'):
             self.app._invalidate_cache(subject, event, **kwargs)
-        elif event in ('domain-pre-start', 'domain-start', 'domain-shutdown',
-                       'domain-paused', 'domain-unpaused',
-                       'domain-start-failed'):
+        elif event in POWER_EVENTS:
             assert subject is not None
             self.app._update_power_state_cache(subject, event, **kwargs)
             subject.devices.clear_cache()

--- a/qubesadmin/tests/tools/qvm_ls.py
+++ b/qubesadmin/tests/tools/qvm_ls.py
@@ -307,35 +307,43 @@ class TC_80_Power_state_filters(qubesadmin.tests.QubesTestCase):
             [
                 ('a', TestVM('a', power_state='Halted')),
                 ('b', TestVM('b', power_state='Transient')),
-                ('c', TestVM('c', power_state='Running'))
+                ('bb', TestVM('bb', power_state='Starting')),
+                ('c', TestVM('c', power_state='Running')),
+                ('d', TestVM('d', power_state='Halting')),
             ]
         )
 
     def test_100_nofilter(self):
         with qubesadmin.tests.tools.StdoutBuffer() as stdout:
-            qubesadmin.tools.qvm_ls.main([], app=self.app)
+            qubesadmin.tools.qvm_ls.main(['--raw-list'], app=self.app)
         self.assertEqual(stdout.getvalue(),
-            'NAME  STATE      CLASS   LABEL  TEMPLATE  NETVM\n'
-            'a     Halted     TestVM  -      -         -\n'
-            'b     Transient  TestVM  -      -         -\n'
-            'c     Running    TestVM  -      -         -\n')
+            'a\n'
+            'b\n'
+            'bb\n'
+            'c\n'
+            'd\n'
+        )
 
     def test_100_running(self):
         with qubesadmin.tests.tools.StdoutBuffer() as stdout:
-            qubesadmin.tools.qvm_ls.main(['--running'], app=self.app)
+            qubesadmin.tools.qvm_ls.main(
+                ['--raw-list', '--running'],
+                app=self.app
+            )
         self.assertEqual(stdout.getvalue(),
-            'NAME  STATE    CLASS   LABEL  TEMPLATE  NETVM\n'
-            'c     Running  TestVM  -      -         -\n')
+            'c\n'
+        )
 
     def test_100_running_or_halted(self):
         with qubesadmin.tests.tools.StdoutBuffer() as stdout:
-            qubesadmin.tools.qvm_ls.main(['--running', '--halted'],
-                                         app=self.app)
+            qubesadmin.tools.qvm_ls.main(
+                ['--raw-list', '--running', '--halted'],
+                app=self.app
+            )
         self.assertEqual(stdout.getvalue(),
-            'NAME  STATE    CLASS   LABEL  TEMPLATE  NETVM\n'
-            'a     Halted   TestVM  -      -         -\n'
-            'c     Running  TestVM  -      -         -\n')
-
+            'a\n'
+            'c\n'
+        )
 
 class TC_90_List_with_qubesd_calls(qubesadmin.tests.QubesTestCase):
     def test_100_list_with_status(self):

--- a/qubesadmin/tests/vm/properties.py
+++ b/qubesadmin/tests/vm/properties.py
@@ -291,6 +291,26 @@ class TC_01_SpecialCases(qubesadmin.tests.vm.VMTestCase):
         self.assertFalse(self.vm.is_paused())
         self.assertFalse(self.vm.is_suspended())
 
+    def test_012_power_state_starting(self):
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.CurrentState', None, None)] = \
+            b'0\x00power_state=Starting'
+        self.assertEqual(self.vm.get_power_state(), 'Starting')
+        self.assertTrue(self.vm.is_running())
+        self.assertFalse(self.vm.is_halted())
+        self.assertFalse(self.vm.is_paused())
+        self.assertFalse(self.vm.is_suspended())
+
+    def test_012_power_state_halting(self):
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.CurrentState', None, None)] = \
+            b'0\x00power_state=Halting'
+        self.assertEqual(self.vm.get_power_state(), 'Halting')
+        self.assertTrue(self.vm.is_running())
+        self.assertFalse(self.vm.is_halted())
+        self.assertFalse(self.vm.is_paused())
+        self.assertFalse(self.vm.is_suspended())
+
     def test_013_power_state_suspended(self):
         self.app.expected_calls[
             ('test-vm', 'admin.vm.CurrentState', None, None)] = \

--- a/qubesadmin/tools/__init__.py
+++ b/qubesadmin/tools/__init__.py
@@ -170,14 +170,21 @@ class VmNameAction(QubesAction):
         assert hasattr(namespace, 'app')
         setattr(namespace, 'domains', [])
         app = namespace.app
-        if hasattr(namespace, 'all_domains') and namespace.all_domains:
+        if (
+            hasattr(namespace, 'all_domains')
+            and namespace.all_domains
+            and not getattr(namespace, 'VMNAME')
+        ):
             namespace.domains = [
                 vm
                 for vm in app.domains
-                if not vm.klass == 'AdminVM' and
-                   vm.name not in namespace.exclude
+                if (
+                    namespace.all_domains == "global"
+                    or not vm.klass == 'AdminVM'
+                ) and vm.name not in namespace.exclude
             ]
         else:
+            setattr(namespace, 'all_domains', False)
             if hasattr(namespace, 'exclude') and namespace.exclude:
                 parser.error('--exclude can only be used with --all')
 
@@ -333,7 +340,7 @@ class QubesArgumentParser(argparse.ArgumentParser):
     '''
 
     def __init__(self, vmname_nargs=None, show_forceroot=False, version=None, \
-            **kwargs):
+            all_default=False, all_include_adminvm=False, **kwargs):
 
         super().__init__(add_help=False, **kwargs)
 
@@ -380,7 +387,8 @@ class QubesArgumentParser(argparse.ArgumentParser):
             self.add_argument('--version', action='version')
 
         if self._vmname_nargs in [argparse.ZERO_OR_MORE, argparse.ONE_OR_MORE]:
-            vm_name_group = VmNameGroup(self,
+            vm_name_group = VmNameGroup(self, all_default=all_default,
+                all_include_adminvm=all_include_adminvm,
                 required=(self._vmname_nargs
                           not in [argparse.ZERO_OR_MORE, argparse.OPTIONAL]))
             self._mutually_exclusive_groups.append(vm_name_group)
@@ -556,13 +564,16 @@ class VmNameGroup(argparse._MutuallyExclusiveGroup):
         :py:class:``argparse.ArgumentParser```.
     '''
 
-    def __init__(self, container, required, vm_action=VmNameAction, help=None):
+    def __init__(self, container, required, vm_action=VmNameAction,\
+            all_default=False, all_include_adminvm=False, help=None):
         # pylint: disable=redefined-builtin
         super().__init__(container, required=required)
         if not help:
             help = 'perform the action on all qubes'
+        if all_default and all_include_adminvm:
+            all_default = "global"
         self.add_argument('--all', action='store_true', dest='all_domains',
-                          help=help)
+                          default=all_default, help=help)
         container.add_argument('--exclude', action='append', default=[],
                                help='exclude the qube from --all')
 

--- a/qubesadmin/tools/qvm_ls.py
+++ b/qubesadmin/tools/qvm_ls.py
@@ -128,8 +128,7 @@ def _format_flags(vm: QubesVM) -> str:
       1  type: 0=AdminVM, a/A=AppVM, d/D=DispVM, s/S=StandaloneVM,
                 t/T=TemplateVM
                (uppercase = HVM)
-      2  power state: r=running, t=transient, p=paused, s=suspended,
-                      h=halting, d=dying, c=crashed, ?=unknown
+      2  power state: See ``qubesadmin.vm.POWER_STATES``
       3  U  updateable
       4  N  provides_network
       5  R  installed_by_rpm
@@ -146,12 +145,9 @@ def _format_flags(vm: QubesVM) -> str:
         if getattr(vm, 'virt_mode', 'pv') == 'hvm':
             type_letter = type_letter.upper()
 
-    state = vm.get_power_state().lower()
-    if state == 'unknown':
-        power_letter = '?'
-    elif state in ('running', 'transient', 'paused', 'suspended',
-                   'halting', 'dying', 'crashed'):
-        power_letter = state[0]
+    state = vm.get_power_state()
+    if state in qubesadmin.vm.POWER_STATES:
+        power_letter = qubesadmin.vm.POWER_STATES[state]["short"]
     else:
         power_letter = '-'
 

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -100,6 +100,7 @@ async def exec_and_check(*args):
             returncode=proc.returncode, cmd=[*args], output=outerr
         )
 
+
 async def console(qubes: list[QubesVM]) -> None:
     """
     Get debug console for provided qubes.
@@ -268,7 +269,7 @@ class Stats:
 
         self.features_default = {"gui": True, "internal": False}
         self.state: str = "NA"
-        self.label: Label | None = None
+        self.label: Label | str = ""
         self.is_preload: bool = False
         self.gui: bool = True
         self.internal: bool = False
@@ -547,53 +548,48 @@ class Stats:
         self.set_verbose({name: value})
 
 
-class Monitor:
+class Screen:
     """
-    Logic responsible for monitoring events and showing statistics on the
-    screen.
+    Organize the screen for drawing, scrolling, typing.
     """
 
     # pylint: disable=too-many-instance-attributes
-
     def __init__(
         self,
         app: QubesBase,
-        domains: list[QubesVM],
-        dispatcher: EventsDispatcher,
-        stats_dispatcher: EventsDispatcher,
         show_halted: bool,
-        all_domains: bool,
         allow_color: bool,
+        filter_query: str,
+        sort_reverse: bool,
+        sort_col_index: int | None,
         columns: dict[str, "Column"],
-        sort_reverse: bool = False,
-        sort_column: str | None = None,
-        filter_query: str = "",
-    ) -> None:
+    ):
         # pylint: disable=too-many-positional-arguments
-        self.app = app
-        self.domains = domains
-        self.dispatcher = dispatcher
-        self.stats_dispatcher = stats_dispatcher
-        self.all_domains = all_domains
-        self.show_halted = show_halted
         self.allow_color = allow_color
-        self.columns = columns
-        self.sort_reverse = sort_reverse
-        if sort_column is None:
-            self.sort_col_index: int | None = None
-        else:
-            self.sort_col_index = list(self.columns.keys()).index(sort_column)
+        self.app = app
+        self.show_halted = show_halted
         self.filter_query = filter_query
+        self.filter = False
+        self.sort_reverse = sort_reverse
+        self.sort_col_index = sort_col_index
+        self.columns = columns
 
         self.log = gen_logger(f"{self.__class__.__qualname__}")
-        root_logger = getLogger()
-        root_logger.setLevel(LOGGING_LEVEL)
-        root_logger.handlers.clear()
-        root_logger.addHandler(self.log.handlers[0])
-
-        self.headers = " ".join(col.header for col in self.columns.values())
+        self.getch_timeout = 1000
         self.version: str = metadata("qubesadmin")["version"]
-        self.entries: dict[QubesVM, Stats] = {}
+        self.headers = " ".join(col.header for col in self.columns.values())
+
+        self.selected_stats: list[Stats] = []
+        self._stats: list[Stats] | None = None
+
+        self.header_row = 3
+        self.old_cursor_row = 0
+        self.visible_stats: dict[int, Stats] = {}
+        self.visible_actions: dict[int, str] = {}
+        self.act = False
+        self.actions: list[str] = []
+        self.label_index = 0
+
         self.scroll_offset = 0
         self.max_offset = 0
         self.action_scroll_offset = 0
@@ -604,36 +600,33 @@ class Monitor:
         self.cursor_row = 0
         self.outdated_sleep = 0.010
         self.uptodate_sleep = 0.1
-        self.getch_timeout = 1000
-        self._stats: list[Stats] | None = None
         self._old_cursor_visibility = 0
-        self.selected_stats: list[Stats] = []
+
         self.last_selected_stat: Stats | None = None
         self.last_selected_row: int | None = None
-        self.header_row = 3
-        self.old_cursor_row = 0
-        self.visible_stats: dict[int, Stats] = {}
-        self.visible_actions: dict[int, str] = {}
-        self.filter = False
-        self.act = False
-        self.actions: list[str] = []
-        self.label_index = 0
 
-    def init_label(self, label) -> None:
+    def init_label(self, label: Label | str) -> Label | None:
         """
         Initialize colors from qube labels.
         """
+        if not curses.can_change_color():
+            return None
+        if isinstance(label, str):
+            label = self.app.labels[label]
         name: str = label.name
         color: str = label.color
+        if name in self.label_colors:
+            return label
         index = self.label_index
         if name == "black":
             self.label_colors[name] = self.colors["FG_DEFAULT"]
-            return
+            return label
         r1000, g1000, b1000 = convert_html_color_to_curses(color)
         curses.init_color(index, r1000, g1000, b1000)
         curses.init_pair(index, index, -1)
         self.label_colors[name] = curses.color_pair(index)
         self.label_index += 1
+        return label
 
     def init_screen(self) -> None:
         """
@@ -768,178 +761,6 @@ class Monitor:
             pass
         curses.endwin()
 
-    def init_entries(self) -> None:
-        """
-        Initialize statistics holder for all qubes.
-        """
-        for vm in sorted(
-            [vm for vm in self.app.domains if vm.klass == "AdminVM"]
-        ):
-            self.add_domain(submitter=None, vm=vm, event=None)
-        for vm in sorted(
-            [vm for vm in self.app.domains if vm not in self.entries]
-        ):
-            self.add_domain(submitter=None, vm=vm, event=None)
-
-    def update_stats(self, vm: QubesVM, _event: str, **kwargs: Any) -> None:
-        """
-        Rpead vm-stats and update qube statistics.
-        """
-        # pylint: disable=missing-function-docstring
-        if vm not in self.entries:
-            return
-        self.entries[vm].update_stats(**kwargs)
-
-    def refresh_all_items(
-        self, submitter: QubesVM | None, _event: str, **_kwargs: Any
-    ) -> None:
-        """
-        Reconnected to the API, check if all entries are up to date.
-        """
-        # pylint: disable= unused-argument
-        items_to_delete = [
-            vm for vm in self.entries if vm not in self.app.domains
-        ]
-        for vm in items_to_delete:
-            self.remove_domain(submitter=None, vm=vm, event=None)
-        for vm in self.app.domains:
-            self.update_domain_item(vm=vm, event=None)
-
-    def add_domain(
-        self,
-        submitter: QubesVM | None,
-        event: str | None,
-        vm: QubesVM,
-        **kwargs: Any,
-    ) -> None:
-        """
-        Add qube to the statistics holder.
-        """
-        # pylint: disable= unused-argument
-        if str(vm) in self.entries:
-            return
-        try:
-            vm = self.app.domains[str(vm)]
-        except KeyError:
-            return
-
-        self.log.debug("add=%s", str(vm))
-        try:
-            self.entries[vm] = Stats(vm)
-        except QubesVMNotFoundError:
-            self.log.debug("Qube removed while adding its entry: %s", str(vm))
-            self.remove_domain(submitter=None, vm=vm, event=event)
-        if self.all_domains:
-            self.domains.append(vm)
-
-    def remove_domain(
-        self,
-        submitter: QubesVM | None,
-        event: str | None,
-        vm: QubesVM,
-        **kwargs: Any,
-    ) -> None:
-        """
-        Remove qube from the statistics holder.
-        """
-        # pylint: disable=unused-argument
-        if str(vm) not in self.entries:
-            return
-        self.log.debug("remove=%s", str(vm))
-        if vm in self.domains:
-            Stats.outdated_by_removal.append(str(vm))
-        if self.entries[vm] in self.selected_stats:
-            self.selected_stats.remove(self.entries[vm])
-        del self.entries[vm]
-
-    def get_entry(self, vm: QubesVM, event: str | None) -> Stats | None:
-        """
-        Safely get ``Stats`` if qube can be accessed, else, remove the entry and
-        return ``None``.
-        """
-        try:
-            item = self.entries[vm]
-        except QubesPropertyAccessError as e:
-            self.log.exception(e)
-            self.remove_domain(submitter=None, vm=vm, event=event)
-            return None
-        return item
-
-    def update_domain_item(
-        self, vm: QubesVM, event: str | None, **kwargs: Any
-    ) -> None:
-        """
-        Fully update the statistics holder of the qube.
-        """
-        # pylint: disable=unused-argument
-        try:
-            item = self.get_entry(vm=vm, event=event)
-            if item is None:
-                return
-        except KeyError:
-            self.add_domain(submitter=None, vm=vm, event=event)
-            if not vm in self.entries:
-                return
-            item = self.entries[vm]
-        try:
-            item.update_cache()
-        except QubesVMNotFoundError:
-            self.log.debug("Qube removed while updating cache: %s", str(vm))
-            self.remove_domain(submitter=None, vm=vm, event=event)
-
-    def set_generic(
-        self, vm, event, name, newvalue=None, oldvalue=None
-    ) -> None:
-        """
-        Update attributes of the qube's statistics holder.
-        """
-        # pylint: disable=unused-argument
-        if not (item := self.get_entry(vm=vm, event=event)):
-            return
-        self.log.debug("update -> %s=%s(%s)", name, vm.name, newvalue)
-        if name == "maxmem":
-            item.update_memory_max(value=newvalue)
-        elif name == "label":
-            if (
-                newvalue.name not in self.label_colors
-                and curses.can_change_color()
-            ):
-                self.init_label(label=newvalue)
-            else:
-                newvalue = "@invalid"
-        else:
-            item.update_generic(name=name, value=newvalue)
-
-    def set_feat_generic(
-        self, vm, event, feature, value, oldvalue=None
-    ) -> None:
-        """
-        Update feature attributes of the qube's statistics holder.
-        """
-        # pylint: disable=unused-argument
-        if not (item := self.get_entry(vm=vm, event=event)):
-            return
-        self.log.debug("update -> %s=%s(%s)", feature, vm.name, value)
-        item.update_generic(name=feature, value=value)
-        for qube in vm.derived_vms:
-            if qube not in self.entries:
-                continue
-            self.entries[qube].update_feat_from_template(name=feature)
-
-    def del_feat_generic(self, vm, event, feature) -> None:
-        """
-        Update feature attributes of the qube's statistics holder.
-        """
-        # pylint: disable=unused-argument
-        if not (item := self.get_entry(vm=vm, event=event)):
-            return
-        self.log.debug("update del -> %s=%s", feature, vm.name)
-        item.update_feat_from_template(name=feature)
-        for qube in vm.derived_vms:
-            if qube not in self.entries:
-                continue
-            self.entries[qube].update_feat_from_template(name=feature)
-
     def write(self, *args: Any, **kwargs: Any) -> None:
         """
         Set screen text and attributes and deal with errors without panic.
@@ -960,6 +781,36 @@ class Monitor:
             if attr is not None:
                 self.stdscr.attroff(attr)
 
+    def get_selection(self) -> list[Stats]:
+        """
+        Get selected qube. If none is selected, consider the last one the
+        cursor was in.
+        """
+        stats = self.selected_stats
+        if not stats and self.last_selected_stat:
+            stats = [self.last_selected_stat]
+        if not stats:
+            stats = []
+        return stats
+
+    def get_action_from_selection(self) -> list[str]:
+        """
+        List common actions that is valid for all selected qubes.
+        """
+        stats = self.get_selection()
+        if not stats:
+            return []
+        actions = []
+        all_actions = []
+        for stat in stats:
+            if not (stat_actions := stat.get_actions()):
+                return []
+            all_actions.append(stat_actions)
+        actions = list(set.intersection(*(set(x) for x in all_actions)))
+        actions = sorted(actions, key=lambda k: int(ACTIONS[k]["identity"]))
+        self.log.debug("available-actions=%s", actions)
+        return actions
+
     def get_stats(self):
         """
         Qubes that can be shown.
@@ -970,9 +821,9 @@ class Monitor:
         self._stats = sorted(
             [
                 stats
-                for stats in self.entries.values()
+                for stats in Monitor.entries.values()
                 if (self.show_halted or stats.state != "Halted")
-                and stats.vm in self.domains
+                and stats.vm in Monitor.domains
                 and (
                     (not self.filter_query and not self.filter)
                     or any(
@@ -1026,36 +877,6 @@ class Monitor:
             outdated,
         )
         return uptodate
-
-    def get_selection(self) -> list[Stats]:
-        """
-        Get selected qube. If none is selected, consider the last one the
-        cursor was in.
-        """
-        stats = self.selected_stats
-        if not stats and self.last_selected_stat:
-            stats = [self.last_selected_stat]
-        if not stats:
-            stats = []
-        return stats
-
-    def get_action_from_selection(self) -> list[str]:
-        """
-        List common actions that is valid for all selected qubes.
-        """
-        stats = self.get_selection()
-        if not stats:
-            return []
-        actions = []
-        all_actions = []
-        for stat in stats:
-            if not (stat_actions := stat.get_actions()):
-                return []
-            all_actions.append(stat_actions)
-        actions = list(set.intersection(*(set(x) for x in all_actions)))
-        actions = sorted(actions, key=lambda k: int(ACTIONS[k]["identity"]))
-        self.log.debug("available-actions=%s", actions)
-        return actions
 
     def draw_table(self) -> None:
         """
@@ -1598,7 +1419,6 @@ class Monitor:
                 return True
 
         if char in (ord("q"), ord("Q"), ESC):
-            self.unregister_events()
             raise KeyboardInterrupt
 
         old_sort_col_index = self.sort_col_index
@@ -1798,6 +1618,218 @@ class Monitor:
                     continue
                 break
 
+
+class Monitor:
+    """
+    Monitor and react to events.
+    """
+
+    entries: dict[QubesVM, Stats] = {}
+    domains: list[QubesVM]
+
+    def __init__(
+        self,
+        app: QubesBase,
+        domains: list[QubesVM],
+        dispatcher: EventsDispatcher,
+        stats_dispatcher: EventsDispatcher,
+        show_halted: bool,
+        all_domains: bool,
+        allow_color: bool,
+        columns: dict[str, "Column"],
+        sort_reverse: bool = False,
+        sort_column: str | None = None,
+        filter_query: str = "",
+    ) -> None:
+        # pylint: disable=too-many-positional-arguments
+        self.app = app
+        self.__class__.domains = domains
+        self.dispatcher = dispatcher
+        self.stats_dispatcher = stats_dispatcher
+        self.all_domains = all_domains
+        sort_col_index: int | None = None
+        if sort_column is not None:
+            sort_col_index = list(columns.keys()).index(sort_column)
+        self.screen = Screen(
+            app=self.app,
+            show_halted=show_halted,
+            allow_color=allow_color,
+            filter_query=filter_query,
+            sort_reverse=sort_reverse,
+            sort_col_index=sort_col_index,
+            columns=columns,
+        )
+        self.log = gen_logger(f"{self.__class__.__qualname__}")
+        root_logger = getLogger()
+        root_logger.setLevel(LOGGING_LEVEL)
+        root_logger.handlers.clear()
+        root_logger.addHandler(self.log.handlers[0])
+
+    def init_entries(self) -> None:
+        """
+        Initialize statistics holder for all qubes.
+        """
+        for vm in sorted(
+            [vm for vm in self.app.domains if vm.klass == "AdminVM"]
+        ):
+            self.add_domain(submitter=None, vm=vm, event=None)
+        for vm in sorted(
+            [vm for vm in self.app.domains if vm not in self.__class__.entries]
+        ):
+            self.add_domain(submitter=None, vm=vm, event=None)
+
+    def update_stats(self, vm: QubesVM, _event: str, **kwargs: Any) -> None:
+        """
+        Read vm-stats and update qube statistics.
+        """
+        if vm not in self.__class__.entries:
+            return
+        self.__class__.entries[vm].update_stats(**kwargs)
+
+    def refresh_all_items(
+        self, submitter: QubesVM | None, _event: str, **_kwargs: Any
+    ) -> None:
+        """
+        Reconnected to the API, check if all entries are up to date.
+        """
+        # pylint: disable=unused-argument
+        items_to_delete = [
+            vm for vm in self.__class__.entries if vm not in self.app.domains
+        ]
+        for vm in items_to_delete:
+            self.remove_domain(submitter=None, vm=vm, event=None)
+        for vm in self.app.domains:
+            self.update_domain_item(vm=vm, event=None)
+
+    def add_domain(
+        self,
+        submitter: QubesVM | None,
+        event: str | None,
+        vm: QubesVM,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Add qube to the statistics holder.
+        """
+        # pylint: disable=unused-argument
+        if str(vm) in self.__class__.entries:
+            return
+        try:
+            vm = self.app.domains[str(vm)]
+        except KeyError:
+            return
+
+        self.log.debug("add=%s", str(vm))
+        try:
+            self.__class__.entries[vm] = Stats(vm)
+        except QubesVMNotFoundError:
+            self.log.debug("Qube removed while adding its entry: %s", str(vm))
+            self.remove_domain(submitter=None, vm=vm, event=event)
+        if self.all_domains:
+            self.__class__.domains.append(vm)
+
+    def remove_domain(
+        self,
+        submitter: QubesVM | None,
+        event: str | None,
+        vm: QubesVM,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Remove qube from the statistics holder.
+        """
+        # pylint: disable=unused-argument
+        if str(vm) not in self.__class__.entries:
+            return
+        self.log.debug("remove=%s", str(vm))
+        if vm in self.__class__.domains:
+            Stats.outdated_by_removal.append(str(vm))
+        if self.__class__.entries[vm] in self.screen.selected_stats:
+            self.screen.selected_stats.remove(self.__class__.entries[vm])
+        del self.__class__.entries[vm]
+
+    def get_entry(self, vm: QubesVM, event: str | None) -> Stats | None:
+        """
+        Safely get ``Stats`` if qube can be accessed, else, remove the entry and
+        return ``None``.
+        """
+        try:
+            item = self.__class__.entries[vm]
+        except QubesPropertyAccessError as e:
+            self.log.exception(e)
+            self.remove_domain(submitter=None, vm=vm, event=event)
+            return None
+        return item
+
+    def update_domain_item(
+        self, vm: QubesVM, event: str | None, **kwargs: Any
+    ) -> None:
+        """
+        Fully update the statistics holder of the qube.
+        """
+        # pylint: disable=unused-argument
+        try:
+            item = self.get_entry(vm=vm, event=event)
+            if item is None:
+                return
+        except KeyError:
+            self.add_domain(submitter=None, vm=vm, event=event)
+            if not vm in self.__class__.entries:
+                return
+            item = self.__class__.entries[vm]
+        try:
+            item.update_cache()
+        except QubesVMNotFoundError:
+            self.log.debug("Qube removed while updating cache: %s", str(vm))
+            self.remove_domain(submitter=None, vm=vm, event=event)
+
+    def set_generic(
+        self, vm, event, name, newvalue=None, oldvalue=None
+    ) -> None:
+        """
+        Update attributes of the qube's statistics holder.
+        """
+        # pylint: disable=unused-argument
+        if not (item := self.get_entry(vm=vm, event=event)):
+            return
+        self.log.debug("update -> %s=%s(%s)", name, vm.name, newvalue)
+        if name == "maxmem":
+            item.update_memory_max(value=newvalue)
+            return
+        if name == "label":
+            newvalue = self.screen.init_label(label=newvalue)
+        item.update_generic(name=name, value=newvalue)
+
+    def set_feat_generic(
+        self, vm, event, feature, value, oldvalue=None
+    ) -> None:
+        """
+        Update feature attributes of the qube's statistics holder.
+        """
+        # pylint: disable=unused-argument
+        if not (item := self.get_entry(vm=vm, event=event)):
+            return
+        self.log.debug("update -> %s=%s(%s)", feature, vm.name, value)
+        item.update_generic(name=feature, value=value)
+        for qube in vm.derived_vms:
+            if qube not in self.__class__.entries:
+                continue
+            self.__class__.entries[qube].update_feat_from_template(name=feature)
+
+    def del_feat_generic(self, vm, event, feature) -> None:
+        """
+        Update feature attributes of the qube's statistics holder.
+        """
+        # pylint: disable=unused-argument
+        if not (item := self.get_entry(vm=vm, event=event)):
+            return
+        self.log.debug("update del -> %s=%s", feature, vm.name)
+        item.update_feat_from_template(name=feature)
+        for qube in vm.derived_vms:
+            if qube not in self.__class__.entries:
+                continue
+            self.__class__.entries[qube].update_feat_from_template(name=feature)
+
     async def run(self) -> None:
         """
         Run initial setup.
@@ -1808,13 +1840,14 @@ class Monitor:
         try:
             # Allow registering events.
             await sleep(0)
-            self.init_screen()
-            await self.paint()
+            self.screen.init_screen()
+            await self.screen.paint()
         except BaseException as e:
             exc_data = exc_info()
             self.log.exception(e)
         finally:
-            self.restore_screen()
+            self.unregister_events()
+            self.screen.restore_screen()
             if exc_data:
                 print_exception(*exc_data, file=stderr)
 
@@ -1867,11 +1900,14 @@ class Column:
         doc: str | None = None,
         right_justify: bool = True,
         percentage: bool = False,
-        percentage_intensity: list[int] = [75, 50],
+        percentage_intensity: list[int] | None = None,
     ):
         # pylint: disable=too-many-positional-arguments
         self.percentage = percentage
-        self.percentage_intensity = percentage_intensity
+        if percentage_intensity is None:
+            self.percentage_intensity = [75, 50]
+        else:
+            self.percentage_intensity = percentage_intensity
         self.__doc__ = doc
         if isinstance(width, int):
             self.width = width

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -1,0 +1,2259 @@
+#!/usr/bin/env python3
+#
+# SPDX-FileCopyrightText: 2025 - 2026 Benjamin Grande <ben.grande.b@gmail.com>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+"""
+Top-like info for Qubes.
+
+Visuals from htop and xentop.
+"""
+
+import curses
+
+from argparse import Action, SUPPRESS, ArgumentTypeError
+from asyncio import (
+    CancelledError,
+    create_subprocess_exec,
+    create_task,
+    ensure_future,
+    gather,
+    run,
+    sleep,
+    to_thread,
+)
+from asyncio.subprocess import PIPE, STDOUT, DEVNULL
+from asyncio.subprocess import subprocess as async_subprocess
+from collections import Counter
+from curses.ascii import (
+    ESC,
+    STX,
+    NAK,
+    EOT,
+    ACK,
+    SOH,
+    ENQ,
+    DLE,
+    SO,
+    FF,
+    SP,
+    CR,
+)
+from importlib.metadata import metadata
+from logging import getLogger, Formatter, Logger, DEBUG, INFO
+from logging.handlers import SysLogHandler
+from os import environ
+from sys import stderr, exc_info, exit as sys_exit
+from time import strftime
+from textwrap import TextWrapper
+from traceback import print_exception
+from typing import TypedDict, NotRequired, Callable, Awaitable, Any
+
+from qubesadmin.app import QubesBase
+from qubesadmin.events import EventsDispatcher
+from qubesadmin.events import POWER_EVENTS
+from qubesadmin.exc import (
+    QubesPropertyAccessError,
+    QubesVMNotFoundError,
+)
+from qubesadmin.label import Label
+from qubesadmin.tools import QubesArgumentParser
+from qubesadmin.utils import start, pause, unpause, shutdown, kill
+from qubesadmin.vm import QubesVM, POWER_STATES
+
+
+class ActionEntry(TypedDict):
+    # pylint: disable=missing-class-docstring
+    identity: int
+    action: Callable[[list[QubesVM]], Awaitable[object]]
+    on_state: list[str]
+    when: NotRequired[list[str]]
+
+
+def log_failures(qubes, results) -> None:
+    """
+    Filter results for failures and log them.
+    """
+    failed: dict[QubesVM, BaseException] = {}
+    for qube, res in zip(qubes, results):
+        if not isinstance(res, BaseException):
+            continue
+        failed[qube] = res
+    for qube, exc in failed.items():
+        qube.log.exception(exc, exc_info=exc)
+
+
+async def exec_and_check(*args):
+    """
+    Execute subprocess asynchronously and check for its result.
+    """
+    proc = await create_subprocess_exec(
+        *args,
+        stdin=DEVNULL,
+        stdout=PIPE,
+        stderr=STDOUT,
+    )
+    outerr, _ = await proc.communicate()
+    if proc.returncode != 0:
+        raise async_subprocess.CalledProcessError(
+            returncode=proc.returncode, cmd=[*args], output=outerr
+        )
+
+async def console(qubes: list[QubesVM]) -> None:
+    """
+    Get debug console for provided qubes.
+    """
+    tasks = [
+        exec_and_check("qvm-console-dispvm", "--autostart", qube.name)
+        for qube in qubes
+    ]
+    results = await gather(*tasks, return_exceptions=True)
+    log_failures(qubes, results)
+
+
+async def terminal(qubes: list[QubesVM], user: str | None = None) -> None:
+    """
+    Get GUI terminal for provided qubes.
+    """
+    tasks = [
+        to_thread(
+            qube.run_service_for_stdio,
+            "qubes.StartApp+qubes-run-terminal",
+            user=user,
+        )
+        for qube in qubes
+    ]
+    results = await gather(*tasks, return_exceptions=True)
+    log_failures(qubes, results)
+
+
+async def action_wrapper(
+    qubes: list[QubesVM], action: Callable, **kwargs
+) -> None:
+    """
+    Run action from utils and log failures.
+    """
+    results = await action(domains=qubes, **kwargs)
+    log_failures(qubes, results)
+
+
+ACTIONS: dict[str, ActionEntry] = {
+    "Run terminal": {
+        "identity": 0,
+        "action": lambda qubes: terminal(qubes=qubes),
+        "on_state": ["Halted", "Running"],
+        "when": ["can_gui"],
+    },
+    "Run root terminal": {
+        "identity": 1,
+        "action": lambda qubes: terminal(qubes=qubes, user="root"),
+        "on_state": ["Halted", "Running"],
+        "when": ["can_gui"],
+    },
+    "Debug console": {
+        "identity": 2,
+        "action": lambda qubes: console(qubes=qubes),
+        "on_state": ["Halted", "Running"],
+        "when": ["can_console"],
+    },
+    "Start": {
+        "identity": 3,
+        "action": lambda qubes: action_wrapper(qubes=qubes, action=start),
+        "on_state": ["Halted"],
+    },
+    "Pause": {
+        "identity": 4,
+        "action": lambda qubes: action_wrapper(qubes=qubes, action=pause),
+        "on_state": ["Running"],
+    },
+    "Unpause": {
+        "identity": 5,
+        "action": lambda qubes: action_wrapper(qubes=qubes, action=unpause),
+        "on_state": ["Paused"],
+    },
+    "Shutdown": {
+        "identity": 6,
+        "action": lambda qubes: action_wrapper(
+            qubes=qubes, action=shutdown, wait=True
+        ),
+        "on_state": ["Transient", "Running"],
+    },
+    "Force shutdown": {
+        "identity": 7,
+        "action": lambda qubes: action_wrapper(
+            qubes=qubes, action=shutdown, force=True, wait=True
+        ),
+        "on_state": ["Transient", "Running"],
+    },
+    # "Restart": {
+    #    "identity": 8,
+    #    "action": lambda qubes: action_wrapper(qubes=qubes, action=restart),
+    #    "on_state": ["Transient", "Running", "Paused", "Halting"],
+    #    "when": ["can_restart"],
+    # },
+    "Kill": {
+        "identity": 9,
+        "action": lambda qubes: action_wrapper(qubes=qubes, action=kill),
+        "on_state": ["Transient", "Running", "Paused", "Halting"],
+    },
+}
+ACTION_NUMBERS: list[int] = [action["identity"] for action in ACTIONS.values()]
+ACTION_WIDTH = max(len(action) for action in ACTIONS)
+ACTION_NUMBER_WIDTH = max(len(str(number)) for number in ACTION_NUMBERS)
+ACTION_ALL_WIDTHS = ACTION_WIDTH + ACTION_NUMBER_WIDTH + 1
+
+QUBES_TOP_DEBUG = bool(environ.get("QUBES_TOP_DEBUG"))
+LOGGING_LEVEL = DEBUG if QUBES_TOP_DEBUG else INFO
+NO_COLOR = bool(environ.get("NO_COLOR"))
+UNICODE = bool("utf-8" in environ.get("LC_ALL", "").lower())
+if UNICODE:
+    SORT_SIGN_UP = "\u2193"
+    SORT_SIGN_DOWN = "\u2191"
+else:
+    SORT_SIGN_UP = "^"
+    SORT_SIGN_DOWN = "v"
+
+
+def convert_html_color_to_curses(hexadecimal: str):
+    """
+    Convert HTML color codes to RGB accepted by curses.
+    """
+    number = int(hexadecimal, 16)
+    red = (number >> 16) & 255
+    green = (number >> 8) & 255
+    blue = number & 255
+    return (
+        int(red * 1000 / 255),
+        int(green * 1000 / 255),
+        int(blue * 1000 / 255),
+    )
+
+
+def gen_logger(name: str) -> Logger:
+    """
+    Return logger for a given name. Use syslog, as stdout and stderr are being
+    used by curses.
+    """
+    logger = getLogger(name)
+    logger.setLevel(LOGGING_LEVEL)
+    formatter = Formatter(
+        f" %(levelname)s: {name} %(funcName)s:%(lineno)d: %(message)s"
+    )
+    handler = SysLogHandler(address="/dev/log")
+    handler.setFormatter(formatter)
+    handler.ident = "qvm-top"
+    logger.addHandler(handler)
+    logger.propagate = False
+    return logger
+
+
+class Stats:
+    """
+    Storage qube statistics.
+    """
+
+    # pylint: disable=too-many-instance-attributes
+
+    outdated_by_removal: list[str] = []
+    host_memory_max: int | str = "NA"
+
+    def __init__(self, vm: QubesVM) -> None:
+        super().__init__()
+        self.vm: QubesVM = vm
+
+        self.uptodate: bool = False
+        self.name = str(self.vm)
+        self.log = gen_logger(f"{self.__class__.__qualname__}.{self.name}")
+
+        self.features_default = {"gui": True, "internal": False}
+        self.state: str = "NA"
+        self.label: Label | None = None
+        self.is_preload: bool = False
+        self.gui: bool = True
+        self.internal: bool = False
+        self.guivm: QubesVM | None = None
+        self.management_dispvm: QubesVM | None = None
+        self.auto_cleanup: bool = False
+        self.memory_max: int | str = "NA"
+        self.update_cache()
+
+        self.memory_assigned: int | str = "NA"
+        self.memory_usage_assigned: float | str = "NA"
+        self.memory_used: int | str = "NA"
+        self.memory_used_with_swap: int | str = "NA"
+        self.memory_usage_used: float | str = "NA"
+        self.memory_usage_used_with_swap: float | str = "NA"
+        self.memory_usage_used_assigned: float | str = "NA"
+        self.cpu_time: int | str = "NA"
+        self.cpu_usage: int | str = "NA"
+        self.online_vcpus: int | str = "NA"
+
+        self.memory_assigned_internal: int | str = "NA"
+        self.memory_used_internal: int | str = "NA"
+        self.cpu_time_internal: int | str = "NA"
+        self.cpu_usage_internal: float | str = "NA"
+        self.online_vcpus_internal: int | str = "NA"
+
+        self.memory_assigned_total: int | str = "NA"
+        self.memory_used_total: int | str = "NA"
+        self.cpu_time_total: int | str = "NA"
+        self.cpu_usage_total: float | str = "NA"
+        self.online_vcpus_total: int | str = "NA"
+
+        if self.__class__.host_memory_max == "NA":
+            self.__class__.host_memory_max = int(self.vm.app.maxmem) // 1024
+
+    def can_gui(self) -> bool:
+        """
+        Returns boolean if qube can show graphical applications.
+        """
+        return bool(
+            self.guivm
+            and self.gui
+            and not self.is_preload
+            and not self.internal
+        )
+
+    def can_console(self) -> bool:
+        """
+        Returns boolean if qube can have a debug console.
+        """
+        return bool(
+            self.guivm
+            and self.management_dispvm
+            and not self.is_preload
+            and not self.internal
+        )
+
+    def can_restart(self) -> bool:
+        """
+        Returns boolean if qube can be restarted.
+        """
+        return bool(not self.auto_cleanup)
+
+    def filter_actions(self) -> list[str]:
+        """
+        Only show actions that passes all filters.
+        """
+        actions: list[str] = []
+        for action, entry in ACTIONS.items():
+            state = entry["on_state"]
+            when = entry.get("when", [])
+            if self.state not in state:
+                continue
+            if not (not when or all(getattr(self, meth)() for meth in when)):
+                continue
+            actions.append(action)
+        return actions
+
+    def get_actions(self) -> list[str]:
+        """
+        List available actions depending on the state.
+        """
+        if self.vm.klass in ["AdminVM", "RemoteVM"]:
+            actions = []
+        else:
+            actions = self.filter_actions()
+        return actions
+
+    def _setter(self, name: str, newvalue) -> dict | None:
+        """
+        Set instance attribute, inform if status is outdated and return changes.
+        """
+        oldvalue = getattr(self, name)
+        if oldvalue == newvalue:
+            return None
+        self.uptodate = False
+        setattr(self, name, newvalue)
+        return {name: [oldvalue, newvalue]}
+
+    def set_verbose(self, items_to_update: dict) -> None:
+        """
+        Set multiple properties at a time and log outdated ones.
+        """
+        updates = [
+            res
+            for prop, value in items_to_update.items()
+            if (res := self._setter(prop, value))
+        ]
+        if updates:
+            self.log.debug("update=%s", updates)
+
+    def update_cache(self) -> None:
+        """
+        Regenerate cache upon (re)connection.
+        """
+        data = {
+            "state": self.vm.get_power_state(),
+            "label": self.vm.label,
+            "memory_max": getattr(self.vm, "maxmem", "NA"),
+            "auto_cleanup": getattr(self.vm, "auto_cleanup", False),
+            "is_preload": getattr(self.vm, "is_preload", False),
+            "guivm": getattr(self.vm, "guivm", None),
+            "management_dispvm": getattr(self.vm, "management_dispvm", None),
+            "gui": (
+                self.vm.features.check_with_template(
+                    "gui", self.features_default["gui"]
+                )
+                if self.vm.klass != "RemoteVM"
+                else self.features_default["gui"]
+            ),
+            "internal": (
+                self.vm.features.check_with_template(
+                    "internal", self.features_default["internal"]
+                )
+                if self.vm.klass != "RemoteVM"
+                else self.features_default["internal"]
+            ),
+        }
+        self.set_verbose(data)
+
+    def update_stats(self, **kwargs: Any) -> None:
+        """
+        Update memory and CPU statistics.
+        """
+        memory_assigned = int(kwargs["memory_assigned_KiB"]) // 1024
+        memory_assigned_internal = kwargs.get("memory_assigned_KiB_internal")
+        if memory_assigned_internal is None:
+            memory_assigned_internal = "NA"
+            memory_assigned_total = memory_assigned
+        else:
+            memory_assigned_internal = int(memory_assigned_internal) // 1024
+            memory_assigned_total = memory_assigned + memory_assigned_internal
+
+        memory_used_with_swap = int(kwargs["memory_used_with_swap_KiB"]) // 1024
+        memory_used = int(kwargs["memory_used_KiB"]) // 1024
+        memory_used_internal = kwargs.get("memory_used_KiB_internal")
+        if memory_used_internal is None:
+            memory_used_internal = "NA"
+            memory_used_total = memory_used
+        else:
+            memory_used_internal = int(memory_used_internal) // 1024
+            memory_used_total = memory_used + memory_used_internal
+
+        if isinstance(self.memory_max, int) and self.memory_max > 0:
+            memory_usage_assigned: float | str = round(
+                float(memory_assigned / self.memory_max) * 100, 1
+            )
+            memory_usage_used: float | str = round(
+                float(memory_used / self.memory_max) * 100, 1
+            )
+        else:
+            memory_usage_assigned = "NA"
+            memory_usage_used = "NA"
+        if memory_assigned > 0:
+            memory_usage_used_assigned = round(
+                float(memory_used / memory_assigned) * 100, 1
+            )
+        else:
+            memory_usage_used_assigned = 0.0
+        if memory_used > 0:
+            memory_usage_used_with_swap: float | str = round(
+                float(memory_used_with_swap / memory_used) * 100 - 100, 1
+            )
+        else:
+            memory_usage_used_with_swap = 0
+
+        cpu_time = int(kwargs["cpu_time"]) // 10**3
+        cpu_time_internal = kwargs.get("cpu_time_internal")
+        if cpu_time_internal is None:
+            cpu_time_internal = "NA"
+            cpu_time_total = cpu_time
+        else:
+            cpu_time_internal = int(cpu_time_internal) // 10**3
+            cpu_time_total = cpu_time + cpu_time_internal
+
+        cpu_usage = int(kwargs["cpu_usage"])
+        cpu_usage_internal = kwargs.get("cpu_usage_internal")
+        if cpu_usage_internal is None:
+            cpu_usage_internal = "NA"
+        else:
+            cpu_usage_internal = float(cpu_usage_internal)
+
+        online_vcpus = int(kwargs["online_vcpus"])
+        online_vcpus_internal = kwargs.get("online_vcpus_internal")
+        if online_vcpus_internal is None:
+            online_vcpus_internal = "NA"
+            online_vcpus_total = online_vcpus
+        else:
+            online_vcpus_internal = int(online_vcpus_internal)
+            online_vcpus_total = online_vcpus + online_vcpus_internal
+
+        data = {
+            "memory_assigned": memory_assigned,
+            "memory_used": memory_used,
+            "memory_used_with_swap": memory_used_with_swap,
+            "memory_usage_used": memory_usage_used,
+            "memory_usage_assigned": memory_usage_assigned,
+            "memory_usage_used_assigned": memory_usage_used_assigned,
+            "memory_usage_used_with_swap": memory_usage_used_with_swap,
+            "cpu_time": cpu_time,
+            "cpu_usage": cpu_usage,
+            "online_vcpus": online_vcpus,
+            "memory_assigned_internal": memory_assigned_internal,
+            "memory_used_internal": memory_used_internal,
+            "cpu_time_internal": cpu_time_internal,
+            "cpu_usage_internal": cpu_usage_internal,
+            "online_vcpus_internal": online_vcpus_internal,
+            "memory_assigned_total": memory_assigned_total,
+            "memory_used_total": memory_used_total,
+            "cpu_time_total": cpu_time_total,
+            "online_vcpus_total": online_vcpus_total,
+        }
+        self.set_verbose(data)
+
+    def update_memory_max(self, value: int) -> None:
+        """
+        Update maximum memory and it's related properties.
+        """
+        memory_max = int(value)
+        if memory_max > 0:
+            memory_usage_assigned: float | str = "NA"
+            if isinstance(self.memory_assigned, int):
+                memory_usage_assigned = round(
+                    float(self.memory_assigned / memory_max) * 100, 1
+                )
+            memory_usage_used: float | str = "NA"
+            if isinstance(self.memory_used, int):
+                memory_usage_used = round(
+                    float(self.memory_used / memory_max) * 100, 1
+                )
+        else:
+            memory_usage_used = "NA"
+            memory_usage_assigned = "NA"
+        data = {
+            "memory_max": memory_max,
+            "memory_usage_used": memory_usage_used,
+            "memory_usage_assigned": memory_usage_assigned,
+        }
+        self.set_verbose(data)
+
+    def update_generic(self, name: str, value: Any) -> None:
+        """
+        Update instance attributes.
+        """
+        self.set_verbose({name: value})
+
+    def update_feat_from_template(self, name: str) -> None:
+        """
+        Update instance features according to template features.
+        """
+        default = self.features_default[name]
+        if self.vm.klass != "RemoteVM":
+            value = self.vm.features.check_with_template(name, default)
+        else:
+            value = default
+        self.set_verbose({name: value})
+
+
+class Monitor:
+    """
+    Logic responsible for monitoring events and showing statistics on the
+    screen.
+    """
+
+    # pylint: disable=too-many-instance-attributes
+
+    def __init__(
+        self,
+        app: QubesBase,
+        domains: list[QubesVM],
+        dispatcher: EventsDispatcher,
+        stats_dispatcher: EventsDispatcher,
+        show_halted: bool,
+        all_domains: bool,
+        allow_color: bool,
+        columns: dict[str, "Column"],
+        sort_reverse: bool = False,
+        sort_column: str | None = None,
+        filter_query: str = "",
+    ) -> None:
+        # pylint: disable=too-many-positional-arguments
+        self.app = app
+        self.domains = domains
+        self.dispatcher = dispatcher
+        self.stats_dispatcher = stats_dispatcher
+        self.all_domains = all_domains
+        self.show_halted = show_halted
+        self.allow_color = allow_color
+        self.columns = columns
+        self.sort_reverse = sort_reverse
+        if sort_column is None:
+            self.sort_col_index: int | None = None
+        else:
+            self.sort_col_index = list(self.columns.keys()).index(sort_column)
+        self.filter_query = filter_query
+
+        self.log = gen_logger(f"{self.__class__.__qualname__}")
+        root_logger = getLogger()
+        root_logger.setLevel(LOGGING_LEVEL)
+        root_logger.handlers.clear()
+        root_logger.addHandler(self.log.handlers[0])
+
+        self.headers = " ".join(col.header for col in self.columns.values())
+        self.version: str = metadata("qubesadmin")["version"]
+        self.entries: dict[QubesVM, Stats] = {}
+        self.scroll_offset = 0
+        self.max_offset = 0
+        self.action_scroll_offset = 0
+        self.action_max_offset = 0
+        self.body_height = 0
+        self.body_top = 0
+        self.body_bottom = 0
+        self.cursor_row = 0
+        self.outdated_sleep = 0.010
+        self.uptodate_sleep = 0.1
+        self.getch_timeout = 1000
+        self._stats: list[Stats] | None = None
+        self._old_cursor_visibility = 0
+        self.selected_stats: list[Stats] = []
+        self.last_selected_stat: Stats | None = None
+        self.last_selected_row: int | None = None
+        self.header_row = 3
+        self.old_cursor_row = 0
+        self.visible_stats: dict[int, Stats] = {}
+        self.visible_actions: dict[int, str] = {}
+        self.filter = False
+        self.act = False
+        self.actions: list[str] = []
+        self.label_index = 0
+
+    def init_label(self, label) -> None:
+        """
+        Initialize colors from qube labels.
+        """
+        name: str = label.name
+        color: str = label.color
+        index = self.label_index
+        if name == "black":
+            self.label_colors[name] = self.colors["FG_DEFAULT"]
+            return
+        r1000, g1000, b1000 = convert_html_color_to_curses(color)
+        curses.init_color(index, r1000, g1000, b1000)
+        curses.init_pair(index, index, -1)
+        self.label_colors[name] = curses.color_pair(index)
+        self.label_index += 1
+
+    def init_screen(self) -> None:
+        """
+        Initialize curses.
+
+        Not a color expert, relied on how existing applications such as Vim and
+        htop use the 8 default colors.
+
+        - Black: only as reverse video
+        - Red: critical
+        - Green: header
+        - Blue: not very used, use with discretion
+        - Yellow: tag, warning
+        - Magenta: not very used, use with discretion
+        - Cyan: filter, cursor
+        - White: only as reverse video
+
+        The problematic colors:
+
+        - White and black: Never use them without reverse video, as they might
+          be the default font and background color.
+        - Blue: Some shades of blue can be too dark to read on dark background.
+          Not widely used.
+        - Magenta: Not widely used, unknown reason, might be too alarming?
+        """
+        # pylint: disable=attribute-defined-outside-init
+        term_fallback = "xterm-256color"
+        term = environ.get("TERM")
+        curses_unknown_colored_term = ["tmux-256color", "tmux-direct"]
+        if term in curses_unknown_colored_term:
+            self.log.debug(
+                "TERM is known to support colors but curses renders it poorly, "
+                "falling back to sane TERM"
+            )
+            environ["TERM"] = term_fallback
+        self.stdscr = curses.initscr()
+        self.stdscr.timeout(self.getch_timeout)
+        self.stdscr.keypad(True)
+        colors = {
+            "BLACK": 0,
+            "RED": 1,
+            "GREEN": 2,
+            "YELLOW": 3,
+            "BLUE": 4,
+            "MAGENTA": 5,
+            "CYAN": 6,
+            "WHITE": 7,
+        }
+        self.label_colors: dict[str, int] = {}
+        self.colors: dict[str, int] = {}
+        if self.allow_color:
+            curses.start_color()
+            curses.use_default_colors()
+            for curses_color_name, index in colors.items():
+                color_code = getattr(curses, f"COLOR_{curses_color_name}")
+                curses.init_pair(index, color_code, -1)
+                self.colors[f"FG_{curses_color_name}"] = curses.color_pair(
+                    index
+                )
+                curses.init_pair(index + len(colors), -1, color_code)
+                self.colors[f"BG_{curses_color_name}"] = curses.color_pair(
+                    index
+                )
+            self.colors.update(
+                {
+                    "FG_DEFAULT": curses.color_pair(0),
+                    "BG_DEFAULT": curses.color_pair(0),
+                }
+            )
+            self.label_index = len(list(self.colors.keys())) + 1
+
+            if curses.can_change_color():
+                for label in self.app.labels.values():
+                    self.init_label(label=label)
+            else:
+                self.label_colors = {
+                    "red": self.colors["FG_RED"],
+                    "orange": self.colors["FG_YELLOW"] | curses.A_DIM,
+                    "yellow": self.colors["FG_YELLOW"],
+                    "green": self.colors["FG_GREEN"],
+                    "gray": self.colors["FG_WHITE"] | curses.A_DIM,
+                    "blue": self.colors["FG_BLUE"],
+                    "purple": self.colors["FG_MAGENTA"],
+                    "black": self.colors["FG_DEFAULT"],
+                }
+                self.label_color_backup = (
+                    self.colors["FG_BLACK"] | curses.A_UNDERLINE
+                )
+            self.header_summary_attr: int | None = self.colors["FG_GREEN"]
+            self.header_attr = curses.A_REVERSE | self.colors["BG_GREEN"]
+            self.header_sel_attr: int | None = (
+                curses.A_REVERSE | self.colors["BG_CYAN"]
+            )
+            self.footer_attr: int | None = (
+                curses.A_REVERSE | self.colors["BG_GREEN"]
+            )
+            self.footer_sel_attr: int | None = (
+                curses.A_REVERSE | self.colors["BG_CYAN"]
+            )
+            self.sel_attr: int | None = (
+                self.colors["FG_YELLOW"] | curses.A_REVERSE
+            )
+            self.cursor_attr: int | None = (
+                curses.A_REVERSE | self.colors["BG_CYAN"]
+            )
+            self.sel_and_cursor_attr = self.cursor_attr | curses.A_DIM
+        else:
+            self.header_summary_attr = curses.A_REVERSE
+            self.header_attr = curses.A_REVERSE
+            self.header_sel_attr = curses.A_REVERSE
+            self.footer_attr = curses.A_REVERSE
+            self.footer_sel_attr = curses.A_REVERSE
+            self.sel_attr = curses.A_REVERSE
+            self.cursor_attr = curses.A_REVERSE
+            self.sel_and_cursor_attr = curses.A_REVERSE
+        curses.noecho()
+        curses.cbreak()
+        curses.nonl()
+        self._old_cursor_visibility = curses.curs_set(0)
+        curses.mousemask(curses.ALL_MOUSE_EVENTS)
+
+    def restore_screen(self) -> None:
+        """
+        Restore sane window.
+        """
+        curses.nl()
+        curses.nocbreak()
+        curses.echo()
+        try:
+            curses.curs_set(self._old_cursor_visibility)
+        except curses.error:
+            pass
+        curses.endwin()
+
+    def init_entries(self) -> None:
+        """
+        Initialize statistics holder for all qubes.
+        """
+        for vm in sorted(
+            [vm for vm in self.app.domains if vm.klass == "AdminVM"]
+        ):
+            self.add_domain(submitter=None, vm=vm, event=None)
+        for vm in sorted(
+            [vm for vm in self.app.domains if vm not in self.entries]
+        ):
+            self.add_domain(submitter=None, vm=vm, event=None)
+
+    def update_stats(self, vm: QubesVM, _event: str, **kwargs: Any) -> None:
+        """
+        Rpead vm-stats and update qube statistics.
+        """
+        # pylint: disable=missing-function-docstring
+        if vm not in self.entries:
+            return
+        self.entries[vm].update_stats(**kwargs)
+
+    def refresh_all_items(
+        self, submitter: QubesVM | None, _event: str, **_kwargs: Any
+    ) -> None:
+        """
+        Reconnected to the API, check if all entries are up to date.
+        """
+        # pylint: disable= unused-argument
+        items_to_delete = [
+            vm for vm in self.entries if vm not in self.app.domains
+        ]
+        for vm in items_to_delete:
+            self.remove_domain(submitter=None, vm=vm, event=None)
+        for vm in self.app.domains:
+            self.update_domain_item(vm=vm, event=None)
+
+    def add_domain(
+        self,
+        submitter: QubesVM | None,
+        event: str | None,
+        vm: QubesVM,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Add qube to the statistics holder.
+        """
+        # pylint: disable= unused-argument
+        if str(vm) in self.entries:
+            return
+        try:
+            vm = self.app.domains[str(vm)]
+        except KeyError:
+            return
+
+        self.log.debug("add=%s", str(vm))
+        try:
+            self.entries[vm] = Stats(vm)
+        except QubesVMNotFoundError:
+            self.log.debug("Qube removed while adding its entry: %s", str(vm))
+            self.remove_domain(submitter=None, vm=vm, event=event)
+        if self.all_domains:
+            self.domains.append(vm)
+
+    def remove_domain(
+        self,
+        submitter: QubesVM | None,
+        event: str | None,
+        vm: QubesVM,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Remove qube from the statistics holder.
+        """
+        # pylint: disable=unused-argument
+        if str(vm) not in self.entries:
+            return
+        self.log.debug("remove=%s", str(vm))
+        if vm in self.domains:
+            Stats.outdated_by_removal.append(str(vm))
+        if self.entries[vm] in self.selected_stats:
+            self.selected_stats.remove(self.entries[vm])
+        del self.entries[vm]
+
+    def get_entry(self, vm: QubesVM, event: str | None) -> Stats | None:
+        """
+        Safely get ``Stats`` if qube can be accessed, else, remove the entry and
+        return ``None``.
+        """
+        try:
+            item = self.entries[vm]
+        except QubesPropertyAccessError as e:
+            self.log.exception(e)
+            self.remove_domain(submitter=None, vm=vm, event=event)
+            return None
+        return item
+
+    def update_domain_item(
+        self, vm: QubesVM, event: str | None, **kwargs: Any
+    ) -> None:
+        """
+        Fully update the statistics holder of the qube.
+        """
+        # pylint: disable=unused-argument
+        try:
+            item = self.get_entry(vm=vm, event=event)
+            if item is None:
+                return
+        except KeyError:
+            self.add_domain(submitter=None, vm=vm, event=event)
+            if not vm in self.entries:
+                return
+            item = self.entries[vm]
+        try:
+            item.update_cache()
+        except QubesVMNotFoundError:
+            self.log.debug("Qube removed while updating cache: %s", str(vm))
+            self.remove_domain(submitter=None, vm=vm, event=event)
+
+    def set_generic(
+        self, vm, event, name, newvalue=None, oldvalue=None
+    ) -> None:
+        """
+        Update attributes of the qube's statistics holder.
+        """
+        # pylint: disable=unused-argument
+        if not (item := self.get_entry(vm=vm, event=event)):
+            return
+        self.log.debug("update -> %s=%s(%s)", name, vm.name, newvalue)
+        if name == "maxmem":
+            item.update_memory_max(value=newvalue)
+        elif name == "label":
+            if (
+                newvalue.name not in self.label_colors
+                and curses.can_change_color()
+            ):
+                self.init_label(label=newvalue)
+            else:
+                newvalue = "@invalid"
+        else:
+            item.update_generic(name=name, value=newvalue)
+
+    def set_feat_generic(
+        self, vm, event, feature, value, oldvalue=None
+    ) -> None:
+        """
+        Update feature attributes of the qube's statistics holder.
+        """
+        # pylint: disable=unused-argument
+        if not (item := self.get_entry(vm=vm, event=event)):
+            return
+        self.log.debug("update -> %s=%s(%s)", feature, vm.name, value)
+        item.update_generic(name=feature, value=value)
+        for qube in vm.derived_vms:
+            if qube not in self.entries:
+                continue
+            self.entries[qube].update_feat_from_template(name=feature)
+
+    def del_feat_generic(self, vm, event, feature) -> None:
+        """
+        Update feature attributes of the qube's statistics holder.
+        """
+        # pylint: disable=unused-argument
+        if not (item := self.get_entry(vm=vm, event=event)):
+            return
+        self.log.debug("update del -> %s=%s", feature, vm.name)
+        item.update_feat_from_template(name=feature)
+        for qube in vm.derived_vms:
+            if qube not in self.entries:
+                continue
+            self.entries[qube].update_feat_from_template(name=feature)
+
+    def write(self, *args: Any, **kwargs: Any) -> None:
+        """
+        Set screen text and attributes and deal with errors without panic.
+        """
+        attr = kwargs.pop("attr", None)
+        max_width = kwargs.pop("max_width", None)
+        row, col, text = args
+        try:
+            if attr is not None:
+                self.stdscr.attron(attr)
+            if max_width:
+                self.stdscr.addnstr(row, col, text, max_width)
+            else:
+                self.stdscr.addstr(row, col, text)
+        except curses.error:
+            pass
+        finally:
+            if attr is not None:
+                self.stdscr.attroff(attr)
+
+    def get_stats(self):
+        """
+        Qubes that can be shown.
+        """
+        if self._stats is not None:
+            return self._stats
+
+        self._stats = sorted(
+            [
+                stats
+                for stats in self.entries.values()
+                if (self.show_halted or stats.state != "Halted")
+                and stats.vm in self.domains
+                and (
+                    (not self.filter_query and not self.filter)
+                    or any(
+                        string in stats.vm.name
+                        for string in self.filter_query.split(",")
+                    )
+                )
+            ],
+            key=self.sort_stats_helper,
+            reverse=self.sort_reverse,
+        )
+        return self._stats
+
+    def sort_stats_helper(self, row) -> tuple[int, float]:
+        """
+        Helper to sort a column according to the values it owns.
+        """
+        if self.sort_col_index is None or (
+            (header := list(self.columns.keys())[self.sort_col_index])
+            and header == "name"
+        ):
+            if row.vm.klass == "AdminVM":
+                return (0, row.vm.name)
+            return (1, row.vm.name)
+        val = getattr(row, header.lower())
+        try:
+            return (1, float(val))
+        except (TypeError, ValueError):
+            return (0, val.lower())
+
+    def mark_uptodate(self) -> None:
+        """
+        Mark everything as up-to-date.
+        """
+        for stats in self.get_stats():
+            stats.uptodate = True
+        Stats.outdated_by_removal = []
+
+    def is_uptodate(self) -> bool:
+        """
+        Check if statistics are live or expired.
+        """
+        self._stats = None
+        outdated = (
+            [stats.vm.name for stats in self.get_stats() if not stats.uptodate],
+        )
+        uptodate = not Stats.outdated_by_removal and not outdated
+        self.log.debug(
+            "removed=%s outdated=%s",
+            Stats.outdated_by_removal,
+            outdated,
+        )
+        return uptodate
+
+    def get_selection(self) -> list[Stats]:
+        """
+        Get selected qube. If none is selected, consider the last one the
+        cursor was in.
+        """
+        stats = self.selected_stats
+        if not stats and self.last_selected_stat:
+            stats = [self.last_selected_stat]
+        if not stats:
+            stats = []
+        return stats
+
+    def get_action_from_selection(self) -> list[str]:
+        """
+        List common actions that is valid for all selected qubes.
+        """
+        stats = self.get_selection()
+        if not stats:
+            return []
+        actions = []
+        all_actions = []
+        for stat in stats:
+            if not (stat_actions := stat.get_actions()):
+                return []
+            all_actions.append(stat_actions)
+        actions = list(set.intersection(*(set(x) for x in all_actions)))
+        actions = sorted(actions, key=lambda k: int(ACTIONS[k]["identity"]))
+        self.log.debug("available-actions=%s", actions)
+        return actions
+
+    def draw_table(self) -> None:
+        """
+        Define screen regions.
+        """
+        # pylint: disable=too-many-locals,too-many-statements,too-many-branches
+        self.stdscr.erase()
+        height, width = self.stdscr.getmaxyx()
+        self.body_top = self.header_row + 1
+        self.body_bottom = height - 1
+        self.body_height = max(0, self.body_bottom - self.body_top)
+
+        if not self.cursor_row:
+            self.cursor_row = self.body_top
+
+        wanted = self.get_stats()
+        self.mark_uptodate()
+
+        total_items = len(wanted)
+        self.max_offset = max(0, total_items - self.body_height)
+        self.scroll_offset = min(self.max_offset, max(0, self.scroll_offset))
+        scroll_start = self.scroll_offset
+        scroll_end = min(total_items, scroll_start + self.body_height)
+        visible = wanted[scroll_start:scroll_end]
+
+        self.actions = self.get_action_from_selection()
+        total_actions = len(self.actions)
+        self.action_max_offset = max(0, total_actions - self.body_height)
+        self.action_scroll_offset = min(
+            self.action_max_offset, max(0, self.action_scroll_offset)
+        )
+        action_scroll_start = self.action_scroll_offset
+        action_scroll_end = min(
+            total_actions, action_scroll_start + self.body_height
+        )
+        action_visible = self.actions[action_scroll_start:action_scroll_end]
+
+        memory_used: list[int] = [
+            stats.memory_used_total
+            for stats in wanted
+            if isinstance(stats.memory_used_total, int)
+        ]
+        memory_assigned: list[int] = [
+            stats.memory_assigned_total
+            for stats in wanted
+            if isinstance(stats.memory_assigned_total, int)
+        ]
+        states = [stats.state for stats in wanted]
+
+        if self.sort_reverse:
+            sort_sign = SORT_SIGN_UP
+        else:
+            sort_sign = SORT_SIGN_DOWN
+
+        self.visible_stats = {}
+        self.visible_actions = {}
+        for row_index in range(self.body_height):
+            curr_height = self.body_top + row_index
+            if row_index >= len(visible):
+                continue
+            self.visible_stats[curr_height] = visible[row_index]
+
+        if (
+            not self.act
+            and self.cursor_row > len(self.visible_stats) + self.header_row
+        ):
+            self.cursor_row = self.body_top
+
+        for row_index in range(self.body_height):
+            line_start = 0
+            curr_height = self.body_top + row_index
+            if self.act and self.actions:
+                act_attr = None
+                if curr_height == self.cursor_row and not self.filter:
+                    act_attr = self.cursor_attr
+                if row_index < len(action_visible):
+                    curr_action = action_visible[row_index]
+                    self.visible_actions[curr_height] = curr_action
+                    action = str(curr_action).ljust(ACTION_WIDTH)
+                    action_number = str(
+                        ACTIONS[action.strip()]["identity"]
+                    ).rjust(ACTION_NUMBER_WIDTH)
+                    content = action_number + " " + action
+                    self.write(
+                        curr_height,
+                        line_start,
+                        content,
+                        attr=act_attr,
+                        max_width=width - line_start,
+                    )
+                line_start = ACTION_ALL_WIDTHS
+                self.write(
+                    curr_height,
+                    line_start,
+                    " ",
+                    max_width=width - line_start,
+                )
+                line_start += 1
+            if row_index >= len(visible):
+                continue
+            stats = self.visible_stats[curr_height]
+            sel_attr = None
+            if (
+                curr_height == self.cursor_row
+                and not self.filter
+                and not self.act
+            ):
+                if stats in self.selected_stats:
+                    sel_attr = self.sel_and_cursor_attr
+                else:
+                    sel_attr = self.cursor_attr
+            elif stats in self.selected_stats:
+                sel_attr = self.sel_attr
+            elif (
+                not self.selected_stats
+                and curr_height == self.last_selected_row
+                and not self.filter
+                and self.act
+            ):
+                sel_attr = self.cursor_attr
+            for column in self.columns.values():
+                color_attr = None
+                attr = column.machine_header.lower()
+                data = getattr(stats, attr)
+                if not sel_attr and self.allow_color:
+                    if attr == "name":
+                        try:
+                            assert isinstance(stats.label, Label)
+                            color_attr = self.label_colors[stats.label.name]
+                        except KeyError:
+                            color_attr = self.label_color_backup
+                    elif attr == "state":
+                        if stats.state in ["Paused", "Suspended"]:
+                            color_attr = self.colors["FG_YELLOW"]
+                        elif stats.state != "Running":
+                            color_attr = self.colors["FG_RED"]
+                    elif column.percentage and data != "NA":
+                        if data > max(column.percentage_intensity):
+                            color_attr = self.colors["FG_RED"]
+                        elif data > min(column.percentage_intensity):
+                            color_attr = self.colors["FG_YELLOW"]
+                    elif data == "NA":
+                        color_attr = self.label_colors["gray"]
+                if column.right_justify:
+                    content = str(data).rjust(column.width)
+                else:
+                    content = data.ljust(column.width)
+                content += " "
+                self.write(
+                    curr_height,
+                    line_start,
+                    content,
+                    attr=sel_attr or color_attr,
+                    max_width=width - line_start,
+                )
+                line_start += len(content)
+
+        memory_total = Stats.host_memory_max
+        sum_memory_used = sum(memory_used)
+        sum_memory_assigned = sum(memory_assigned)
+        pct_memory_used: float | str = "NA"
+        pct_memory_assigned: float | str = "NA"
+        if isinstance(memory_total, int):
+            pct_memory_used = round(sum_memory_used / memory_total * 100, 1)
+            pct_memory_assigned = round(
+                sum_memory_assigned / memory_total * 100, 1
+            )
+        header_mem_prefix = "MEM(MiB)"
+        total_mem_len = len(str(memory_total))
+        header_mem_total = "{} total".format(memory_total)
+        header_mem_used = "{}({}%) used".format(
+            str(sum_memory_used).rjust(total_mem_len), pct_memory_used
+        )
+        header_mem_assigned = "{}({}%) assigned".format(
+            str(sum_memory_assigned).rjust(total_mem_len), pct_memory_assigned
+        )
+        header_mem_suffix = ": {}, {}, {}".format(
+            header_mem_total,
+            header_mem_assigned,
+            header_mem_used,
+        )
+
+        state_counts = Counter(states)
+        total_states = len(states)
+        total_states_len = len(str(total_states))
+        all_states = list(POWER_STATES)
+        state_parts = ["{}".format(total_states)]
+        state_parts.append(
+            "({} selected)".format(
+                str(len(self.selected_stats)).rjust(total_states_len)
+            )
+        )
+        for state in all_states:
+            state_parts.append(
+                "{} {}".format(
+                    str(state_counts.get(state, 0)).rjust(total_states_len),
+                    state.lower() if state != "NA" else "NA",
+                )
+            )
+        extra = [state for state in state_counts if state not in all_states]
+        for state in sorted(extra):
+            state_parts.append(
+                "{} {}".format(
+                    str(state_counts[state]).rjust(total_states_len),
+                    state.lower(),
+                )
+            )
+        header_dom_prefix = "Domain{}".format("s" if total_states > 0 else "")
+        header_dom_suffix = ": " + ", ".join(state_parts)
+
+        current_time = strftime("%H:%M:%S")
+        if self.sort_col_index is not None:
+            sort_col_index = self.sort_col_index
+        else:
+            sort_col_index = 0
+        sorted_header = str(list(self.columns.values())[sort_col_index].header)
+        sorted_header += sort_sign
+
+        header_desc_prefix = "qvm-top"
+        header_desc_suffix = f": {self.version} - {current_time}"
+        scroll_hint = (
+            f"{scroll_start + 1}-{scroll_end}/{total_items}"
+            if total_items > 0
+            else "0/0"
+        )
+
+        self.write(
+            0,
+            0,
+            header_desc_prefix,
+            max_width=width,
+            attr=self.header_summary_attr,
+        )
+        self.write(
+            0,
+            len(header_desc_prefix),
+            header_desc_suffix,
+            max_width=width - len(header_desc_prefix),
+        )
+
+        self.write(
+            1,
+            0,
+            header_dom_prefix,
+            max_width=width,
+            attr=self.header_summary_attr,
+        )
+        self.write(
+            1,
+            len(header_dom_prefix),
+            header_dom_suffix,
+            max_width=width - len(header_dom_prefix),
+        )
+
+        self.write(
+            2,
+            0,
+            header_mem_prefix,
+            max_width=width,
+            attr=self.header_summary_attr,
+        )
+        self.write(
+            2,
+            len(header_mem_prefix),
+            header_mem_suffix,
+            max_width=width - len(header_mem_prefix),
+        )
+
+        action_headers = ""
+        if self.act and self.actions:
+            action_headers = "ACTION".ljust(ACTION_ALL_WIDTHS)
+        pre_headers = " ".join(
+            col.header for col in list(self.columns.values())[:sort_col_index]
+        )
+        if sort_col_index > 0:
+            pre_headers += " "
+        post_headers = " ".join(
+            col.header
+            for col in list(self.columns.values())[sort_col_index + 1 :]
+        )
+        if post_headers:
+            post_headers += " "
+        self.log.debug("draw-header-pre=%s", pre_headers)
+        self.log.debug("draw-header-sorted=%s", sorted_header)
+        self.log.debug("draw-header-post=%s", post_headers)
+        header_start = 0
+        if action_headers:
+            self.write(
+                3,
+                0,
+                action_headers,
+                max_width=width - header_start,
+                attr=self.header_attr,
+            )
+            header_start += len(action_headers)
+            self.write(
+                3,
+                header_start,
+                " ",
+                max_width=width - header_start,
+            )
+            header_start += 1
+        self.write(
+            3,
+            header_start,
+            pre_headers,
+            max_width=width - header_start,
+            attr=self.header_attr,
+        )
+        header_start += len(pre_headers)
+        self.log.debug("pre-sort-start=%s", header_start)
+        if header_start < width:
+            self.write(
+                3,
+                header_start,
+                sorted_header,
+                max_width=width - header_start,
+                attr=self.header_sel_attr,
+            )
+        header_start += len(sorted_header)
+        self.log.debug("post-sort-start=%s", header_start)
+        if len(post_headers.strip()) > 0 and header_start < width:
+            self.write(
+                3,
+                header_start,
+                post_headers,
+                max_width=width - header_start,
+                attr=self.header_attr,
+            )
+
+        current_headers_len = len(self.headers) + len(sort_sign)
+        if self.actions:
+            current_headers_len += len(action_headers)
+        filter_prefix = "Filter: "
+        if self.filter or self.filter_query:
+            if self.filter:
+                footer_base = filter_prefix
+            else:
+                footer_base = filter_prefix.upper()
+            footer_filter = self.filter_query
+
+            footer_start = 0
+            self.write(
+                height - 1,
+                0,
+                footer_base,
+                max_width=width,
+                attr=self.footer_attr,
+            )
+            footer_start += len(footer_base)
+            self.write(
+                height - 1,
+                footer_start,
+                footer_filter,
+                max_width=width - footer_start,
+                attr=self.footer_sel_attr,
+            )
+            footer_start += len(footer_filter)
+            if self.filter:
+                self.write(
+                    height - 1,
+                    footer_start,
+                    " ",
+                    max_width=width - footer_start,
+                    attr=curses.A_REVERSE,
+                )
+                footer_start += 1
+            space_between = (
+                min(width, current_headers_len)
+                - footer_start
+                - len(scroll_hint)
+            )
+            footer_suffix = " " * space_between + scroll_hint
+            self.write(
+                height - 1,
+                footer_start,
+                footer_suffix,
+                max_width=width - footer_start,
+                attr=self.footer_attr,
+            )
+
+        else:
+            footer_base = ""
+            space_between = (
+                min(width, current_headers_len)
+                - len(footer_base)
+                - len(scroll_hint)
+            )
+            footer = footer_base + (" " * space_between) + scroll_hint
+            self.write(
+                height - 1,
+                0,
+                footer,
+                max_width=width,
+                attr=self.footer_attr,
+            )
+
+        self.stdscr.refresh()
+
+    def select_row(self, row) -> bool | None:
+        """
+        React to selecting and deselecting a row.
+        """
+        if (
+            row in self.visible_stats
+            and self.visible_stats[row] in self.selected_stats
+        ):
+            self.log.debug("unlick-row=%s", row)
+            self.selected_stats.remove(self.visible_stats[row])
+            return True
+
+        if (
+            row != self.header_row
+            and row in self.visible_stats
+            and self.visible_stats[row].get_actions()
+        ):
+            self.log.debug("click-row=%s", row)
+            self.selected_stats.append(self.visible_stats[row])
+            return True
+        return None
+
+    def line_scroll(self, upward: bool):
+        """
+        React to clicking on a row, selecting an deselecting line.
+        """
+        if upward:
+            self.cursor_row -= 1
+            if self.cursor_row == self.header_row:
+                self.cursor_row = self.old_cursor_row
+                if self.act:
+                    self.action_scroll_offset = max(
+                        0, self.action_scroll_offset - 1
+                    )
+                else:
+                    self.scroll_offset = max(0, self.scroll_offset - 1)
+        else:
+            self.cursor_row += 1
+            if self.act:
+                bottom = self.body_top + len(self.visible_actions)
+                visible: dict[int, str] | dict[int, Stats] = (
+                    self.visible_actions
+                )
+            else:
+                bottom = self.body_bottom
+                visible = self.visible_stats
+            if self.cursor_row == bottom:
+                self.cursor_row = self.old_cursor_row
+                if self.act:
+                    self.action_scroll_offset = min(
+                        self.action_max_offset, self.action_scroll_offset + 1
+                    )
+                else:
+                    self.scroll_offset = min(
+                        self.max_offset, self.scroll_offset + 1
+                    )
+            elif self.cursor_row > len(visible) + self.header_row:
+                self.cursor_row = self.old_cursor_row
+
+    def page_scroll(self, upward: bool, half: bool = False):
+        """
+        Scroll a page up to down and even half in the chosen direction.
+        """
+        if upward:
+            self.scroll_offset = max(0, self.scroll_offset - self.body_height)
+            if half:
+                self.scroll_offset = self.scroll_offset // 2
+        else:
+            self.scroll_offset = min(
+                self.max_offset, self.scroll_offset + self.body_height
+            )
+            if half:
+                self.scroll_offset = self.scroll_offset // 2
+
+    def cancel_filter(self) -> None:
+        """
+        Cancel filter mode.
+        """
+        self.filter = False
+        self.cursor_row = self.body_top
+
+    def cancel_act(self) -> None:
+        """
+        Cancel action mode.
+        """
+        self.act = False
+        self.cursor_row = self.body_top
+
+    def getch(self) -> bool | None:
+        """
+        Act based on received key, if any. Returns ``True`` if screen should be
+        refreshed.
+        """
+        # pylint: disable=too-many-return-statements,too-many-statements,too-many-branches
+
+        char = self.stdscr.getch()
+        if char == -1:
+            return None
+
+        self.log.debug("char: %s", char)
+
+        if self.filter:
+            if 32 <= char <= 126:
+                self.filter_query += chr(char)
+            elif char in (curses.KEY_BACKSPACE,):
+                self.filter_query = self.filter_query[:-1]
+            else:
+                if char not in (
+                    curses.KEY_ENTER,
+                    CR,
+                ):
+                    self.filter_query = ""
+                self.cancel_filter()
+            return True
+
+        if self.act:
+            if char in (curses.KEY_ENTER, CR):
+                action: str = self.actions[self.cursor_row - self.body_top]
+                qubes = [stat.vm for stat in self.get_selection()]
+                self.log.info(
+                    "Running action '%s' on domain%s: %s",
+                    action,
+                    "s" if len(qubes) > 1 else "",
+                    ", ".join(qube.name for qube in qubes),
+                )
+                command = ACTIONS[action]["action"]
+                self.cancel_act()
+                ensure_future(command(qubes))
+                return True
+            if char in (ord("a"),):
+                self.cancel_act()
+                return True
+            if char in [ord(str(n)) for n in ACTION_NUMBERS]:
+                action = [
+                    action
+                    for action in self.actions
+                    if str(ACTIONS[action]["identity"]) == chr(char)
+                ][0]
+                action_index = self.actions.index(action)
+                self.cursor_row = self.body_top + action_index
+                return True
+
+        if char in (ord("q"), ord("Q"), ESC):
+            self.unregister_events()
+            raise KeyboardInterrupt
+
+        old_sort_col_index = self.sort_col_index
+        old_scroll_offset = self.scroll_offset
+        self.old_cursor_row = self.cursor_row
+        old_selected_stats = self.selected_stats
+
+        if char in (curses.KEY_UP, ord("k"), DLE):
+            self.line_scroll(upward=True)
+
+        elif char in (curses.KEY_DOWN, ord("j"), SO):
+            self.line_scroll(upward=False)
+
+        elif char in (curses.KEY_PPAGE, NAK, STX):
+            self.page_scroll(upward=True, half=char == NAK)
+
+        elif char in (curses.KEY_NPAGE, ACK, EOT):
+            self.page_scroll(upward=False, half=char == EOT)
+
+        elif char in (curses.KEY_HOME, SOH):
+            self.scroll_offset = 0
+
+        elif char in (curses.KEY_END, ENQ):
+            self.scroll_offset = self.max_offset
+
+        elif char in (FF,):
+            self.stdscr.clearok(True)
+
+        elif char in (curses.KEY_LEFT, ord("h")):
+            if self.sort_col_index is None:
+                self.sort_col_index = -1
+            else:
+                self.sort_col_index -= 1
+            if self.sort_col_index == -1:
+                self.sort_col_index = len(self.columns) - 1
+            if not bool(self.sort_col_index != old_sort_col_index):
+                return None
+            self.log.debug("sort-col=%s", self.sort_col_index)
+            return True
+
+        elif char in (curses.KEY_RIGHT, ord("l")):
+            if self.sort_col_index is None:
+                self.sort_col_index = 1
+            else:
+                self.sort_col_index += 1
+            if self.sort_col_index > len(self.columns) - 1:
+                self.sort_col_index = 0
+            if not bool(self.sort_col_index != old_sort_col_index):
+                return None
+            self.log.debug("sort-col=%s", self.sort_col_index)
+            return True
+
+        elif char in (ord("r"),):
+            self.sort_reverse = not self.sort_reverse
+
+        elif char in (ord("S"),):
+            self.show_halted = not self.show_halted
+
+        elif char in (SP,) and not self.act:
+            return self.select_row(self.cursor_row)
+
+        elif char in (ord("U"),):
+            self.selected_stats = []
+
+        elif char in (ord("T"),):
+            if self.visible_stats:
+                first_visible = list(self.visible_stats.values())[0]
+                if first_visible in self.selected_stats:
+                    self.selected_stats = [
+                        stat
+                        for stat in self.selected_stats
+                        if stat in self.visible_stats
+                    ]
+                else:
+                    self.selected_stats += [
+                        stat
+                        for stat in self.visible_stats.values()
+                        if stat not in self.selected_stats
+                    ]
+
+        elif char in (ord("a"),):
+            if self.cursor_row in self.visible_stats:
+                self.last_selected_row = self.cursor_row
+                self.last_selected_stat = self.visible_stats[
+                    self.last_selected_row
+                ]
+                self.log.debug(
+                    "last-stat(row)=%s(%s)",
+                    self.last_selected_stat.vm.name,
+                    self.last_selected_row,
+                )
+            if self.get_action_from_selection():
+                self.cursor_row = self.body_top
+                self.act = True
+                return True
+
+        elif not self.act and char in (ord("/"),):
+            self.filter = True
+
+        elif char == curses.KEY_MOUSE:
+            try:
+                _, mouse_col, mouse_row, _, button_state = curses.getmouse()
+            except curses.error:
+                return None
+
+            if button_state & curses.BUTTON4_PRESSED:
+                self.page_scroll(upward=True, half=True)
+
+            elif button_state & curses.BUTTON5_PRESSED:
+                self.page_scroll(upward=False, half=True)
+
+            elif button_state & curses.BUTTON1_DOUBLE_CLICKED:
+                return self.select_row(mouse_row)
+
+            elif button_state & curses.BUTTON1_CLICKED:
+                if self.body_top <= mouse_row <= self.body_bottom:
+                    self.cursor_row = mouse_row
+                else:
+                    col_index = self.get_col_index(mouse_col)
+                    if col_index is None:
+                        return None
+                    if self.sort_col_index == col_index:
+                        self.sort_reverse = not self.sort_reverse
+                    else:
+                        if self.sort_col_index is None:
+                            reverse = not self.sort_reverse
+                        else:
+                            reverse = False
+                        self.sort_col_index = col_index
+                        self.sort_reverse = reverse
+                    self.log.debug(
+                        "sort-col=%s, reverse=%s",
+                        self.sort_col_index,
+                        self.sort_reverse,
+                    )
+                    return True
+
+        scrolled = bool(
+            self.scroll_offset != old_scroll_offset
+            or self.cursor_row != self.old_cursor_row
+            or self.selected_stats != old_selected_stats
+        )
+        return scrolled
+
+    def get_col_index(self, col) -> int | None:
+        """
+        Returns the index of the specified column.
+        """
+        pos = 0
+        # The +1 is to consider space between columns.
+        for i, width in enumerate(
+            col.width + 1 for col in self.columns.values()
+        ):
+            if pos <= col < pos + width:
+                return i
+            pos += width
+        return None
+
+    async def paint(self) -> None:
+        """
+        Draw a top-like table when necessary, and get input to react on quit or
+        body scrolling.
+        """
+        scrolled: bool | None = False
+        while True:
+            try:
+                self.log.debug("loop")
+                uptodate = self.is_uptodate()
+                self.log.debug("uptodate=%s, scrolled=%s", uptodate, scrolled)
+                if scrolled or not uptodate:
+                    self.log.debug("draw")
+                    self.draw_table()
+                self.log.debug("getch")
+                scrolled = self.getch()
+                self.log.debug("scrolled=%s", scrolled)
+                if not uptodate or scrolled or scrolled is False:
+                    self.log.debug(
+                        "urgent need redraw, sleeping for %ss",
+                        self.outdated_sleep,
+                    )
+                    # Sleep a bit to avoid unhappy CPU.
+                    await sleep(self.outdated_sleep)
+                    continue
+                self.log.debug(
+                    "not rushing redraw, sleeping for %ss",
+                    self.outdated_sleep,
+                )
+                await sleep(self.uptodate_sleep)
+                continue
+            except (KeyboardInterrupt, CancelledError):
+                if self.filter:
+                    self.filter_query = ""
+                    self.cancel_filter()
+                    continue
+                if self.act:
+                    self.cancel_act()
+                    continue
+                break
+
+    async def run(self) -> None:
+        """
+        Run initial setup.
+        """
+        self.register_events()
+        self.init_entries()
+        exc_data = None
+        try:
+            # Allow registering events.
+            await sleep(0)
+            self.init_screen()
+            await self.paint()
+        except BaseException as e:
+            exc_data = exc_info()
+            self.log.exception(e)
+        finally:
+            self.restore_screen()
+            if exc_data:
+                print_exception(*exc_data, file=stderr)
+
+    def register_events(self):  # type: ignore[list-item]
+        """
+        Track and set event handlers.
+        """
+        stats_handlers = [("vm-stats", self.update_stats)]
+        handlers = [
+            ("connection-established", self.refresh_all_items),
+            ("domain-add", self.add_domain),
+            ("domain-delete", self.remove_domain),
+            ("property-set:maxmem", self.set_generic),
+            ("property-set:label", self.set_generic),
+            ("property-set:auto_cleanup", self.set_generic),
+            ("property-reset:is_preload", self.set_generic),
+            ("property-set:guivm", self.set_generic),
+            ("domain-feature-set:gui", self.set_feat_generic),
+            ("domain-feature-delete:gui", self.del_feat_generic),
+            ("domain-feature-set:internal", self.set_feat_generic),
+            ("domain-feature-delete:internal", self.del_feat_generic),
+        ]
+        for event in POWER_EVENTS:
+            handlers.append((event, self.update_domain_item))
+        for event, handler in stats_handlers:
+            self.stats_dispatcher.add_handler(event=event, handler=handler)
+        for event, handler in handlers:
+            self.dispatcher.add_handler(event=event, handler=handler)
+
+    def unregister_events(self) -> None:
+        """
+        Stop watchers.
+        """
+        self.stats_dispatcher.stop()
+        self.dispatcher.stop()
+
+
+class Column:
+    """
+    Column store.
+    """
+
+    columns: dict[str, "Column"] = {}
+
+    def __init__(
+        self,
+        width: int | Callable,
+        header: str,
+        machine_header: str = "",
+        doc: str | None = None,
+        right_justify: bool = True,
+        percentage: bool = False,
+        percentage_intensity: list[int] = [75, 50],
+    ):
+        # pylint: disable=too-many-positional-arguments
+        self.percentage = percentage
+        self.percentage_intensity = percentage_intensity
+        self.__doc__ = doc
+        if isinstance(width, int):
+            self.width = width
+        else:
+            self.width = width(header)
+        self.right_justify = right_justify
+        if self.right_justify:
+            self.header = header.rjust(self.width)
+        else:
+            self.header = header.ljust(self.width)
+        if machine_header:
+            self.machine_header = machine_header
+        else:
+            self.machine_header = self.header.strip()
+        self.columns[self.machine_header] = self
+
+
+class _HelpColumnsAction(Action):
+    """Action for argument parser that displays all columns and exits."""
+
+    # pylint: disable=redefined-builtin
+    def __init__(
+        self,
+        option_strings,
+        dest=SUPPRESS,
+        default=SUPPRESS,
+        help="list all available columns with short descriptions and exit",
+    ):
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            default=default,
+            nargs=0,
+            help=help,
+        )
+
+    def __call__(self, _parser, _namespace, _values, option_string=None):
+        width = max(len(column.header) for column in Column.columns.values())
+        wrapper = TextWrapper(
+            width=80, initial_indent="  ", subsequent_indent=" " * (width + 6)
+        )
+
+        text = "Available columns:\n" + "\n".join(
+            wrapper.fill(
+                "{header:{width}s}  {doc}".format(
+                    header="{} -> {}".format(
+                        column.machine_header, column.header.strip()
+                    ),
+                    doc=column.__doc__ or "",
+                    width=width,
+                )
+            )
+            for column in Column.columns.values()
+        )
+        print(text + "\n")
+        sys_exit(0)
+
+
+class _HelpFormatsAction(Action):
+    """Action for argument parser that displays all formats and exits."""
+
+    # pylint: disable=redefined-builtin
+    def __init__(
+        self,
+        option_strings,
+        dest=SUPPRESS,
+        default=SUPPRESS,
+        help="list all available formats with short descriptions and exit",
+    ):
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            default=default,
+            nargs=0,
+            help=help,
+        )
+
+    def __call__(self, _parser, _namespace, _values, option_string=None):
+        width = max(len(fmt) for fmt in FORMATS)
+        text = "Available formats:\n" + "".join(
+            "  {fmt:{width}s}  {columns}\n".format(
+                fmt=fmt, columns=",".join(columns), width=width
+            )
+            for fmt, columns in FORMATS.items()
+        )
+        print(text)
+        sys_exit(0)
+
+
+Column(
+    header="NAME",
+    machine_header="name",
+    width=31,
+    doc="Qube name",
+    right_justify=False,
+)
+Column(
+    header="STATE",
+    machine_header="state",
+    width=max(len(state) for state in POWER_STATES),
+    doc="Current power state",
+    right_justify=False,
+)
+Column(
+    header="MU",
+    machine_header="memory_used",
+    width=lambda header: max(len(header), 6),
+    doc="How much memory the domain is using",
+)
+Column(
+    header="MSU",
+    machine_header="memory_used_with_swap",
+    width=lambda header: max(len(header), 6),
+    doc="How much memory including swap the domain is using",
+)
+Column(
+    header="MS",
+    machine_header="memory_assigned",
+    width=lambda header: max(len(header), 6),
+    doc="How much memory the domain is allowed to claim at any time",
+)
+Column(
+    header="MM",
+    machine_header="memory_max",
+    width=lambda header: max(len(header), 6),
+    doc="How much memory the domain can try to scale up to",
+)
+Column(
+    header="MU/MM",
+    machine_header="memory_usage_used",
+    width=lambda header: max(len(header), 4),
+    doc="How much memory the domain is using in percentage",
+    percentage=True,
+)
+Column(
+    header="MSU/MU",
+    machine_header="memory_usage_used_with_swap",
+    width=lambda header: max(len(header), 6),
+    doc="How much memory the domain is swaping over what it is using",
+    percentage=True,
+    percentage_intensity=[30, 10],
+)
+Column(
+    header="MS/MM",
+    machine_header="memory_usage_assigned",
+    width=lambda header: max(len(header), 4),
+    doc="How much memory the domain has assigned in percentage",
+    percentage=True,
+)
+Column(
+    header="MU/MS",
+    machine_header="memory_usage_used_assigned",
+    width=lambda header: max(len(header), 4),
+    doc="How much memory the is using from the assigned amount, in percentage",
+    percentage=True,
+)
+Column(
+    header="CPUsec",
+    machine_header="cpu_time",
+    width=lambda header: max(len(header), 8),
+    doc="How many seconds the domain has used from the CPU",
+)
+Column(
+    header="CPU%",
+    machine_header="cpu_usage",
+    width=lambda header: max(len(header), 4),
+    doc="How much CPU the domain is using in percentage",
+    percentage=True,
+)
+Column(
+    header="VC",
+    machine_header="online_vcpus",
+    width=lambda header: max(len(header), 3),
+    doc="How many VCPUs are online",
+)
+
+Column(
+    header="MUi",
+    machine_header="memory_used_internal",
+    width=lambda header: max(len(header), 6),
+    doc="How much memory the domain is using indirectly",
+)
+Column(
+    header="MSi",
+    machine_header="memory_assigned_internal",
+    width=lambda header: max(len(header), 6),
+    doc="How much memory the domain is allowed to claim at any time",
+)
+Column(
+    header="CPUisec",
+    machine_header="cpu_time_internal",
+    width=lambda header: max(len(header), 8),
+    doc="How many seconds the domain has used indirectly from the CPU",
+)
+Column(
+    header="CPUi%",
+    machine_header="cpu_usage_internal",
+    width=lambda header: max(len(header), 4),
+    doc="How much CPU the domain is using indirectly in percentage",
+    percentage=True,
+)
+Column(
+    header="VCi",
+    machine_header="online_vcpus_internal",
+    width=lambda header: max(len(header), 3),
+    doc="How many VCPUs are online indirectly",
+)
+
+
+Column(
+    header="MUT",
+    machine_header="memory_used_total",
+    width=lambda header: max(len(header), 6),
+    doc="How much memory the domain is using in total",
+)
+Column(
+    header="MST",
+    machine_header="memory_assigned_total",
+    width=lambda header: max(len(header), 6),
+    doc="How much memory the domain is allowed to claim at any time",
+)
+Column(
+    header="CPU(s)T",
+    machine_header="cpu_time_total",
+    width=lambda header: max(len(header), 8),
+    doc="How many seconds the domain has used in total from the CPU",
+)
+Column(
+    header="VCT",
+    machine_header="online_vcpus_total",
+    width=lambda header: max(len(header), 3),
+    doc="How many VCPUs are online in total",
+)
+
+
+FORMATS = {
+    "min": ("name", "state", "memory_usage_used", "cpu_usage"),
+    "default": (
+        "name",
+        "state",
+        "memory_used",
+        "memory_max",
+        "memory_usage_used",
+        "cpu_usage",
+        "online_vcpus",
+    ),
+    "max-no-internal": [
+        k for k in list(Column.columns.keys()) if not k.endswith("_internal")
+    ],
+    "max": list(Column.columns.keys()),
+}
+
+
+def column_multiple_choice(value: str):
+    """
+    Validate CSV column values.
+    """
+    if bad := [x for x in value.split(",") if x not in Column.columns]:
+        raise ArgumentTypeError("Invalid choice(s): {}".format(", ".join(bad)))
+    return value
+
+
+parser = QubesArgumentParser(
+    description=__doc__ + " Defaults is to show all non-halted qubes.",
+    vmname_nargs="*",
+    all_default=True,
+    all_include_adminvm=True,
+)
+parser.add_argument(
+    "--show-halted",
+    "-S",
+    action="store_true",
+    default=False,
+    help="don't hide halted qubes",
+)
+parser.add_argument(
+    "--filter",
+    "-f",
+    metavar="FILTER,...",
+    action="store",
+    default="",
+    help="filter domains name matching each fixed string separated by comma",
+)
+
+parser_format = parser.add_argument_group(title="formatting options")
+parser_format_exclusive = parser_format.add_mutually_exclusive_group()
+
+parser_format_exclusive.add_argument(
+    "--columns",
+    "-C",
+    metavar="COLUMN,...",
+    action="store",
+    type=column_multiple_choice,
+    help="show only specified columns",
+)
+parser_format_exclusive.add_argument(
+    "--format",
+    "-F",
+    metavar="FORMAT",
+    action="store",
+    choices=FORMATS.keys(),
+    help="show only columns declared by format: " + ", ".join(FORMATS),
+)
+parser_format.add_argument("--help-columns", action=_HelpColumnsAction)
+parser_format.add_argument("--help-formats", action=_HelpFormatsAction)
+
+parser_sort = parser.add_argument_group(title="sorting options")
+parser_sort.add_argument(
+    "--sort-column",
+    "-k",
+    metavar="COLUMN",
+    action="store",
+    choices=Column.columns,
+    help="sort by specified column",
+)
+parser_sort.add_argument(
+    "--reverse",
+    "-r",
+    action="store_true",
+    help="reverse sorting",
+)
+parser.add_argument(
+    "--no-color",
+    action="store_true",
+    help="do not colorize the screen",
+)
+
+
+async def run_async(args) -> int:
+    """
+    Dispatch events, display statistics and wait for exit.
+    """
+    if args.columns:
+        user_columns = [col.strip() for col in args.columns.split(",")]
+        columns = {col: Column.columns[col] for col in user_columns}
+    else:
+        columns = {
+            machine_header: col
+            for machine_header, col in Column.columns.items()
+            if (not args.format and machine_header in FORMATS["default"])
+            or (args.format and machine_header in FORMATS[args.format])
+        }
+    sort_column = args.sort_column or None
+
+    app = args.app
+    app.cache_enabled = True
+    dispatcher = EventsDispatcher(app)
+    stats_dispatcher = EventsDispatcher(app, api_method="admin.vm.Stats")
+    top = Monitor(
+        all_domains=args.all_domains,
+        app=app,
+        domains=args.domains,
+        dispatcher=dispatcher,
+        stats_dispatcher=stats_dispatcher,
+        show_halted=args.show_halted,
+        sort_column=sort_column,
+        sort_reverse=args.reverse,
+        columns=columns,
+        allow_color=not (args.no_color or NO_COLOR),
+        filter_query=args.filter,
+    )
+    tasks = [
+        create_task(dispatcher.listen_for_events()),
+        create_task(stats_dispatcher.listen_for_events()),
+        create_task(top.run()),
+    ]
+    await gather(*tasks)
+    return 0
+
+
+def main(args=None, app=None) -> int:
+    """
+    Show top-like statistics for all qubes by default, else, show for the
+    specified qubes.
+    """
+    try:
+        args = parser.parse_args(args, app=app)
+        run(run_async(args=args))
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys_exit(main())

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -1947,22 +1947,25 @@ class _HelpColumnsAction(Action):
     def __call__(self, _parser, _namespace, _values, option_string=None):
         width = max(len(column.header) for column in Column.columns.values())
         wrapper = TextWrapper(
-            width=80, initial_indent="  ", subsequent_indent=" " * (width + 6)
+            width=800, initial_indent="  ", subsequent_indent=" " * (width + 6)
         )
 
-        text = "Available columns:\n" + "\n".join(
-            wrapper.fill(
-                "{header:{width}s}  {doc}".format(
-                    header="{} -> {}".format(
-                        column.machine_header, column.header.strip()
-                    ),
-                    doc=column.__doc__ or "",
-                    width=width,
+        text = (
+            "Available columns (machine_header -> header   Description):\n"
+            + "\n".join(
+                wrapper.fill(
+                    "{header:{width}s}  {doc}".format(
+                        header="{} -> {}".format(
+                            column.machine_header, column.header.strip()
+                        ),
+                        doc=column.__doc__ or "",
+                        width=width,
+                    )
                 )
+                for column in Column.columns.values()
             )
-            for column in Column.columns.values()
         )
-        print(text + "\n")
+        print(text)
         sys_exit(0)
 
 
@@ -1997,123 +2000,146 @@ class _HelpFormatsAction(Action):
         sys_exit(0)
 
 
+UNTRUSTED_COLUMN = (
+    "This value or part of it is broadcast by the qube, it can be a lie."
+)
+
 Column(
     header="NAME",
     machine_header="name",
     width=31,
-    doc="Qube name",
+    doc="Qube's name.",
     right_justify=False,
 )
 Column(
     header="STATE",
     machine_header="state",
     width=max(len(state) for state in POWER_STATES),
-    doc="Current power state",
+    doc="Qube's power state.",
     right_justify=False,
 )
+
 Column(
     header="MU",
     machine_header="memory_used",
     width=lambda header: max(len(header), 6),
-    doc="How much memory the domain is using",
+    doc="How much memory the qube alleges to use. " + UNTRUSTED_COLUMN,
 )
 Column(
     header="MSU",
     machine_header="memory_used_with_swap",
     width=lambda header: max(len(header), 6),
-    doc="How much memory including swap the domain is using",
+    doc="How much memory including swap the qube alleges to use. "
+    + UNTRUSTED_COLUMN,
 )
 Column(
     header="MS",
     machine_header="memory_assigned",
     width=lambda header: max(len(header), 6),
-    doc="How much memory the domain is allowed to claim at any time",
+    doc="How much memory has been assigned to the qube, including videoram. A "
+    "qube is allowed to claim this amount at any time, and it cannot use more "
+    "memory than what has been assigned to it. When the system is under no "
+    "memory pressure, this value is close to ``MM``, while when the system is"
+    "under memory pressure, the value can be as low as enough for the qube to "
+    "survive."
 )
 Column(
     header="MM",
     machine_header="memory_max",
     width=lambda header: max(len(header), 6),
-    doc="How much memory the domain can try to scale up to",
+    doc="How much memory the qube can use from the system. Part of this value "
+    "is reserved to videoram, while the rest is up to qmemman to balloon up "
+    "this qube when there is enough free memory on the host."
 )
 Column(
     header="MU/MM",
     machine_header="memory_usage_used",
     width=lambda header: max(len(header), 4),
-    doc="How much memory the domain is using in percentage",
+    doc="How much memory the qube alleges to use compared to the maximum it can"
+    "use from the system, in percentage.",
     percentage=True,
-)
-Column(
-    header="MSU/MU",
-    machine_header="memory_usage_used_with_swap",
-    width=lambda header: max(len(header), 6),
-    doc="How much memory the domain is swaping over what it is using",
-    percentage=True,
-    percentage_intensity=[30, 10],
 )
 Column(
     header="MS/MM",
     machine_header="memory_usage_assigned",
     width=lambda header: max(len(header), 4),
-    doc="How much memory the domain has assigned in percentage",
+    doc="How much memory the qube has assigned compared to the maximum it can "
+    "use from the system, in percentage. A high percentage means the system is "
+    "not pressuring the qube to release memory.",
     percentage=True,
 )
 Column(
     header="MU/MS",
     machine_header="memory_usage_used_assigned",
     width=lambda header: max(len(header), 4),
-    doc="How much memory the is using from the assigned amount, in percentage",
+    doc="How much memory the qube alleges to use from the assigned amount, in "
+    "percentage. A high percentage on non-memory-balanced qubes is irrelevant. "
+    "On memory balanced qubes, a higher value indicates the qube is using a lot"
+    " of the memory it has assigned, which might be near exhaustion, if ``MS`` "
+    "can't be ballooned up anymore.",
     percentage=True,
 )
+Column(
+    header="MSU/MU",
+    machine_header="memory_usage_used_with_swap",
+    width=lambda header: max(len(header), 6),
+    doc="How much memory the qube alleges to be swaping from what it alleges to"
+    "use, in percentage. When it is over 10%, the qube might be swaping too "
+    "much.",
+    percentage=True,
+    percentage_intensity=[30, 10],
+)
+
 Column(
     header="CPUsec",
     machine_header="cpu_time",
     width=lambda header: max(len(header), 8),
-    doc="How many seconds the domain has used from the CPU",
+    doc="How many seconds the qube has used from the CPU.",
 )
 Column(
     header="CPU%",
     machine_header="cpu_usage",
     width=lambda header: max(len(header), 4),
-    doc="How much CPU the domain is using in percentage",
+    doc="How much CPU the qube is using, in percentage.",
     percentage=True,
 )
 Column(
     header="VC",
     machine_header="online_vcpus",
     width=lambda header: max(len(header), 3),
-    doc="How many VCPUs are online",
+    doc="How many Virtual CPUs are online.",
 )
 
 Column(
     header="MUi",
     machine_header="memory_used_internal",
     width=lambda header: max(len(header), 6),
-    doc="How much memory the domain is using indirectly",
+    doc="Same as MU, but internal usage.",
 )
 Column(
     header="MSi",
     machine_header="memory_assigned_internal",
     width=lambda header: max(len(header), 6),
-    doc="How much memory the domain is allowed to claim at any time",
+    doc="Same as ``MS``, but internal usage.",
 )
 Column(
     header="CPUisec",
     machine_header="cpu_time_internal",
     width=lambda header: max(len(header), 8),
-    doc="How many seconds the domain has used indirectly from the CPU",
+    doc="Same as ``CPUsec``, but internal usage.",
 )
 Column(
     header="CPUi%",
     machine_header="cpu_usage_internal",
     width=lambda header: max(len(header), 4),
-    doc="How much CPU the domain is using indirectly in percentage",
+    doc="Same as ``CPU%``, but internal usage.",
     percentage=True,
 )
 Column(
     header="VCi",
     machine_header="online_vcpus_internal",
     width=lambda header: max(len(header), 3),
-    doc="How many VCPUs are online indirectly",
+    doc="Same as ``VC``, but internal usage.",
 )
 
 
@@ -2121,25 +2147,25 @@ Column(
     header="MUT",
     machine_header="memory_used_total",
     width=lambda header: max(len(header), 6),
-    doc="How much memory the domain is using in total",
+    doc="``MU`` + ``MUi``.",
 )
 Column(
     header="MST",
     machine_header="memory_assigned_total",
     width=lambda header: max(len(header), 6),
-    doc="How much memory the domain is allowed to claim at any time",
+    doc="``MS`` + ``MSi``.",
 )
 Column(
-    header="CPU(s)T",
+    header="CPUsecT",
     machine_header="cpu_time_total",
     width=lambda header: max(len(header), 8),
-    doc="How many seconds the domain has used in total from the CPU",
+    doc="``CPUsec`` + ``CPUisec``.",
 )
 Column(
-    header="VCT",
+    header="``VCT``",
     machine_header="online_vcpus_total",
     width=lambda header: max(len(header), 3),
-    doc="How many VCPUs are online in total",
+    doc="``VC`` + ``VCi``.",
 )
 
 

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -2251,26 +2251,38 @@ class _HelpColumnsAction(Action):
         )
 
     def __call__(self, _parser, _namespace, _values, option_string=None):
-        width = max(len(column.header) for column in Column.columns.values())
-        wrapper = TextWrapper(
-            width=800, initial_indent="  ", subsequent_indent=" " * (width + 6)
+        sep = " -> "
+        width = max(
+            len(column.header) + len(sep) + len(column.machine_header)
+            for column in Column.columns.values()
         )
+        text = f"Available columns (machine_header{sep}header   Description):\n"
+        if QUBES_TOP_DEBUG:
+            text += "\n" + "\n".join(
+                ".. option:: {header:{width}s}\n\n   {doc}\n".format(
+                    header=f"{column.machine_header}{sep}{column.header}",
+                    doc=column.__doc__,
+                    width=width,
+                )
+                for column in Column.columns.values()
+            )
 
-        text = (
-            "Available columns (machine_header -> header   Description):\n"
-            + "\n".join(
+        else:
+            wrapper = TextWrapper(
+                width=80,
+                initial_indent="  ",
+                subsequent_indent=" " * (width + 6),
+            )
+            text += "\n".join(
                 wrapper.fill(
                     "{header:{width}s}  {doc}".format(
-                        header="{} -> {}".format(
-                            column.machine_header, column.header.strip()
-                        ),
-                        doc=column.__doc__ or "",
+                        header=f"{column.machine_header}{sep}{column.header}",
+                        doc=column.__doc__,
                         width=width,
                     )
                 )
                 for column in Column.columns.values()
             )
-        )
         print(text)
         sys_exit(0)
 

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -216,6 +216,7 @@ else:
     SORT_SIGN_UP = "^"
     SORT_SIGN_DOWN = "v"
     ELLIPSIS = "..."
+UNTRUSTED_NUMBER_MAX_LEN = 20
 
 
 def convert_html_color_to_curses(hexadecimal: str):
@@ -618,7 +619,6 @@ class Screen:
         self.log = gen_logger(f"{self.__class__.__qualname__}")
         self.getch_timeout = 1000
         self.version: str = metadata("qubesadmin")["version"]
-        self.headers = " ".join(col.header for col in self.columns.values())
 
         self.selected_stats: list[Stats] = []
         self._stats: list[Stats] | None = None
@@ -627,6 +627,7 @@ class Screen:
         self.old_cursor_row = 0
         self.visible_stats: dict[int, Stats] = {}
         self.visible_actions: dict[int, str] = {}
+        self.column_width: dict[str, int] = {}
         self.act = False
         self.actions: list[str] = []
         self.label_index = 0
@@ -1003,6 +1004,9 @@ class Screen:
         ):
             self.cursor_row = self.body_top
 
+        line_content: dict[str, dict[int, tuple]] = {}
+        line_start_after_action = 0
+
         for row_index in range(self.body_height):
             line_start = 0
             curr_height = self.body_top + row_index
@@ -1033,7 +1037,16 @@ class Screen:
                     max_width=width - line_start,
                 )
                 line_start += 1
+                line_start_after_action = line_start
             if row_index >= len(visible):
+                if row_index not in wanted:
+                    continue
+                for column in self.columns.values():
+                    stats = wanted[row_index]
+                    data = getattr(stats, column.machine_header.lower())
+                    line_content.setdefault(
+                        column.machine_header, {}
+                    ).setdefault(curr_height, (data, None))
                 continue
             stats = self.visible_stats[curr_height]
             sel_attr = None
@@ -1082,41 +1095,75 @@ class Screen:
                             color_attr = self.colors["FG_YELLOW"]
                     elif data == "NA":
                         color_attr = self.label_colors["gray"]
-                if column.right_justify:
-                    if len(str(data)) > column.width:
-                        # Either a programming error when setting column width
-                        # or the domain is lying about this value and it's
-                        # better to not show it, as it exceeded our
-                        # expectations.
-                        content = ELLIPSIS.rjust(column.width)
-                    else:
-                        content = str(data).rjust(column.width)
-                else:
-                    content = data.ljust(column.width)[: column.width]
+
+                line_content.setdefault(column.machine_header, {}).setdefault(
+                    curr_height, (data, sel_attr or color_attr)
+                )
+
+        del column
+
+        self.column_width = {}
+        col_line_start: dict[int, int] = {}
+        for machine_header, column in self.columns.items():
+            self.column_width[machine_header] = 0
+            header_sum = 0
+            if machine_header in sums:
+                header_sum = sum(sums[machine_header])
+                header_sum_len = len(str(header_sum))
+                if not column.untrusted or (
+                    column.untrusted
+                    and header_sum_len <= UNTRUSTED_NUMBER_MAX_LEN
+                ):
+                    self.column_width[machine_header] = header_sum_len
+
+            if machine_header not in line_content:
+                continue
+
+            for curr_height, height_data in line_content[
+                machine_header
+            ].items():
+                col_line_start.setdefault(curr_height, line_start_after_action)
+                col_width = len(str(height_data[0]))
+                if col_width > self.column_width[machine_header]:
+                    self.column_width[machine_header] = col_width
+
+            for curr_height, height_data in line_content[
+                machine_header
+            ].items():
+                data, data_attr = height_data
+
+                content_str = str(data)
+                curr_width = self.column_width[machine_header]
+                content = column.justify(content_str, curr_width)
+                if (
+                    column.untrusted
+                    and len(content_str) > UNTRUSTED_NUMBER_MAX_LEN
+                ):
+                    content = column.justify(ELLIPSIS, curr_width)
+
                 if column.summable_for_overall:
-                    header_sum = sum(sums[column.machine_header])
-                    if len(str(header_sum)) > column.width:
-                        sum_content = ELLIPSIS.rjust(column.width)
-                    else:
-                        sum_content = str(header_sum).rjust(column.width)
+                    sum_content = column.justify(str(header_sum), curr_width)
                 else:
                     sum_content = " " * len(content)
+
                 content += " "
                 sum_content += " "
                 self.write(
                     sums_row,
-                    line_start,
+                    col_line_start[curr_height],
                     sum_content,
-                    max_width=width - line_start,
+                    max_width=width - col_line_start[curr_height],
                 )
                 self.write(
                     curr_height,
-                    line_start,
+                    col_line_start[curr_height],
                     content,
-                    attr=sel_attr or color_attr,
-                    max_width=width - line_start,
+                    attr=data_attr,
+                    max_width=width - col_line_start[curr_height],
                 )
-                line_start += len(content)
+                col_line_start[curr_height] += (
+                    max(curr_width, column.min_width) + 1
+                )
 
         memory_total = Stats.host_memory_max
         sum_memory_used_noswap = sum(memory_used_noswap_total)
@@ -1196,7 +1243,12 @@ class Screen:
             sort_col_index = self.sort_col_index
         else:
             sort_col_index = 0
-        sorted_header = str(list(self.columns.values())[sort_col_index].header)
+        sorted_col = list(self.columns.values())[sort_col_index]
+        sorted_header = str(
+            sorted_col.justify(
+                sorted_col.header, self.column_width[sorted_col.machine_header]
+            )
+        )
         sorted_header += sort_sign
 
         header_desc_prefix = "qvm-top"
@@ -1270,12 +1322,13 @@ class Screen:
         if self.act and self.actions:
             action_headers = "ACTION".ljust(ACTION_ALL_WIDTHS)
         pre_headers = " ".join(
-            col.header for col in list(self.columns.values())[:sort_col_index]
+            col.justify(col.header, self.column_width[col.machine_header])
+            for col in list(self.columns.values())[:sort_col_index]
         )
         if sort_col_index > 0:
             pre_headers += " "
         post_headers = " ".join(
-            col.header
+            col.justify(col.header, self.column_width[col.machine_header])
             for col in list(self.columns.values())[sort_col_index + 1 :]
         )
         if post_headers:
@@ -1327,8 +1380,11 @@ class Screen:
                 max_width=width - header_start,
                 attr=self.header_attr,
             )
+            header_end = header_start + len(post_headers)
+        else:
+            header_end = header_start
 
-        current_headers_len = len(self.headers) + len(sort_sign)
+        current_headers_len = header_end
         if self.actions:
             current_headers_len += len(action_headers)
         filter_prefix = "Filter: "
@@ -1691,7 +1747,8 @@ class Screen:
         pos = 0
         # The +1 is to consider space between columns.
         for i, width in enumerate(
-            col.width + 1 for col in self.columns.values()
+            max(column.min_width, self.column_width[machine_header]) + 1
+            for machine_header, column in self.columns.items()
         ):
             if pos <= col < pos + width:
                 return i
@@ -2019,8 +2076,8 @@ class Column:
 
     def __init__(
         self,
-        width: int | Callable,
         header: str,
+        min_width: int | Callable = 0,
         internal: bool = False,
         total: bool = False,
         machine_header: str = "",
@@ -2029,30 +2086,34 @@ class Column:
         percentage: bool = False,
         percentage_intensity: list[int] | None = None,
         summable_for_overall: bool = False,
+        untrusted: bool = False,
     ):
         # pylint: disable=too-many-positional-arguments
         self.internal = internal
         self.total = total
         self.percentage = percentage
         self.summable_for_overall = summable_for_overall
+        self.untrusted = untrusted
         if percentage_intensity is None:
             self.percentage_intensity = [75, 50]
         else:
             self.percentage_intensity = percentage_intensity
         self.__doc__ = doc
-        if isinstance(width, int):
-            self.width = width
-        else:
-            self.width = width(header)
-        self.right_justify = right_justify
-        if self.right_justify:
-            self.header = header.rjust(self.width)
-        else:
-            self.header = header.ljust(self.width)
+
+        self.header = header
         if machine_header:
             self.machine_header = machine_header
         else:
             self.machine_header = self.header.strip()
+        if isinstance(min_width, int):
+            self.min_width = min_width
+        else:
+            self.min_width = min_width(header)
+        self.min_width = max(self.min_width, len(header))
+        if right_justify:
+            self.justify = lambda x, w: x.rjust(max(w, self.min_width))
+        else:
+            self.justify = lambda x, w: x.ljust(max(w, self.min_width))
         self.columns[self.machine_header] = self
 
 
@@ -2139,14 +2200,14 @@ UNTRUSTED_COLUMN = (
 Column(
     header="NAME",
     machine_header="name",
-    width=31,
+    min_width=31,
     doc="Qube's name.",
     right_justify=False,
 )
 Column(
     header="STATE",
     machine_header="state",
-    width=max(len(state) for state in POWER_STATES),
+    min_width=max(len(state) for state in POWER_STATES),
     doc="Qube's power state.",
     right_justify=False,
 )
@@ -2155,7 +2216,7 @@ Column(
 Column(
     header="MI",
     machine_header="memory_init",
-    width=lambda header: max(len(header), 6),
+    min_width=lambda header: max(len(header), 5),
     doc="How much memory the system must reserve for the qube to be able to "
     "initialize. On non-memory-balanced qubes, this is the maximum amount of "
     "memory a domain will ever have while it is running.",
@@ -2163,7 +2224,7 @@ Column(
 Column(
     header="MM",
     machine_header="memory_max",
-    width=lambda header: max(len(header), 6),
+    min_width=lambda header: max(len(header), 5),
     doc="How much memory the qube can use from the system. Part of this value "
     "is reserved to videoram, while the rest is up to qmemman to balloon up "
     "this qube when there is enough free memory on the host.",
@@ -2172,7 +2233,7 @@ Column(
 Column(
     header="MAMT",
     machine_header="memory_assigned_max_total",
-    width=lambda header: max(len(header), 6),
+    min_width=lambda header: max(len(header), 5),
     doc="``MAM`` + ``MAMi``.",
     total=True,
     summable_for_overall=True,
@@ -2180,7 +2241,7 @@ Column(
 Column(
     header="MAUT",
     machine_header="memory_assigned_usable_total",
-    width=lambda header: max(len(header), 6),
+    min_width=lambda header: max(len(header), 5),
     doc="``MAU`` + ``MAUi``.",
     total=True,
     summable_for_overall=True,
@@ -2188,7 +2249,7 @@ Column(
 Column(
     header="MUT",
     machine_header="memory_used_total",
-    width=lambda header: max(len(header), 6),
+    min_width=lambda header: max(len(header), 5),
     doc="``MU`` + ``MUi``.",
     total=True,
     summable_for_overall=True,
@@ -2196,7 +2257,6 @@ Column(
 Column(
     header="CPUsecT",
     machine_header="cpu_time_total",
-    width=lambda header: max(len(header), 10),
     doc="``CPUsec`` + ``CPUisec``.",
     total=True,
     summable_for_overall=True,
@@ -2204,7 +2264,7 @@ Column(
 Column(
     header="VCT",
     machine_header="online_vcpus_total",
-    width=lambda header: max(len(header), 3),
+    min_width=lambda header: max(len(header), 3),
     doc="``VC`` + ``VCi``.",
     total=True,
     summable_for_overall=True,
@@ -2214,14 +2274,14 @@ Column(
 Column(
     header="MAM",
     machine_header="memory_assigned_max",
-    width=lambda header: max(len(header), 6),
+    min_width=lambda header: max(len(header), 5),
     doc="How much memory has been assigned to the qube, including overhead.",
     summable_for_overall=True,
 )
 Column(
     header="MAU",
     machine_header="memory_assigned_usable",
-    width=lambda header: max(len(header), 6),
+    min_width=lambda header: max(len(header), 5),
     doc="How much memory has been assigned to the qube and can be used. A qube "
     "is allowed to claim this amount at any time, and it cannot use more memory"
     " than what has been assigned to it. When the system is under no memory "
@@ -2233,21 +2293,23 @@ Column(
 Column(
     header="MU",
     machine_header="memory_used_noswap",
-    width=lambda header: max(len(header), 6),
+    min_width=lambda header: max(len(header), 5),
     doc="How much memory the qube alleges to use. " + UNTRUSTED_COLUMN,
     summable_for_overall=True,
+    untrusted=True,
 )
 Column(
     header="MUS",
     machine_header="memory_used_swap",
-    width=lambda header: max(len(header), 6),
+    min_width=lambda header: max(len(header), 5),
     doc="How much memory the qube alleges to use for swap. " + UNTRUSTED_COLUMN,
     summable_for_overall=True,
+    untrusted=True,
 )
 Column(
     header="MAM/MM",
     machine_header="memory_usage_assigned",
-    width=lambda header: max(len(header), 4),
+    min_width=lambda header: max(len(header), 5),
     doc="How much memory the qube has assigned compared to the maximum it can "
     "have assigned, in percentage. A high percentage means the system is not "
     "pressuring the qube to release memory.",
@@ -2257,42 +2319,43 @@ Column(
 Column(
     header="MU/MAU",
     machine_header="memory_usage_used",
-    width=lambda header: max(len(header), 4),
+    min_width=lambda header: max(len(header), 5),
     doc="How much memory the qube alleges to use from the assigned amount, in "
     "percentage. A high percentage on non-memory-balanced qubes is irrelevant. "
     "On memory balanced qubes, a higher value indicates the qube is using a lot"
     " of the memory it has assigned, which might be near exhaustion, if ``MAU``"
     " can't be ballooned up anymore.",
     percentage=True,
+    untrusted=True,
 )
 Column(
     header="MUS/MU",
     machine_header="memory_usage_swap_over_used",
-    width=lambda header: max(len(header), 6),
+    min_width=lambda header: max(len(header), 5),
     doc="How much memory the qube alleges to be swaping from what it alleges to"
     "use, in percentage. When it is over 10%, the qube might be swaping too "
     "much.",
     percentage=True,
     percentage_intensity=[30, 10],
+    untrusted=True,
 )
 Column(
     header="CPUsec",
     machine_header="cpu_time",
-    width=lambda header: max(len(header), 10),
     doc="How many seconds the qube has used from the CPU.",
     summable_for_overall=True,
 )
 Column(
     header="CPU%",
     machine_header="cpu_usage",
-    width=lambda header: max(len(header), 4),
+    min_width=lambda header: max(len(header), 5),
     doc="How much CPU the qube is using, in percentage.",
     percentage=True,
 )
 Column(
     header="VC",
     machine_header="online_vcpus",
-    width=lambda header: max(len(header), 3),
+    min_width=lambda header: max(len(header), 3),
     doc="How many Virtual CPUs are online.",
     summable_for_overall=True,
 )
@@ -2301,7 +2364,7 @@ Column(
 Column(
     header="MAMi",
     machine_header="memory_assigned_max_internal",
-    width=lambda header: max(len(header), 6),
+    min_width=lambda header: max(len(header), 5),
     doc="Same as ``MAM``, but internal usage.",
     internal=True,
     summable_for_overall=True,
@@ -2309,7 +2372,7 @@ Column(
 Column(
     header="MAUi",
     machine_header="memory_assigned_usable_internal",
-    width=lambda header: max(len(header), 6),
+    min_width=lambda header: max(len(header), 5),
     doc="Same as ``MAU``, but internal usage.",
     internal=True,
     summable_for_overall=True,
@@ -2317,7 +2380,7 @@ Column(
 Column(
     header="MUi",
     machine_header="memory_used_noswap_internal",
-    width=lambda header: max(len(header), 6),
+    min_width=lambda header: max(len(header), 5),
     doc="Same as ``MU``, but internal usage.",
     internal=True,
     summable_for_overall=True,
@@ -2325,7 +2388,6 @@ Column(
 Column(
     header="CPUisec",
     machine_header="cpu_time_internal",
-    width=lambda header: max(len(header), 10),
     doc="Same as ``CPUsec``, but internal usage.",
     internal=True,
     summable_for_overall=True,
@@ -2333,7 +2395,7 @@ Column(
 Column(
     header="CPUi%",
     machine_header="cpu_usage_internal",
-    width=lambda header: max(len(header), 4),
+    min_width=lambda header: max(len(header), 5),
     doc="Same as ``CPU%``, but internal usage.",
     percentage=True,
     internal=True,
@@ -2341,7 +2403,7 @@ Column(
 Column(
     header="VCi",
     machine_header="online_vcpus_internal",
-    width=lambda header: max(len(header), 3),
+    min_width=lambda header: max(len(header), 3),
     doc="Same as ``VC``, but internal usage.",
     internal=True,
     summable_for_overall=True,

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -623,7 +623,7 @@ class Screen:
         self.selected_stats: list[Stats] = []
         self._stats: list[Stats] | None = None
 
-        self.header_row = 3
+        self.header_row = 4
         self.old_cursor_row = 0
         self.visible_stats: dict[int, Stats] = {}
         self.visible_actions: dict[int, str] = {}
@@ -926,6 +926,8 @@ class Screen:
         # pylint: disable=too-many-locals,too-many-statements,too-many-branches
         self.stdscr.erase()
         height, width = self.stdscr.getmaxyx()
+        sums_row = self.header_row - 1
+        self.body_top = self.header_row + 1
         self.body_top = self.header_row + 1
         self.body_bottom = height - 1
         self.body_height = max(0, self.body_bottom - self.body_top)
@@ -971,6 +973,16 @@ class Screen:
             if isinstance(stats.memory_assigned_max_total, int)
         ]
         states = [stats.state for stats in wanted]
+        sums: dict[str, list[int]] = {}
+        for machine_header, column in self.columns.items():
+            if not column.summable_for_overall:
+                continue
+            sums[machine_header] = [
+                val
+                for stats in wanted
+                if (val := getattr(stats, machine_header, "NA"))
+                and isinstance(val, int)
+            ]
 
         if self.sort_reverse:
             sort_sign = SORT_SIGN_UP
@@ -1081,7 +1093,22 @@ class Screen:
                         content = str(data).rjust(column.width)
                 else:
                     content = data.ljust(column.width)[: column.width]
+                if column.summable_for_overall:
+                    header_sum = sum(sums[column.machine_header])
+                    if len(str(header_sum)) > column.width:
+                        sum_content = ELLIPSIS.rjust(column.width)
+                    else:
+                        sum_content = str(header_sum).rjust(column.width)
+                else:
+                    sum_content = " " * len(content)
                 content += " "
+                sum_content += " "
+                self.write(
+                    sums_row,
+                    line_start,
+                    sum_content,
+                    max_width=width - line_start,
+                )
                 self.write(
                     curr_height,
                     line_start,
@@ -1259,7 +1286,7 @@ class Screen:
         header_start = 0
         if action_headers:
             self.write(
-                3,
+                self.header_row,
                 0,
                 action_headers,
                 max_width=width - header_start,
@@ -1267,14 +1294,14 @@ class Screen:
             )
             header_start += len(action_headers)
             self.write(
-                3,
+                self.header_row,
                 header_start,
                 " ",
                 max_width=width - header_start,
             )
             header_start += 1
         self.write(
-            3,
+            self.header_row,
             header_start,
             pre_headers,
             max_width=width - header_start,
@@ -1284,7 +1311,7 @@ class Screen:
         self.log.debug("pre-sort-start=%s", header_start)
         if header_start < width:
             self.write(
-                3,
+                self.header_row,
                 header_start,
                 sorted_header,
                 max_width=width - header_start,
@@ -1294,7 +1321,7 @@ class Screen:
         self.log.debug("post-sort-start=%s", header_start)
         if len(post_headers.strip()) > 0 and header_start < width:
             self.write(
-                3,
+                self.header_row,
                 header_start,
                 post_headers,
                 max_width=width - header_start,
@@ -2001,11 +2028,13 @@ class Column:
         right_justify: bool = True,
         percentage: bool = False,
         percentage_intensity: list[int] | None = None,
+        summable_for_overall: bool = False,
     ):
         # pylint: disable=too-many-positional-arguments
         self.internal = internal
         self.total = total
         self.percentage = percentage
+        self.summable_for_overall = summable_for_overall
         if percentage_intensity is None:
             self.percentage_intensity = [75, 50]
         else:
@@ -2146,6 +2175,7 @@ Column(
     width=lambda header: max(len(header), 6),
     doc="``MAM`` + ``MAMi``.",
     total=True,
+    summable_for_overall=True,
 )
 Column(
     header="MAUT",
@@ -2153,6 +2183,7 @@ Column(
     width=lambda header: max(len(header), 6),
     doc="``MAU`` + ``MAUi``.",
     total=True,
+    summable_for_overall=True,
 )
 Column(
     header="MUT",
@@ -2160,6 +2191,7 @@ Column(
     width=lambda header: max(len(header), 6),
     doc="``MU`` + ``MUi``.",
     total=True,
+    summable_for_overall=True,
 )
 Column(
     header="CPUsecT",
@@ -2167,6 +2199,7 @@ Column(
     width=lambda header: max(len(header), 10),
     doc="``CPUsec`` + ``CPUisec``.",
     total=True,
+    summable_for_overall=True,
 )
 Column(
     header="VCT",
@@ -2174,6 +2207,7 @@ Column(
     width=lambda header: max(len(header), 3),
     doc="``VC`` + ``VCi``.",
     total=True,
+    summable_for_overall=True,
 )
 
 # Standard
@@ -2182,6 +2216,7 @@ Column(
     machine_header="memory_assigned_max",
     width=lambda header: max(len(header), 6),
     doc="How much memory has been assigned to the qube, including overhead.",
+    summable_for_overall=True,
 )
 Column(
     header="MAU",
@@ -2193,18 +2228,21 @@ Column(
     "pressure, this value is close to ``MM``, while when the system is under "
     "memory pressure, the value can be as low as enough for the qube to "
     "survive.",
+    summable_for_overall=True,
 )
 Column(
     header="MU",
     machine_header="memory_used_noswap",
     width=lambda header: max(len(header), 6),
     doc="How much memory the qube alleges to use. " + UNTRUSTED_COLUMN,
+    summable_for_overall=True,
 )
 Column(
     header="MUS",
     machine_header="memory_used_swap",
     width=lambda header: max(len(header), 6),
     doc="How much memory the qube alleges to use for swap. " + UNTRUSTED_COLUMN,
+    summable_for_overall=True,
 )
 Column(
     header="MAM/MM",
@@ -2242,6 +2280,7 @@ Column(
     machine_header="cpu_time",
     width=lambda header: max(len(header), 10),
     doc="How many seconds the qube has used from the CPU.",
+    summable_for_overall=True,
 )
 Column(
     header="CPU%",
@@ -2255,6 +2294,7 @@ Column(
     machine_header="online_vcpus",
     width=lambda header: max(len(header), 3),
     doc="How many Virtual CPUs are online.",
+    summable_for_overall=True,
 )
 
 # Internal
@@ -2264,6 +2304,7 @@ Column(
     width=lambda header: max(len(header), 6),
     doc="Same as ``MAM``, but internal usage.",
     internal=True,
+    summable_for_overall=True,
 )
 Column(
     header="MAUi",
@@ -2271,6 +2312,7 @@ Column(
     width=lambda header: max(len(header), 6),
     doc="Same as ``MAU``, but internal usage.",
     internal=True,
+    summable_for_overall=True,
 )
 Column(
     header="MUi",
@@ -2278,6 +2320,7 @@ Column(
     width=lambda header: max(len(header), 6),
     doc="Same as ``MU``, but internal usage.",
     internal=True,
+    summable_for_overall=True,
 )
 Column(
     header="CPUisec",
@@ -2285,6 +2328,7 @@ Column(
     width=lambda header: max(len(header), 10),
     doc="Same as ``CPUsec``, but internal usage.",
     internal=True,
+    summable_for_overall=True,
 )
 Column(
     header="CPUi%",
@@ -2300,6 +2344,7 @@ Column(
     width=lambda header: max(len(header), 3),
     doc="Same as ``VC``, but internal usage.",
     internal=True,
+    summable_for_overall=True,
 )
 
 

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -1028,6 +1028,13 @@ class Screen:
             and self.cursor_row > len(self.visible_stats) + self.header_row
         ):
             self.cursor_row = self.body_top
+        elif self.cursor_row == -1:
+            if self.last_selected_stat in visible:
+                self.cursor_row = (
+                    visible.index(self.last_selected_stat) + self.body_top
+                )
+            else:
+                self.cursor_row = self.body_top
 
         line_content: dict[str, dict[int, tuple]] = {}
         line_start_after_action = 0
@@ -1597,7 +1604,7 @@ class Screen:
         Cancel action mode.
         """
         self.act = False
-        self.cursor_row = self.body_top
+        self.cursor_row = -1
 
     def getch(self) -> bool | None:
         """
@@ -1748,6 +1755,9 @@ class Screen:
             if self.get_action_from_selection():
                 self.cursor_row = self.body_top
                 self.act = True
+                return True
+            if self.act:
+                self.act = False
                 return True
 
         elif not self.act and char in (ord("/"),):

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -217,6 +217,9 @@ else:
     SORT_SIGN_DOWN = "v"
     ELLIPSIS = "..."
 UNTRUSTED_NUMBER_MAX_LEN = 20
+MEMORY_UNIT = "MiB"
+MEMORY_UNIT_PRECISION = 0
+MEMORY_UNIT_AVAILABLE = ["KiB", "MiB", "GiB.0", "GiB.1", "GiB.2", "GiB.3"]
 
 
 def convert_html_color_to_curses(hexadecimal: str):
@@ -252,9 +255,30 @@ def gen_logger(name: str) -> Logger:
     return logger
 
 
+def convert_memory(number: int) -> int | float:
+    """
+    Convert memory data to the expected unit.
+    """
+    precision: int | None = MEMORY_UNIT_PRECISION
+    if precision == 0:
+        precision = None
+    match MEMORY_UNIT:
+        case "KiB":
+            return number
+        case "MiB":
+            return number // 1024
+        case "GiB":
+            return round(float(number / 1024**2), precision)
+        case _:
+            raise ValueError("Unknown MEMORY_UNIT")
+
+
 class Stats:
     """
     Storage qube statistics.
+
+    Memory is always saved in KiB to avoid rounding errors when values are
+    calculated by clients.
     """
 
     # pylint: disable=too-many-instance-attributes
@@ -314,9 +338,9 @@ class Stats:
 
         if self.__class__.host_checked is False:
             self.__class__.host_checked = True
-            host_memory_max = getattr(self.vm.app, "maxmem", "NA")
+            host_memory_max: int | str = getattr(self.vm.app, "maxmem", "NA")
             if isinstance(host_memory_max, int):
-                host_memory_max = int(host_memory_max) // 1024
+                host_memory_max = int(host_memory_max) * 1024
             self.__class__.host_memory_max = host_memory_max
             self.__class__.host_no_cpus = getattr(self.vm.app, "no_cpus", "NA")
 
@@ -424,16 +448,18 @@ class Stats:
                 else self.features_default["internal"]
             ),
         }
+        for k in ["memory_init", "memory_max"]:
+            if isinstance(data[k], int):
+                data[k] = data[k] * 1024
+
         self.set_verbose(data)
 
     def update_stats(self, **kwargs: Any) -> None:
         """
         Update memory and CPU statistics.
         """
-        memory_assigned_max = int(kwargs["memory_assigned_max_KiB"]) // 1024
-        memory_assigned_usable = (
-            int(kwargs["memory_assigned_usable_KiB"]) // 1024
-        )
+        memory_assigned_max = int(kwargs["memory_assigned_max_KiB"])
+        memory_assigned_usable = int(kwargs["memory_assigned_usable_KiB"])
         memory_assigned_max_internal = kwargs.get(
             "memory_assigned_max_KiB_internal"
         )
@@ -444,9 +470,7 @@ class Stats:
             memory_assigned_max_internal = "NA"
             memory_assigned_max_total = memory_assigned_max
         else:
-            memory_assigned_max_internal = (
-                int(memory_assigned_max_internal) // 1024
-            )
+            memory_assigned_max_internal = int(memory_assigned_max_internal)
             memory_assigned_max_total = (
                 memory_assigned_max + memory_assigned_max_internal
             )
@@ -454,15 +478,15 @@ class Stats:
             memory_assigned_usable_internal = "NA"
             memory_assigned_usable_total = memory_assigned_usable
         else:
-            memory_assigned_usable_internal = (
-                int(memory_assigned_usable_internal) // 1024
+            memory_assigned_usable_internal = int(
+                memory_assigned_usable_internal
             )
             memory_assigned_usable_total = (
                 memory_assigned_usable + memory_assigned_usable_internal
             )
 
-        memory_used_swap = int(kwargs["memory_used_swap_KiB"]) // 1024
-        memory_used_noswap = int(kwargs["memory_used_noswap_KiB"]) // 1024
+        memory_used_swap = int(kwargs["memory_used_swap_KiB"])
+        memory_used_noswap = int(kwargs["memory_used_noswap_KiB"])
         memory_used_noswap_internal = kwargs.get(
             "memory_used_noswap_KiB_internal"
         )
@@ -470,9 +494,7 @@ class Stats:
             memory_used_noswap_internal = "NA"
             memory_used_noswap_total = memory_used_noswap
         else:
-            memory_used_noswap_internal = (
-                int(memory_used_noswap_internal) // 1024
-            )
+            memory_used_noswap_internal = int(memory_used_noswap_internal)
             memory_used_noswap_total = (
                 memory_used_noswap + memory_used_noswap_internal
             )
@@ -485,9 +507,12 @@ class Stats:
             )
         else:
             memory_usage_assigned = "NA"
-        memory_usage_used: float | str = round(
-            float(memory_used_noswap / memory_assigned_usable) * 100, 1
-        )
+        if memory_assigned_usable > 0:
+            memory_usage_used: float | str = round(
+                float(memory_used_noswap / memory_assigned_usable) * 100, 1
+            )
+        else:
+            memory_usage_used = 0.0
         if memory_used_noswap > 0:
             memory_usage_swap_over_used: float | str = round(
                 float(memory_used_swap / memory_used_noswap) * 100, 1
@@ -551,13 +576,13 @@ class Stats:
         """
         Update initial memory.
         """
-        self.set_verbose({"memory_init": value})
+        self.set_verbose({"memory_init": value * 1024})
 
     def update_memory_max(self, value: int) -> None:
         """
         Update maximum memory and it's related properties.
         """
-        memory_max = int(value)
+        memory_max = int(value) * 1024
         if memory_max > 0:
             memory_usage_assigned: float | str = "NA"
             if isinstance(self.memory_assigned_max, int):
@@ -982,7 +1007,7 @@ class Screen:
                 val
                 for stats in wanted
                 if (val := getattr(stats, machine_header, "NA"))
-                and isinstance(val, int)
+                and isinstance(val, (int, float))
             ]
 
         if self.sort_reverse:
@@ -1100,6 +1125,13 @@ class Screen:
                     ):
                         color_attr = self.label_colors["gray"]
 
+                if (
+                    isinstance(data, int)
+                    and not column.percentage
+                    and column.memory_convertable
+                ):
+                    data = convert_memory(data)
+
                 line_content.setdefault(column.machine_header, {}).setdefault(
                     curr_height, (data, sel_attr or color_attr)
                 )
@@ -1110,10 +1142,18 @@ class Screen:
         col_line_start: dict[int, int] = {}
         for machine_header, column in self.columns.items():
             self.column_width[machine_header] = 0
-            header_sum = 0
+            header_sum: int | float = 0
             if machine_header in sums:
                 header_sum = sum(sums[machine_header])
-                header_sum_len = len(str(header_sum))
+                if column.memory_convertable:
+                    header_sum = convert_memory(header_sum)
+                if not column.percentage and isinstance(header_sum, float):
+                    header_sum_formatted = (
+                        f"{header_sum:.{MEMORY_UNIT_PRECISION}f}"
+                    )
+                else:
+                    header_sum_formatted = str(header_sum)
+                header_sum_len = len(str(header_sum_formatted))
                 if not column.untrusted or (
                     column.untrusted
                     and header_sum_len <= UNTRUSTED_NUMBER_MAX_LEN
@@ -1136,7 +1176,10 @@ class Screen:
             ].items():
                 data, data_attr = height_data
 
-                content_str = str(data)
+                if not column.percentage and isinstance(data, float):
+                    content_str = f"{data:.{MEMORY_UNIT_PRECISION}f}"
+                else:
+                    content_str = str(data)
                 curr_width = self.column_width[machine_header]
                 content = column.justify(content_str, curr_width)
                 if (
@@ -1146,7 +1189,9 @@ class Screen:
                     content = column.justify(ELLIPSIS, curr_width)
 
                 if column.summable_for_overall:
-                    sum_content = column.justify(str(header_sum), curr_width)
+                    sum_content = column.justify(
+                        header_sum_formatted, curr_width
+                    )
                 else:
                     sum_content = " " * len(content)
 
@@ -1170,13 +1215,17 @@ class Screen:
                 )
 
         memory_total = Stats.host_memory_max
-        sum_memory_used_noswap = sum(memory_used_noswap_total)
-        sum_memory_used_swap = sum(memory_used_swap_total)
-        sum_memory_assigned_max_total = sum(memory_assigned_max_total)
+        if isinstance(memory_total, int):
+            memory_total = convert_memory(memory_total)
+        sum_memory_used_noswap = convert_memory(sum(memory_used_noswap_total))
+        sum_memory_used_swap = convert_memory(sum(memory_used_swap_total))
+        sum_memory_assigned_max_total = convert_memory(
+            sum(memory_assigned_max_total)
+        )
         pct_memory_used_noswap: float | str = "NA"
         pct_memory_used_swap: float | str = "NA"
         pct_memory_assigned_max_total: float | str = "NA"
-        if isinstance(memory_total, int):
+        if isinstance(memory_total, (int, float)):
             pct_memory_used_noswap = round(
                 sum_memory_used_noswap / memory_total * 100, 1
             )
@@ -1190,7 +1239,12 @@ class Screen:
         no_cpus = Stats.host_no_cpus
         header_cpu_prefix = "  CPUs"
         header_cpu_suffix = ": {}".format(no_cpus)
-        header_mem_prefix = "Mem"
+        if MEMORY_UNIT_PRECISION == 0:
+            header_mem_prefix = "Mem({})".format(MEMORY_UNIT)
+        else:
+            header_mem_prefix = "Mem({}.{})".format(
+                MEMORY_UNIT, MEMORY_UNIT_PRECISION
+            )
         total_mem_len = len(str(memory_total))
         header_mem_total = "{}".format(memory_total)
         header_mem_assigned_max_total = "{}({}%) assigned".format(
@@ -2091,6 +2145,7 @@ class Column:
         percentage_intensity: list[int] | None = None,
         summable_for_overall: bool = False,
         untrusted: bool = False,
+        memory_convertable: bool = False,
     ):
         # pylint: disable=too-many-positional-arguments
         self.internal = internal
@@ -2098,6 +2153,7 @@ class Column:
         self.percentage = percentage
         self.summable_for_overall = summable_for_overall
         self.untrusted = untrusted
+        self.memory_convertable = memory_convertable
         if percentage_intensity is None:
             self.percentage_intensity = [75, 50]
         else:
@@ -2109,7 +2165,7 @@ class Column:
             self.machine_header = machine_header
         else:
             self.machine_header = self.header.strip()
-        if isinstance(min_width, int):
+        if isinstance(min_width, (int, float)):
             self.min_width = min_width
         else:
             self.min_width = min_width(header)
@@ -2224,6 +2280,7 @@ Column(
     doc="How much memory the system must reserve for the qube to be able to "
     "initialize. On non-memory-balanced qubes, this is the maximum amount of "
     "memory a domain will ever have while it is running.",
+    memory_convertable=True,
 )
 Column(
     header="MM",
@@ -2232,6 +2289,7 @@ Column(
     doc="How much memory the qube can use from the system. Part of this value "
     "is reserved to videoram, while the rest is up to qmemman to balloon up "
     "this qube when there is enough free memory on the host.",
+    memory_convertable=True,
 )
 
 Column(
@@ -2241,6 +2299,7 @@ Column(
     doc="``MAM`` + ``MAMi``.",
     total=True,
     summable_for_overall=True,
+    memory_convertable=True,
 )
 Column(
     header="MAUT",
@@ -2249,6 +2308,7 @@ Column(
     doc="``MAU`` + ``MAUi``.",
     total=True,
     summable_for_overall=True,
+    memory_convertable=True,
 )
 Column(
     header="MUT",
@@ -2257,6 +2317,7 @@ Column(
     doc="``MU`` + ``MUi``.",
     total=True,
     summable_for_overall=True,
+    memory_convertable=True,
 )
 Column(
     header="CPUsecT",
@@ -2281,6 +2342,7 @@ Column(
     min_width=lambda header: max(len(header), 5),
     doc="How much memory has been assigned to the qube, including overhead.",
     summable_for_overall=True,
+    memory_convertable=True,
 )
 Column(
     header="MAU",
@@ -2293,6 +2355,7 @@ Column(
     "memory pressure, the value can be as low as enough for the qube to "
     "survive.",
     summable_for_overall=True,
+    memory_convertable=True,
 )
 Column(
     header="MU",
@@ -2301,6 +2364,7 @@ Column(
     doc="How much memory the qube alleges to use. " + UNTRUSTED_COLUMN,
     summable_for_overall=True,
     untrusted=True,
+    memory_convertable=True,
 )
 Column(
     header="MUS",
@@ -2309,6 +2373,7 @@ Column(
     doc="How much memory the qube alleges to use for swap. " + UNTRUSTED_COLUMN,
     summable_for_overall=True,
     untrusted=True,
+    memory_convertable=True,
 )
 Column(
     header="MAM/MM",
@@ -2475,6 +2540,15 @@ parser.add_argument(
     default="",
     help="filter domains name matching each fixed string separated by comma",
 )
+parser.add_argument(
+    "--memory-unit",
+    action="store",
+    choices=MEMORY_UNIT_AVAILABLE,
+    default=MEMORY_UNIT,
+    metavar="UNIT",
+    help="Unit to use for displaying memory. The digit after the dot is the "
+    "precision. Available: " + ", ".join(MEMORY_UNIT_AVAILABLE),
+)
 
 parser_format = parser.add_argument_group(title="formatting options")
 parser_format_exclusive = parser_format.add_mutually_exclusive_group()
@@ -2524,6 +2598,11 @@ async def run_async(args) -> int:
     """
     Dispatch events, display statistics and wait for exit.
     """
+    global MEMORY_UNIT  # pylint: disable=global-statement
+    global MEMORY_UNIT_PRECISION  # pylint: disable=global-statement
+    MEMORY_UNIT = args.memory_unit.split(".")[0]
+    if "." in args.memory_unit:
+        MEMORY_UNIT_PRECISION = int(args.memory_unit.split(".")[1])
     if args.columns:
         user_columns = [col.strip() for col in args.columns.split(",")]
     elif args.format:

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -309,31 +309,23 @@ class Stats:
         self.memory_init: int | str = "NA"
         self.update_cache()
 
-        self.memory_assigned_max: int | str = "NA"
+        self.memory_assigned_total: int | str = "NA"
         self.memory_assigned_usable: int | str = "NA"
         self.memory_usage_assigned: float | str = "NA"
         self.memory_used_noswap: int | str = "NA"
-        self.memory_used_swap: int | str = "NA"
+        self.swap_used: int | str = "NA"
         self.memory_usage_used: float | str = "NA"
         self.memory_usage_swap_over_used: float | str = "NA"
         self.cpu_time: int | str = "NA"
         self.cpu_usage: int | str = "NA"
         self.online_vcpus: int | str = "NA"
 
-        self.memory_assigned_max_internal: int | str = "NA"
-        self.memory_assigned_usable_internal: int | str = "NA"
-        self.memory_used_noswap_internal: int | str = "NA"
         self.cpu_time_internal: int | str = "NA"
         self.cpu_usage_internal: float | str = "NA"
         self.online_vcpus_internal: int | str = "NA"
 
-        self.memory_assigned_max_total: int | str = "NA"
-        self.memory_assigned_usable_total: int | str = "NA"
-        self.memory_used_noswap_total: int | str = "NA"
-        self.memory_used_swap_total: int | str = "NA"
         self.memory_used_total: int | str = "NA"
         self.cpu_time_total: int | str = "NA"
-        self.cpu_usage_total: float | str = "NA"
         self.online_vcpus_total: int | str = "NA"
 
         if self.__class__.host_checked is False:
@@ -458,65 +450,47 @@ class Stats:
         """
         Update memory and CPU statistics.
         """
-        memory_assigned_max = int(kwargs["memory_assigned_max_KiB"])
-        memory_assigned_usable = int(kwargs["memory_assigned_usable_KiB"])
-        memory_assigned_max_internal = kwargs.get(
-            "memory_assigned_max_KiB_internal"
-        )
-        memory_assigned_usable_internal = kwargs.get(
-            "memory_assigned_usable_KiB_internal"
-        )
-        if memory_assigned_max_internal is None:
-            memory_assigned_max_internal = "NA"
-            memory_assigned_max_total = memory_assigned_max
+        memory_assigned_total = int(kwargs["memory_assigned_total"])
+        memory_assigned_usable = int(kwargs["memory_assigned_usable"])
+        memory_with_swap_used = int(kwargs["memory_with_swap_used"])
+        memory_used_total = memory_with_swap_used
+        swap_used = kwargs.get("swap_used")
+        if swap_used:
+            swap_used = int(swap_used)
+            memory_used_noswap = round(
+                memory_with_swap_used - swap_used, MEMORY_UNIT_PRECISION
+            )
         else:
-            memory_assigned_max_internal = int(memory_assigned_max_internal)
-            memory_assigned_max_total = (
-                memory_assigned_max + memory_assigned_max_internal
-            )
-        if memory_assigned_usable_internal is None:
-            memory_assigned_usable_internal = "NA"
-            memory_assigned_usable_total = memory_assigned_usable
-        else:
-            memory_assigned_usable_internal = int(
-                memory_assigned_usable_internal
-            )
-            memory_assigned_usable_total = (
-                memory_assigned_usable + memory_assigned_usable_internal
-            )
-
-        memory_used_swap = int(kwargs["memory_used_swap_KiB"])
-        memory_used_noswap = int(kwargs["memory_used_noswap_KiB"])
-        memory_used_noswap_internal = kwargs.get(
-            "memory_used_noswap_KiB_internal"
-        )
-        if memory_used_noswap_internal is None:
-            memory_used_noswap_internal = "NA"
-            memory_used_noswap_total = memory_used_noswap
-        else:
-            memory_used_noswap_internal = int(memory_used_noswap_internal)
-            memory_used_noswap_total = (
-                memory_used_noswap + memory_used_noswap_internal
-            )
-        memory_used_swap_total = memory_used_swap
-        memory_used_total = memory_used_swap_total + memory_used_noswap_total
+            swap_used = "NA"
+            memory_used_noswap = "NA"
 
         if isinstance(self.memory_max, int) and self.memory_max > 0:
             memory_usage_assigned: float | str = round(
-                float(memory_assigned_max / self.memory_max) * 100, 1
+                float(memory_assigned_total / self.memory_max) * 100, 1
             )
         else:
             memory_usage_assigned = "NA"
         if memory_assigned_usable > 0:
-            memory_usage_used: float | str = round(
-                float(memory_used_noswap / memory_assigned_usable) * 100, 1
-            )
+            if isinstance(memory_used_noswap, (int, float)):
+                memory_usage_used: float | str = round(
+                    float(memory_used_noswap / memory_assigned_usable) * 100, 1
+                )
+            else:
+                memory_usage_used = "NA"
         else:
             memory_usage_used = 0.0
-        if memory_used_noswap > 0:
+        if (
+            isinstance(memory_used_noswap, (int, float))
+            and memory_used_noswap > 0
+            and isinstance(swap_used, (int, float))
+        ):
             memory_usage_swap_over_used: float | str = round(
-                float(memory_used_swap / memory_used_noswap) * 100, 1
+                float(swap_used / memory_used_noswap) * 100, 1
             )
+        elif not isinstance(memory_used_noswap, (int, float)) or not isinstance(
+            swap_used, (int, float)
+        ):
+            memory_usage_swap_over_used = "NA"
         else:
             memory_usage_swap_over_used = 0.0
 
@@ -546,27 +520,20 @@ class Stats:
             online_vcpus_total = online_vcpus + online_vcpus_internal
 
         data = {
-            "memory_assigned_max": memory_assigned_max,
+            "memory_assigned_total": memory_assigned_total,
             "memory_assigned_usable": memory_assigned_usable,
+            "memory_used_total": memory_used_total,
             "memory_used_noswap": memory_used_noswap,
-            "memory_used_swap": memory_used_swap,
+            "swap_used": swap_used,
             "memory_usage_used": memory_usage_used,
             "memory_usage_assigned": memory_usage_assigned,
             "memory_usage_swap_over_used": memory_usage_swap_over_used,
             "cpu_time": cpu_time,
             "cpu_usage": cpu_usage,
             "online_vcpus": online_vcpus,
-            "memory_assigned_usable_internal": memory_assigned_usable_internal,
-            "memory_assigned_max_internal": memory_assigned_max_internal,
-            "memory_used_noswap_internal": memory_used_noswap_internal,
             "cpu_time_internal": cpu_time_internal,
             "cpu_usage_internal": cpu_usage_internal,
             "online_vcpus_internal": online_vcpus_internal,
-            "memory_assigned_usable_total": memory_assigned_usable_total,
-            "memory_assigned_max_total": memory_assigned_max_total,
-            "memory_used_noswap_total": memory_used_noswap_total,
-            "memory_used_swap_total": memory_used_swap_total,
-            "memory_used_total": memory_used_total,
             "cpu_time_total": cpu_time_total,
             "online_vcpus_total": online_vcpus_total,
         }
@@ -585,9 +552,9 @@ class Stats:
         memory_max = int(value) * 1024
         if memory_max > 0:
             memory_usage_assigned: float | str = "NA"
-            if isinstance(self.memory_assigned_max, int):
+            if isinstance(self.memory_assigned_total, int):
                 memory_usage_assigned = round(
-                    float(self.memory_assigned_max / memory_max) * 100, 1
+                    float(self.memory_assigned_total / memory_max) * 100, 1
                 )
         else:
             memory_usage_assigned = "NA"
@@ -991,19 +958,19 @@ class Screen:
         action_visible = self.actions[action_scroll_start:action_scroll_end]
 
         memory_used_noswap_total: list[int] = [
-            stats.memory_used_noswap_total
+            stats.memory_used_noswap
             for stats in wanted
-            if isinstance(stats.memory_used_noswap_total, int)
+            if isinstance(stats.memory_used_noswap, int)
         ]
-        memory_used_swap_total: list[int] = [
-            stats.memory_used_swap_total
+        swap_used_total: list[int] = [
+            stats.swap_used
             for stats in wanted
-            if isinstance(stats.memory_used_swap_total, int)
+            if isinstance(stats.swap_used, int)
         ]
-        memory_assigned_max_total: list[int] = [
-            stats.memory_assigned_max_total
+        memory_assigned_total_total: list[int] = [
+            stats.memory_assigned_total
             for stats in wanted
-            if isinstance(stats.memory_assigned_max_total, int)
+            if isinstance(stats.memory_assigned_total, int)
         ]
         states = [stats.state for stats in wanted]
         sums: dict[str, list[int]] = {}
@@ -1260,22 +1227,20 @@ class Screen:
         if isinstance(memory_total, int):
             memory_total = convert_memory(memory_total)
         sum_memory_used_noswap = convert_memory(sum(memory_used_noswap_total))
-        sum_memory_used_swap = convert_memory(sum(memory_used_swap_total))
-        sum_memory_assigned_max_total = convert_memory(
-            sum(memory_assigned_max_total)
+        sum_swap_used = convert_memory(sum(swap_used_total))
+        sum_memory_assigned_total_total = convert_memory(
+            sum(memory_assigned_total_total)
         )
         pct_memory_used_noswap: float | str = "NA"
-        pct_memory_used_swap: float | str = "NA"
-        pct_memory_assigned_max_total: float | str = "NA"
+        pct_swap_used: float | str = "NA"
+        pct_memory_assigned_total_total: float | str = "NA"
         if isinstance(memory_total, (int, float)):
             pct_memory_used_noswap = round(
                 sum_memory_used_noswap / memory_total * 100, 1
             )
-            pct_memory_used_swap = round(
-                sum_memory_used_swap / memory_total * 100, 1
-            )
-            pct_memory_assigned_max_total = round(
-                sum_memory_assigned_max_total / memory_total * 100, 1
+            pct_swap_used = round(sum_swap_used / memory_total * 100, 1)
+            pct_memory_assigned_total_total = round(
+                sum_memory_assigned_total_total / memory_total * 100, 1
             )
 
         no_cpus = Stats.host_no_cpus
@@ -1291,8 +1256,8 @@ class Screen:
         header_mem_total = "{}".format(memory_total)
 
         header_mem_assigned_max_total = "{}({}%) {}".format(
-            str(sum_memory_assigned_max_total).rjust(total_mem_len),
-            pct_memory_assigned_max_total,
+            str(sum_memory_assigned_total_total).rjust(total_mem_len),
+            pct_memory_assigned_total_total,
             assigned_text,
         )
         header_mem_used_noswap = "{}({}%) {}".format(
@@ -1301,8 +1266,8 @@ class Screen:
             used_text,
         )
         header_mem_used_swap = "{}({}%) {}".format(
-            str(sum_memory_used_swap).rjust(total_mem_len),
-            pct_memory_used_swap,
+            str(sum_swap_used).rjust(total_mem_len),
+            pct_swap_used,
             swap_text,
         )
         header_mem_suffix = ": "
@@ -2339,7 +2304,7 @@ Column(
     right_justify=False,
 )
 
-# Totals
+# Memory
 Column(
     header="MI",
     machine_header="memory_init",
@@ -2358,56 +2323,12 @@ Column(
     "this qube when there is enough free memory on the host.",
     memory_convertable=True,
 )
-
-Column(
-    header="MAMT",
-    machine_header="memory_assigned_max_total",
-    min_width=lambda header: max(len(header), 5),
-    doc="``MAM`` + ``MAMi``.",
-    total=True,
-    summable_for_overall=True,
-    memory_convertable=True,
-)
-Column(
-    header="MAUT",
-    machine_header="memory_assigned_usable_total",
-    min_width=lambda header: max(len(header), 5),
-    doc="``MAU`` + ``MAUi``.",
-    total=True,
-    summable_for_overall=True,
-    memory_convertable=True,
-)
-Column(
-    header="MUT",
-    machine_header="memory_used_total",
-    min_width=lambda header: max(len(header), 5),
-    doc="``MU`` + ``MUi``.",
-    total=True,
-    summable_for_overall=True,
-    memory_convertable=True,
-)
-Column(
-    header="CPUsecT",
-    machine_header="cpu_time_total",
-    doc="``CPUsec`` + ``CPUisec``.",
-    total=True,
-    summable_for_overall=True,
-)
-Column(
-    header="VCT",
-    machine_header="online_vcpus_total",
-    min_width=lambda header: max(len(header), 3),
-    doc="``VC`` + ``VCi``.",
-    total=True,
-    summable_for_overall=True,
-)
-
-# Standard
 Column(
     header="MAM",
-    machine_header="memory_assigned_max",
+    machine_header="memory_assigned_total",
     min_width=lambda header: max(len(header), 5),
-    doc="How much memory has been assigned to the qube, including overhead.",
+    doc="How much memory has been assigned to the qube, including overhead of "
+    "videoram and internal usage.",
     summable_for_overall=True,
     memory_convertable=True,
 )
@@ -2417,13 +2338,23 @@ Column(
     min_width=lambda header: max(len(header), 5),
     doc="How much memory has been assigned to the qube and can be used. A qube "
     "is allowed to claim this amount at any time, and it cannot use more memory"
-    " than what has been assigned to it. When the system is under no memory "
-    "pressure, this value is close to ``MM``, while when the system is under "
-    "memory pressure, the value can be as low as enough for the qube to "
-    "survive.",
+    " than what has been assigned to it. When the system is under memory "
+    "pressure, the value can be just low enough for the qube to survive.",
     summable_for_overall=True,
     memory_convertable=True,
 )
+
+Column(
+    header="MUT",
+    machine_header="memory_used_total",
+    min_width=lambda header: max(len(header), 5),
+    doc="``MU`` + ``MUi``.",
+    total=True,
+    untrusted=True,
+    summable_for_overall=True,
+    memory_convertable=True,
+)
+
 Column(
     header="MU",
     machine_header="memory_used_noswap",
@@ -2434,14 +2365,15 @@ Column(
     memory_convertable=True,
 )
 Column(
-    header="MUS",
-    machine_header="memory_used_swap",
+    header="SU",
+    machine_header="swap_used",
     min_width=lambda header: max(len(header), 5),
-    doc="How much memory the qube alleges to use for swap. " + UNTRUSTED_COLUMN,
+    doc="How much swap the qube alleges to use. " + UNTRUSTED_COLUMN,
     summable_for_overall=True,
     untrusted=True,
     memory_convertable=True,
 )
+
 Column(
     header="MAM/MM",
     machine_header="memory_usage_assigned",
@@ -2465,15 +2397,32 @@ Column(
     untrusted=True,
 )
 Column(
-    header="MUS/MU",
+    header="SU/MU",
     machine_header="memory_usage_swap_over_used",
     min_width=lambda header: max(len(header), 5),
-    doc="How much memory the qube alleges to be swaping from what it alleges to"
-    "use, in percentage. When it is over 10%, the qube might be swaping too "
+    doc="How much swap the qube alleges to do from how much memory it alleges "
+    "to use, in percentage. When it is over 10%, the qube might be swaping too "
     "much.",
     percentage=True,
     percentage_intensity=[30, 10],
     untrusted=True,
+)
+
+# CPU
+Column(
+    header="CPUsecT",
+    machine_header="cpu_time_total",
+    doc="``CPUsec`` + ``CPUisec``.",
+    total=True,
+    summable_for_overall=True,
+)
+Column(
+    header="VCT",
+    machine_header="online_vcpus_total",
+    min_width=lambda header: max(len(header), 3),
+    doc="``VC`` + ``VCi``.",
+    total=True,
+    summable_for_overall=True,
 )
 Column(
     header="CPUsec",
@@ -2497,30 +2446,6 @@ Column(
 )
 
 # Internal
-Column(
-    header="MAMi",
-    machine_header="memory_assigned_max_internal",
-    min_width=lambda header: max(len(header), 5),
-    doc="Same as ``MAM``, but internal usage.",
-    internal=True,
-    summable_for_overall=True,
-)
-Column(
-    header="MAUi",
-    machine_header="memory_assigned_usable_internal",
-    min_width=lambda header: max(len(header), 5),
-    doc="Same as ``MAU``, but internal usage.",
-    internal=True,
-    summable_for_overall=True,
-)
-Column(
-    header="MUi",
-    machine_header="memory_used_noswap_internal",
-    min_width=lambda header: max(len(header), 5),
-    doc="Same as ``MU``, but internal usage.",
-    internal=True,
-    summable_for_overall=True,
-)
 Column(
     header="CPUisec",
     machine_header="cpu_time_internal",
@@ -2546,6 +2471,7 @@ Column(
 )
 
 
+# TODO: ben: check formats
 FORMATS: dict[str, list[str]] = {
     "min": ["name", "state", "memory_usage_used", "cpu_usage"],
     "default": [
@@ -2553,7 +2479,7 @@ FORMATS: dict[str, list[str]] = {
         "state",
         "memory_assigned_usable",
         "memory_used_noswap",
-        "memory_used_swap",
+        "swap_used",
         "memory_usage_used",
         "online_vcpus",
         "cpu_usage",

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -734,14 +734,14 @@ class Screen:
             )
             self.sel_and_cursor_attr = self.cursor_attr | curses.A_DIM
         else:
-            self.header_summary_attr = curses.A_REVERSE
+            self.header_summary_attr = None
             self.header_attr = curses.A_REVERSE
-            self.header_sel_attr = curses.A_REVERSE
+            self.header_sel_attr = curses.A_REVERSE | curses.A_DIM
             self.footer_attr = curses.A_REVERSE
-            self.footer_sel_attr = curses.A_REVERSE
-            self.sel_attr = curses.A_REVERSE
+            self.footer_sel_attr = curses.A_REVERSE | curses.A_DIM
+            self.sel_attr = curses.A_DIM
             self.cursor_attr = curses.A_REVERSE
-            self.sel_and_cursor_attr = curses.A_REVERSE
+            self.sel_and_cursor_attr = curses.A_REVERSE | curses.A_DIM
         curses.noecho()
         curses.cbreak()
         curses.nonl()

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -1093,7 +1093,11 @@ class Screen:
                             color_attr = self.colors["FG_RED"]
                         elif data > min(column.percentage_intensity):
                             color_attr = self.colors["FG_YELLOW"]
-                    elif data == "NA":
+                        elif isinstance(data, (int, float)) and data == 0:
+                            color_attr = self.label_colors["gray"]
+                    elif data == "NA" or (
+                        isinstance(data, (int, float)) and data == 0
+                    ):
                         color_attr = self.label_colors["gray"]
 
                 line_content.setdefault(column.machine_header, {}).setdefault(

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -1504,10 +1504,10 @@ class Screen:
         elif char in (curses.KEY_NPAGE, ACK, EOT):
             self.page_scroll(upward=False, half=char == EOT)
 
-        elif char in (curses.KEY_HOME, SOH):
+        elif char in (curses.KEY_HOME, SOH, ord("g")):
             self.scroll_offset = 0
 
-        elif char in (curses.KEY_END, ENQ):
+        elif char in (curses.KEY_END, ENQ, ord("G")):
             self.scroll_offset = self.max_offset
 
         elif char in (FF,):

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -1732,8 +1732,15 @@ class Screen:
 
         elif char in (ord("T"),):
             if self.visible_stats:
-                first_visible = list(self.visible_stats.values())[0]
-                if first_visible in self.selected_stats:
+                first_actionable = next(
+                    (
+                        stat
+                        for stat in list(self.visible_stats.values())
+                        if stat.get_actions()
+                    ),
+                    None,
+                )
+                if first_actionable in self.selected_stats:
                     self.selected_stats = [
                         stat
                         for stat in self.selected_stats
@@ -1744,6 +1751,7 @@ class Screen:
                         stat
                         for stat in self.visible_stats.values()
                         if stat not in self.selected_stats
+                        and stat.get_actions()
                     ]
 
         elif char in (ord("a"),):

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -279,26 +279,31 @@ class Stats:
         self.management_dispvm: QubesVM | None = None
         self.auto_cleanup: bool = False
         self.memory_max: int | str = "NA"
+        self.memory_init: int | str = "NA"
         self.update_cache()
 
-        self.memory_assigned: int | str = "NA"
+        self.memory_assigned_max: int | str = "NA"
+        self.memory_assigned_usable: int | str = "NA"
         self.memory_usage_assigned: float | str = "NA"
-        self.memory_used: int | str = "NA"
-        self.memory_used_with_swap: int | str = "NA"
+        self.memory_used_noswap: int | str = "NA"
+        self.memory_used_swap: int | str = "NA"
         self.memory_usage_used: float | str = "NA"
-        self.memory_usage_used_with_swap: float | str = "NA"
-        self.memory_usage_used_assigned: float | str = "NA"
+        self.memory_usage_swap_over_used: float | str = "NA"
         self.cpu_time: int | str = "NA"
         self.cpu_usage: int | str = "NA"
         self.online_vcpus: int | str = "NA"
 
-        self.memory_assigned_internal: int | str = "NA"
-        self.memory_used_internal: int | str = "NA"
+        self.memory_assigned_max_internal: int | str = "NA"
+        self.memory_assigned_usable_internal: int | str = "NA"
+        self.memory_used_noswap_internal: int | str = "NA"
         self.cpu_time_internal: int | str = "NA"
         self.cpu_usage_internal: float | str = "NA"
         self.online_vcpus_internal: int | str = "NA"
 
-        self.memory_assigned_total: int | str = "NA"
+        self.memory_assigned_max_total: int | str = "NA"
+        self.memory_assigned_usable_total: int | str = "NA"
+        self.memory_used_noswap_total: int | str = "NA"
+        self.memory_used_swap_total: int | str = "NA"
         self.memory_used_total: int | str = "NA"
         self.cpu_time_total: int | str = "NA"
         self.cpu_usage_total: float | str = "NA"
@@ -390,6 +395,7 @@ class Stats:
         data = {
             "state": self.vm.get_power_state(),
             "label": self.vm.label,
+            "memory_init": getattr(self.vm, "memory", "NA"),
             "memory_max": getattr(self.vm, "maxmem", "NA"),
             "auto_cleanup": getattr(self.vm, "auto_cleanup", False),
             "is_preload": getattr(self.vm, "is_preload", False),
@@ -416,47 +422,70 @@ class Stats:
         """
         Update memory and CPU statistics.
         """
-        memory_assigned = int(kwargs["memory_assigned_KiB"]) // 1024
-        memory_assigned_internal = kwargs.get("memory_assigned_KiB_internal")
-        if memory_assigned_internal is None:
-            memory_assigned_internal = "NA"
-            memory_assigned_total = memory_assigned
+        memory_assigned_max = int(kwargs["memory_assigned_max_KiB"]) // 1024
+        memory_assigned_usable = (
+            int(kwargs["memory_assigned_usable_KiB"]) // 1024
+        )
+        memory_assigned_max_internal = kwargs.get(
+            "memory_assigned_max_KiB_internal"
+        )
+        memory_assigned_usable_internal = kwargs.get(
+            "memory_assigned_usable_KiB_internal"
+        )
+        if memory_assigned_max_internal is None:
+            memory_assigned_max_internal = "NA"
+            memory_assigned_max_total = memory_assigned_max
         else:
-            memory_assigned_internal = int(memory_assigned_internal) // 1024
-            memory_assigned_total = memory_assigned + memory_assigned_internal
+            memory_assigned_max_internal = (
+                int(memory_assigned_max_internal) // 1024
+            )
+            memory_assigned_max_total = (
+                memory_assigned_max + memory_assigned_max_internal
+            )
+        if memory_assigned_usable_internal is None:
+            memory_assigned_usable_internal = "NA"
+            memory_assigned_usable_total = memory_assigned_usable
+        else:
+            memory_assigned_usable_internal = (
+                int(memory_assigned_usable_internal) // 1024
+            )
+            memory_assigned_usable_total = (
+                memory_assigned_usable + memory_assigned_usable_internal
+            )
 
-        memory_used_with_swap = int(kwargs["memory_used_with_swap_KiB"]) // 1024
-        memory_used = int(kwargs["memory_used_KiB"]) // 1024
-        memory_used_internal = kwargs.get("memory_used_KiB_internal")
-        if memory_used_internal is None:
-            memory_used_internal = "NA"
-            memory_used_total = memory_used
+        memory_used_swap = int(kwargs["memory_used_swap_KiB"]) // 1024
+        memory_used_noswap = int(kwargs["memory_used_noswap_KiB"]) // 1024
+        memory_used_noswap_internal = kwargs.get(
+            "memory_used_noswap_KiB_internal"
+        )
+        if memory_used_noswap_internal is None:
+            memory_used_noswap_internal = "NA"
+            memory_used_noswap_total = memory_used_noswap
         else:
-            memory_used_internal = int(memory_used_internal) // 1024
-            memory_used_total = memory_used + memory_used_internal
+            memory_used_noswap_internal = (
+                int(memory_used_noswap_internal) // 1024
+            )
+            memory_used_noswap_total = (
+                memory_used_noswap + memory_used_noswap_internal
+            )
+        memory_used_swap_total = memory_used_swap
+        memory_used_total = memory_used_swap_total + memory_used_noswap_total
 
         if isinstance(self.memory_max, int) and self.memory_max > 0:
             memory_usage_assigned: float | str = round(
-                float(memory_assigned / self.memory_max) * 100, 1
-            )
-            memory_usage_used: float | str = round(
-                float(memory_used / self.memory_max) * 100, 1
+                float(memory_assigned_max / self.memory_max) * 100, 1
             )
         else:
             memory_usage_assigned = "NA"
-            memory_usage_used = "NA"
-        if memory_assigned > 0:
-            memory_usage_used_assigned = round(
-                float(memory_used / memory_assigned) * 100, 1
+        memory_usage_used: float | str = round(
+            float(memory_used_noswap / memory_assigned_usable) * 100, 1
+        )
+        if memory_used_noswap > 0:
+            memory_usage_swap_over_used: float | str = round(
+                float(memory_used_swap / memory_used_noswap) * 100, 1
             )
         else:
-            memory_usage_used_assigned = 0.0
-        if memory_used > 0:
-            memory_usage_used_with_swap: float | str = round(
-                float(memory_used_with_swap / memory_used) * 100 - 100, 1
-            )
-        else:
-            memory_usage_used_with_swap = 0
+            memory_usage_swap_over_used = 0.0
 
         cpu_time = int(kwargs["cpu_time"]) // 10**3
         cpu_time_internal = kwargs.get("cpu_time_internal")
@@ -484,27 +513,37 @@ class Stats:
             online_vcpus_total = online_vcpus + online_vcpus_internal
 
         data = {
-            "memory_assigned": memory_assigned,
-            "memory_used": memory_used,
-            "memory_used_with_swap": memory_used_with_swap,
+            "memory_assigned_max": memory_assigned_max,
+            "memory_assigned_usable": memory_assigned_usable,
+            "memory_used_noswap": memory_used_noswap,
+            "memory_used_swap": memory_used_swap,
             "memory_usage_used": memory_usage_used,
             "memory_usage_assigned": memory_usage_assigned,
-            "memory_usage_used_assigned": memory_usage_used_assigned,
-            "memory_usage_used_with_swap": memory_usage_used_with_swap,
+            "memory_usage_swap_over_used": memory_usage_swap_over_used,
             "cpu_time": cpu_time,
             "cpu_usage": cpu_usage,
             "online_vcpus": online_vcpus,
-            "memory_assigned_internal": memory_assigned_internal,
-            "memory_used_internal": memory_used_internal,
+            "memory_assigned_usable_internal": memory_assigned_usable_internal,
+            "memory_assigned_max_internal": memory_assigned_max_internal,
+            "memory_used_noswap_internal": memory_used_noswap_internal,
             "cpu_time_internal": cpu_time_internal,
             "cpu_usage_internal": cpu_usage_internal,
             "online_vcpus_internal": online_vcpus_internal,
-            "memory_assigned_total": memory_assigned_total,
+            "memory_assigned_usable_total": memory_assigned_usable_total,
+            "memory_assigned_max_total": memory_assigned_max_total,
+            "memory_used_noswap_total": memory_used_noswap_total,
+            "memory_used_swap_total": memory_used_swap_total,
             "memory_used_total": memory_used_total,
             "cpu_time_total": cpu_time_total,
             "online_vcpus_total": online_vcpus_total,
         }
         self.set_verbose(data)
+
+    def update_memory_init(self, value: int) -> None:
+        """
+        Update initial memory.
+        """
+        self.set_verbose({"memory_init": value})
 
     def update_memory_max(self, value: int) -> None:
         """
@@ -513,21 +552,14 @@ class Stats:
         memory_max = int(value)
         if memory_max > 0:
             memory_usage_assigned: float | str = "NA"
-            if isinstance(self.memory_assigned, int):
+            if isinstance(self.memory_assigned_max, int):
                 memory_usage_assigned = round(
-                    float(self.memory_assigned / memory_max) * 100, 1
-                )
-            memory_usage_used: float | str = "NA"
-            if isinstance(self.memory_used, int):
-                memory_usage_used = round(
-                    float(self.memory_used / memory_max) * 100, 1
+                    float(self.memory_assigned_max / memory_max) * 100, 1
                 )
         else:
-            memory_usage_used = "NA"
             memory_usage_assigned = "NA"
         data = {
             "memory_max": memory_max,
-            "memory_usage_used": memory_usage_used,
             "memory_usage_assigned": memory_usage_assigned,
         }
         self.set_verbose(data)
@@ -916,15 +948,20 @@ class Screen:
         )
         action_visible = self.actions[action_scroll_start:action_scroll_end]
 
-        memory_used: list[int] = [
-            stats.memory_used_total
+        memory_used_noswap_total: list[int] = [
+            stats.memory_used_noswap_total
             for stats in wanted
-            if isinstance(stats.memory_used_total, int)
+            if isinstance(stats.memory_used_noswap_total, int)
         ]
-        memory_assigned: list[int] = [
-            stats.memory_assigned_total
+        memory_used_swap_total: list[int] = [
+            stats.memory_used_swap_total
             for stats in wanted
-            if isinstance(stats.memory_assigned_total, int)
+            if isinstance(stats.memory_used_swap_total, int)
+        ]
+        memory_assigned_max_total: list[int] = [
+            stats.memory_assigned_max_total
+            for stats in wanted
+            if isinstance(stats.memory_assigned_max_total, int)
         ]
         states = [stats.state for stats in wanted]
 
@@ -1015,7 +1052,11 @@ class Screen:
                             color_attr = self.colors["FG_YELLOW"]
                         elif stats.state != "Running":
                             color_attr = self.colors["FG_RED"]
-                    elif column.percentage and data != "NA":
+                    elif (
+                        column.percentage
+                        and data != "NA"
+                        and column.percentage_intensity
+                    ):
                         if data > max(column.percentage_intensity):
                             color_attr = self.colors["FG_RED"]
                         elif data > min(column.percentage_intensity):
@@ -1044,29 +1085,45 @@ class Screen:
                 line_start += len(content)
 
         memory_total = Stats.host_memory_max
-        sum_memory_used = sum(memory_used)
-        sum_memory_assigned = sum(memory_assigned)
-        pct_memory_used: float | str = "NA"
-        pct_memory_assigned: float | str = "NA"
+        sum_memory_used_noswap = sum(memory_used_noswap_total)
+        sum_memory_used_swap = sum(memory_used_swap_total)
+        sum_memory_assigned_max_total = sum(memory_assigned_max_total)
+        pct_memory_used_noswap: float | str = "NA"
+        pct_memory_used_swap: float | str = "NA"
+        pct_memory_assigned_max_total: float | str = "NA"
         if isinstance(memory_total, int):
-            pct_memory_used = round(sum_memory_used / memory_total * 100, 1)
-            pct_memory_assigned = round(
-                sum_memory_assigned / memory_total * 100, 1
+            pct_memory_used_noswap = round(
+                sum_memory_used_noswap / memory_total * 100, 1
             )
-        header_mem_prefix = "MEM(MiB)"
+            pct_memory_used_swap = round(
+                sum_memory_used_swap / memory_total * 100, 1
+            )
+            pct_memory_assigned_max_total = round(
+                sum_memory_assigned_max_total / memory_total * 100, 1
+            )
+        header_mem_prefix = "Memory"
         total_mem_len = len(str(memory_total))
-        header_mem_total = "{} total".format(memory_total)
-        header_mem_used = "{}({}%) used".format(
-            str(sum_memory_used).rjust(total_mem_len), pct_memory_used
+        header_mem_total = "{}".format(memory_total)
+        header_mem_assigned_max_total = "{}({}%) assigned".format(
+            str(sum_memory_assigned_max_total).rjust(total_mem_len),
+            pct_memory_assigned_max_total,
         )
-        header_mem_assigned = "{}({}%) assigned".format(
-            str(sum_memory_assigned).rjust(total_mem_len), pct_memory_assigned
+        header_mem_used_noswap = "{}({}%) used".format(
+            str(sum_memory_used_noswap).rjust(total_mem_len),
+            pct_memory_used_noswap,
         )
-        header_mem_suffix = ": {}, {}, {}".format(
+        header_mem_used_swap = "{}({}%) swap".format(
+            str(sum_memory_used_swap).rjust(total_mem_len),
+            pct_memory_used_swap,
+        )
+        header_mem_suffix = ": "
+        header_mem_values = [
             header_mem_total,
-            header_mem_assigned,
-            header_mem_used,
-        )
+            header_mem_assigned_max_total,
+            header_mem_used_noswap,
+            header_mem_used_swap,
+        ]
+        header_mem_suffix += ", ".join(header_mem_values)
 
         state_counts = Counter(states)
         total_states = len(states)
@@ -1168,9 +1225,9 @@ class Screen:
         )
         if post_headers:
             post_headers += " "
-        self.log.debug("draw-header-pre=%s", pre_headers)
-        self.log.debug("draw-header-sorted=%s", sorted_header)
-        self.log.debug("draw-header-post=%s", post_headers)
+        self.log.debug("draw-header-pre=%r", pre_headers)
+        self.log.debug("draw-header-sorted=%r", sorted_header)
+        self.log.debug("draw-header-post=%r", post_headers)
         header_start = 0
         if action_headers:
             self.write(
@@ -1805,6 +1862,9 @@ class Monitor:
         if name == "maxmem":
             item.update_memory_max(value=newvalue)
             return
+        if name == "memory":
+            item.update_memory_init(value=newvalue)
+            return
         if name == "label":
             newvalue = self.screen.init_label(label=newvalue)
         item.update_generic(name=name, value=newvalue)
@@ -1870,6 +1930,7 @@ class Monitor:
             ("domain-add", self.add_domain),
             ("domain-delete", self.remove_domain),
             ("property-set:maxmem", self.set_generic),
+            ("property-set:memory", self.set_generic),
             ("property-set:label", self.set_generic),
             ("property-set:auto_cleanup", self.set_generic),
             ("property-reset:is_preload", self.set_generic),
@@ -1905,6 +1966,8 @@ class Column:
         self,
         width: int | Callable,
         header: str,
+        internal: bool = False,
+        total: bool = False,
         machine_header: str = "",
         doc: str | None = None,
         right_justify: bool = True,
@@ -1912,6 +1975,8 @@ class Column:
         percentage_intensity: list[int] | None = None,
     ):
         # pylint: disable=too-many-positional-arguments
+        self.internal = internal
+        self.total = total
         self.percentage = percentage
         if percentage_intensity is None:
             self.percentage_intensity = [75, 50]
@@ -2005,7 +2070,7 @@ class _HelpFormatsAction(Action):
             )
             for fmt, columns in FORMATS.items()
         )
-        print(text)
+        print(text, end="")
         sys_exit(0)
 
 
@@ -2013,6 +2078,7 @@ UNTRUSTED_COLUMN = (
     "This value or part of it is broadcast by the qube, it can be a lie."
 )
 
+# Basic
 Column(
     header="NAME",
     machine_header="name",
@@ -2028,29 +2094,14 @@ Column(
     right_justify=False,
 )
 
+# Totals
 Column(
-    header="MU",
-    machine_header="memory_used",
+    header="MI",
+    machine_header="memory_init",
     width=lambda header: max(len(header), 6),
-    doc="How much memory the qube alleges to use. " + UNTRUSTED_COLUMN,
-)
-Column(
-    header="MSU",
-    machine_header="memory_used_with_swap",
-    width=lambda header: max(len(header), 6),
-    doc="How much memory including swap the qube alleges to use. "
-    + UNTRUSTED_COLUMN,
-)
-Column(
-    header="MS",
-    machine_header="memory_assigned",
-    width=lambda header: max(len(header), 6),
-    doc="How much memory has been assigned to the qube, including videoram. A "
-    "qube is allowed to claim this amount at any time, and it cannot use more "
-    "memory than what has been assigned to it. When the system is under no "
-    "memory pressure, this value is close to ``MM``, while when the system is"
-    "under memory pressure, the value can be as low as enough for the qube to "
-    "survive.",
+    doc="How much memory the system must reserve for the qube to be able to "
+    "initialize. On non-memory-balanced qubes, this is the maximum amount of "
+    "memory a domain will ever have while it is running.",
 )
 Column(
     header="MM",
@@ -2060,37 +2111,97 @@ Column(
     "is reserved to videoram, while the rest is up to qmemman to balloon up "
     "this qube when there is enough free memory on the host.",
 )
+
 Column(
-    header="MU/MM",
-    machine_header="memory_usage_used",
-    width=lambda header: max(len(header), 4),
-    doc="How much memory the qube alleges to use compared to the maximum it can"
-    "use from the system, in percentage.",
-    percentage=True,
+    header="MAMT",
+    machine_header="memory_assigned_max_total",
+    width=lambda header: max(len(header), 6),
+    doc="``MAM`` + ``MAMi``.",
+    total=True,
 )
 Column(
-    header="MS/MM",
+    header="MAUT",
+    machine_header="memory_assigned_usable_total",
+    width=lambda header: max(len(header), 6),
+    doc="``MAU`` + ``MAUi``.",
+    total=True,
+)
+Column(
+    header="MUT",
+    machine_header="memory_used_total",
+    width=lambda header: max(len(header), 6),
+    doc="``MU`` + ``MUi``.",
+    total=True,
+)
+Column(
+    header="CPUsecT",
+    machine_header="cpu_time_total",
+    width=lambda header: max(len(header), 10),
+    doc="``CPUsec`` + ``CPUisec``.",
+    total=True,
+)
+Column(
+    header="VCT",
+    machine_header="online_vcpus_total",
+    width=lambda header: max(len(header), 3),
+    doc="``VC`` + ``VCi``.",
+    total=True,
+)
+
+# Standard
+Column(
+    header="MAM",
+    machine_header="memory_assigned_max",
+    width=lambda header: max(len(header), 6),
+    doc="How much memory has been assigned to the qube, including overhead.",
+)
+Column(
+    header="MAU",
+    machine_header="memory_assigned_usable",
+    width=lambda header: max(len(header), 6),
+    doc="How much memory has been assigned to the qube and can be used. A qube "
+    "is allowed to claim this amount at any time, and it cannot use more memory"
+    " than what has been assigned to it. When the system is under no memory "
+    "pressure, this value is close to ``MM``, while when the system is under "
+    "memory pressure, the value can be as low as enough for the qube to "
+    "survive.",
+)
+Column(
+    header="MU",
+    machine_header="memory_used_noswap",
+    width=lambda header: max(len(header), 6),
+    doc="How much memory the qube alleges to use. " + UNTRUSTED_COLUMN,
+)
+Column(
+    header="MUS",
+    machine_header="memory_used_swap",
+    width=lambda header: max(len(header), 6),
+    doc="How much memory the qube alleges to use for swap. " + UNTRUSTED_COLUMN,
+)
+Column(
+    header="MAM/MM",
     machine_header="memory_usage_assigned",
     width=lambda header: max(len(header), 4),
     doc="How much memory the qube has assigned compared to the maximum it can "
-    "use from the system, in percentage. A high percentage means the system is "
-    "not pressuring the qube to release memory.",
+    "have assigned, in percentage. A high percentage means the system is not "
+    "pressuring the qube to release memory.",
     percentage=True,
+    percentage_intensity=[],
 )
 Column(
-    header="MU/MS",
-    machine_header="memory_usage_used_assigned",
+    header="MU/MAU",
+    machine_header="memory_usage_used",
     width=lambda header: max(len(header), 4),
     doc="How much memory the qube alleges to use from the assigned amount, in "
     "percentage. A high percentage on non-memory-balanced qubes is irrelevant. "
     "On memory balanced qubes, a higher value indicates the qube is using a lot"
-    " of the memory it has assigned, which might be near exhaustion, if ``MS`` "
-    "can't be ballooned up anymore.",
+    " of the memory it has assigned, which might be near exhaustion, if ``MAU``"
+    " can't be ballooned up anymore.",
     percentage=True,
 )
 Column(
-    header="MSU/MU",
-    machine_header="memory_usage_used_with_swap",
+    header="MUS/MU",
+    machine_header="memory_usage_swap_over_used",
     width=lambda header: max(len(header), 6),
     doc="How much memory the qube alleges to be swaping from what it alleges to"
     "use, in percentage. When it is over 10%, the qube might be swaping too "
@@ -2098,11 +2209,10 @@ Column(
     percentage=True,
     percentage_intensity=[30, 10],
 )
-
 Column(
     header="CPUsec",
     machine_header="cpu_time",
-    width=lambda header: max(len(header), 8),
+    width=lambda header: max(len(header), 10),
     doc="How many seconds the qube has used from the CPU.",
 )
 Column(
@@ -2119,23 +2229,34 @@ Column(
     doc="How many Virtual CPUs are online.",
 )
 
+# Internal
 Column(
-    header="MUi",
-    machine_header="memory_used_internal",
+    header="MAMi",
+    machine_header="memory_assigned_max_internal",
     width=lambda header: max(len(header), 6),
-    doc="Same as MU, but internal usage.",
+    doc="Same as ``MAM``, but internal usage.",
+    internal=True,
 )
 Column(
-    header="MSi",
-    machine_header="memory_assigned_internal",
+    header="MAUi",
+    machine_header="memory_assigned_usable_internal",
     width=lambda header: max(len(header), 6),
-    doc="Same as ``MS``, but internal usage.",
+    doc="Same as ``MAU``, but internal usage.",
+    internal=True,
+)
+Column(
+    header="MUi",
+    machine_header="memory_used_noswap_internal",
+    width=lambda header: max(len(header), 6),
+    doc="Same as ``MU``, but internal usage.",
+    internal=True,
 )
 Column(
     header="CPUisec",
     machine_header="cpu_time_internal",
-    width=lambda header: max(len(header), 8),
+    width=lambda header: max(len(header), 10),
     doc="Same as ``CPUsec``, but internal usage.",
+    internal=True,
 )
 Column(
     header="CPUi%",
@@ -2143,54 +2264,43 @@ Column(
     width=lambda header: max(len(header), 4),
     doc="Same as ``CPU%``, but internal usage.",
     percentage=True,
+    internal=True,
 )
 Column(
     header="VCi",
     machine_header="online_vcpus_internal",
     width=lambda header: max(len(header), 3),
     doc="Same as ``VC``, but internal usage.",
+    internal=True,
 )
 
 
-Column(
-    header="MUT",
-    machine_header="memory_used_total",
-    width=lambda header: max(len(header), 6),
-    doc="``MU`` + ``MUi``.",
-)
-Column(
-    header="MST",
-    machine_header="memory_assigned_total",
-    width=lambda header: max(len(header), 6),
-    doc="``MS`` + ``MSi``.",
-)
-Column(
-    header="CPUsecT",
-    machine_header="cpu_time_total",
-    width=lambda header: max(len(header), 8),
-    doc="``CPUsec`` + ``CPUisec``.",
-)
-Column(
-    header="``VCT``",
-    machine_header="online_vcpus_total",
-    width=lambda header: max(len(header), 3),
-    doc="``VC`` + ``VCi``.",
-)
-
-
-FORMATS = {
-    "min": ("name", "state", "memory_usage_used", "cpu_usage"),
-    "default": (
+FORMATS: dict[str, list[str]] = {
+    "min": ["name", "state", "memory_usage_used", "cpu_usage"],
+    "default": [
         "name",
         "state",
-        "memory_used",
-        "memory_max",
+        "memory_assigned_usable",
+        "memory_used_noswap",
+        "memory_used_swap",
         "memory_usage_used",
-        "cpu_usage",
         "online_vcpus",
-    ),
+        "cpu_usage",
+    ],
     "max-no-internal": [
-        k for k in list(Column.columns.keys()) if not k.endswith("_internal")
+        machine_header
+        for machine_header, column in list(Column.columns.items())
+        if not column.internal
+    ],
+    "max-no-total": [
+        machine_header
+        for machine_header, column in list(Column.columns.items())
+        if not column.total
+    ],
+    "max-no-total-no-internal": [
+        machine_header
+        for machine_header, column in list(Column.columns.items())
+        if not column.internal and not column.total
     ],
     "max": list(Column.columns.keys()),
 }
@@ -2277,14 +2387,11 @@ async def run_async(args) -> int:
     """
     if args.columns:
         user_columns = [col.strip() for col in args.columns.split(",")]
-        columns = {col: Column.columns[col] for col in user_columns}
+    elif args.format:
+        user_columns = [col.strip() for col in FORMATS[args.format]]
     else:
-        columns = {
-            machine_header: col
-            for machine_header, col in Column.columns.items()
-            if (not args.format and machine_header in FORMATS["default"])
-            or (args.format and machine_header in FORMATS[args.format])
-        }
+        user_columns = [col.strip() for col in FORMATS["default"]]
+    columns = {col: Column.columns[col] for col in user_columns}
     sort_column = args.sort_column or None
 
     app = args.app

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -1231,17 +1231,6 @@ class Screen:
         sum_memory_assigned_total_total = convert_memory(
             sum(memory_assigned_total_total)
         )
-        pct_memory_used_noswap: float | str = "NA"
-        pct_swap_used: float | str = "NA"
-        pct_memory_assigned_total_total: float | str = "NA"
-        if isinstance(memory_total, (int, float)):
-            pct_memory_used_noswap = round(
-                sum_memory_used_noswap / memory_total * 100, 1
-            )
-            pct_swap_used = round(sum_swap_used / memory_total * 100, 1)
-            pct_memory_assigned_total_total = round(
-                sum_memory_assigned_total_total / memory_total * 100, 1
-            )
 
         no_cpus = Stats.host_no_cpus
         header_cpu_prefix = "  {}".format(cpu_text)
@@ -1255,19 +1244,16 @@ class Screen:
         total_mem_len = len(str(memory_total))
         header_mem_total = "{}".format(memory_total)
 
-        header_mem_assigned_max_total = "{}({}%) {}".format(
+        header_mem_assigned_max_total = "{} {}".format(
             str(sum_memory_assigned_total_total).rjust(total_mem_len),
-            pct_memory_assigned_total_total,
             assigned_text,
         )
-        header_mem_used_noswap = "{}({}%) {}".format(
+        header_mem_used_noswap = "{} {}".format(
             str(sum_memory_used_noswap).rjust(total_mem_len),
-            pct_memory_used_noswap,
             used_text,
         )
-        header_mem_used_swap = "{}({}%) {}".format(
+        header_mem_used_swap = "{} {}".format(
             str(sum_swap_used).rjust(total_mem_len),
-            pct_swap_used,
             swap_text,
         )
         header_mem_suffix = ": "

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -259,7 +259,9 @@ class Stats:
     # pylint: disable=too-many-instance-attributes
 
     outdated_by_removal: list[str] = []
+    host_checked: bool = False
     host_memory_max: int | str = "NA"
+    host_no_cpus: int | str = "NA"
 
     def __init__(self, vm: QubesVM) -> None:
         super().__init__()
@@ -309,8 +311,13 @@ class Stats:
         self.cpu_usage_total: float | str = "NA"
         self.online_vcpus_total: int | str = "NA"
 
-        if self.__class__.host_memory_max == "NA":
-            self.__class__.host_memory_max = int(self.vm.app.maxmem) // 1024
+        if self.__class__.host_checked is False:
+            self.__class__.host_checked = True
+            host_memory_max = getattr(self.vm.app, "maxmem", "NA")
+            if isinstance(host_memory_max, int):
+                host_memory_max = int(host_memory_max) // 1024
+            self.__class__.host_memory_max = host_memory_max
+            self.__class__.host_no_cpus = getattr(self.vm.app, "no_cpus", "NA")
 
     def can_gui(self) -> bool:
         """
@@ -1101,7 +1108,11 @@ class Screen:
             pct_memory_assigned_max_total = round(
                 sum_memory_assigned_max_total / memory_total * 100, 1
             )
-        header_mem_prefix = "Memory"
+
+        no_cpus = Stats.host_no_cpus
+        header_cpu_prefix = "  CPUs"
+        header_cpu_suffix = ": {}".format(no_cpus)
+        header_mem_prefix = "Mem"
         total_mem_len = len(str(memory_total))
         header_mem_total = "{}".format(memory_total)
         header_mem_assigned_max_total = "{}({}%) assigned".format(
@@ -1197,6 +1208,7 @@ class Screen:
             max_width=width - len(header_dom_prefix),
         )
 
+        header_resources_start = 0
         self.write(
             2,
             0,
@@ -1204,11 +1216,27 @@ class Screen:
             max_width=width,
             attr=self.header_summary_attr,
         )
+        header_resources_start += len(header_mem_prefix)
         self.write(
             2,
-            len(header_mem_prefix),
+            header_resources_start,
             header_mem_suffix,
-            max_width=width - len(header_mem_prefix),
+            max_width=width - header_resources_start,
+        )
+        header_resources_start += len(header_mem_suffix)
+        self.write(
+            2,
+            header_resources_start,
+            header_cpu_prefix,
+            max_width=width - header_resources_start,
+            attr=self.header_summary_attr,
+        )
+        header_resources_start += len(header_cpu_prefix)
+        self.write(
+            2,
+            header_resources_start,
+            header_cpu_suffix,
+            max_width=width - header_resources_start,
         )
 
         action_headers = ""

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -2541,6 +2541,14 @@ parser.add_argument(
     help="filter domains name matching each fixed string separated by comma",
 )
 parser.add_argument(
+    "--thin-columns",
+    action="store_true",
+    default=False,
+    help="Columns will to be as large as the its header or current lengthiest "
+    "data. It is not the default because columns will move every time the "
+    "length of the lengthiest data change.",
+)
+parser.add_argument(
     "--memory-unit",
     action="store",
     choices=MEMORY_UNIT_AVAILABLE,
@@ -2610,6 +2618,10 @@ async def run_async(args) -> int:
     else:
         user_columns = [col.strip() for col in FORMATS["default"]]
     columns = {col: Column.columns[col] for col in user_columns}
+    if args.thin_columns:
+        for col, column in columns.items():
+            columns[col].min_width = len(column.header)
+
     sort_column = args.sort_column or None
 
     app = args.app

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -630,6 +630,7 @@ class Screen:
         sort_reverse: bool,
         sort_col_index: int | None,
         columns: dict[str, "Column"],
+        thin_columns: bool,
     ):
         # pylint: disable=too-many-positional-arguments
         self.allow_color = allow_color
@@ -640,6 +641,7 @@ class Screen:
         self.sort_reverse = sort_reverse
         self.sort_col_index = sort_col_index
         self.columns = columns
+        self.thin_columns = thin_columns
 
         self.log = gen_logger(f"{self.__class__.__qualname__}")
         self.getch_timeout = 1000
@@ -1137,7 +1139,9 @@ class Screen:
                     ):
                         color_attr = self.label_colors["gray"]
 
-                if (
+                if attr == "state" and self.thin_columns:
+                    data = POWER_STATES[data]["short"]
+                elif (
                     isinstance(data, int)
                     and not column.percentage
                     and column.memory_convertable
@@ -1226,6 +1230,32 @@ class Screen:
                     max(curr_width, column.min_width) + 1
                 )
 
+        state_counts = Counter(states)
+        total_states = len(states)
+        total_states_len = len(str(total_states))
+        all_states = list(POWER_STATES)
+
+        if self.thin_columns:
+            top_text = "top"
+            domain_text = "D"
+            mem_text = "M"
+            mem_unit = MEMORY_UNIT[0]
+            cpu_text = "C"
+            selected_text = "*"
+            assigned_text = "a"
+            used_text = "u"
+            swap_text = "s"
+        else:
+            top_text = "qvm-top"
+            domain_text = "Domain{}".format("s" if total_states > 0 else "")
+            mem_text = "Mem"
+            mem_unit = MEMORY_UNIT
+            cpu_text = "CPUs"
+            selected_text = "selected"
+            assigned_text = "assigned"
+            used_text = "used"
+            swap_text = "swap"
+
         memory_total = Stats.host_memory_max
         if isinstance(memory_total, int):
             memory_total = convert_memory(memory_total)
@@ -1249,27 +1279,31 @@ class Screen:
             )
 
         no_cpus = Stats.host_no_cpus
-        header_cpu_prefix = "  CPUs"
+        header_cpu_prefix = "  {}".format(cpu_text)
         header_cpu_suffix = ": {}".format(no_cpus)
         if MEMORY_UNIT_PRECISION == 0:
-            header_mem_prefix = "Mem({})".format(MEMORY_UNIT)
+            header_mem_prefix = "{}({})".format(mem_text, mem_unit)
         else:
-            header_mem_prefix = "Mem({}.{})".format(
-                MEMORY_UNIT, MEMORY_UNIT_PRECISION
+            header_mem_prefix = "{}({}.{})".format(
+                mem_text, mem_unit, MEMORY_UNIT_PRECISION
             )
         total_mem_len = len(str(memory_total))
         header_mem_total = "{}".format(memory_total)
-        header_mem_assigned_max_total = "{}({}%) assigned".format(
+
+        header_mem_assigned_max_total = "{}({}%) {}".format(
             str(sum_memory_assigned_max_total).rjust(total_mem_len),
             pct_memory_assigned_max_total,
+            assigned_text,
         )
-        header_mem_used_noswap = "{}({}%) used".format(
+        header_mem_used_noswap = "{}({}%) {}".format(
             str(sum_memory_used_noswap).rjust(total_mem_len),
             pct_memory_used_noswap,
+            used_text,
         )
-        header_mem_used_swap = "{}({}%) swap".format(
+        header_mem_used_swap = "{}({}%) {}".format(
             str(sum_memory_used_swap).rjust(total_mem_len),
             pct_memory_used_swap,
+            swap_text,
         )
         header_mem_suffix = ": "
         header_mem_values = [
@@ -1280,21 +1314,22 @@ class Screen:
         ]
         header_mem_suffix += ", ".join(header_mem_values)
 
-        state_counts = Counter(states)
-        total_states = len(states)
-        total_states_len = len(str(total_states))
-        all_states = list(POWER_STATES)
         state_parts = ["{}".format(total_states)]
         state_parts.append(
-            "({} selected)".format(
-                str(len(self.selected_stats)).rjust(total_states_len)
+            "({} {})".format(
+                str(len(self.selected_stats)).rjust(total_states_len),
+                selected_text,
             )
         )
         for state in all_states:
+            if self.thin_columns:
+                pretty_state = POWER_STATES[state]["short"]
+            else:
+                pretty_state = state.lower() if state != "NA" else "NA"
             state_parts.append(
                 "{} {}".format(
                     str(state_counts.get(state, 0)).rjust(total_states_len),
-                    state.lower() if state != "NA" else "NA",
+                    pretty_state,
                 )
             )
         extra = [state for state in state_counts if state not in all_states]
@@ -1305,7 +1340,7 @@ class Screen:
                     state.lower(),
                 )
             )
-        header_dom_prefix = "Domain{}".format("s" if total_states > 0 else "")
+        header_dom_prefix = domain_text
         header_dom_suffix = ": " + ", ".join(state_parts)
 
         current_time = strftime("%H:%M:%S")
@@ -1321,7 +1356,7 @@ class Screen:
         )
         sorted_header += sort_sign
 
-        header_desc_prefix = "qvm-top"
+        header_desc_prefix = top_text
         header_desc_suffix = f": {self.version} - {current_time}"
         scroll_hint = (
             f"{scroll_start + 1}-{scroll_end}/{total_items}"
@@ -1891,6 +1926,7 @@ class Monitor:
         sort_reverse: bool = False,
         sort_column: str | None = None,
         filter_query: str = "",
+        thin_columns: bool = False,
     ) -> None:
         # pylint: disable=too-many-positional-arguments
         self.app = app
@@ -1909,6 +1945,7 @@ class Monitor:
             sort_reverse=sort_reverse,
             sort_col_index=sort_col_index,
             columns=columns,
+            thin_columns=thin_columns,
         )
         self.log = gen_logger(f"{self.__class__.__qualname__}")
         root_logger = getLogger()
@@ -2150,6 +2187,7 @@ class Column:
     def __init__(
         self,
         header: str,
+        min_header: str | None = None,
         min_width: int | Callable = 0,
         internal: bool = False,
         total: bool = False,
@@ -2169,6 +2207,7 @@ class Column:
         self.summable_for_overall = summable_for_overall
         self.untrusted = untrusted
         self.memory_convertable = memory_convertable
+        self.min_header = min_header
         if percentage_intensity is None:
             self.percentage_intensity = [75, 50]
         else:
@@ -2281,6 +2320,7 @@ Column(
 )
 Column(
     header="STATE",
+    min_header="S",
     machine_header="state",
     min_width=max(len(state) for state in POWER_STATES),
     doc="Qube's power state.",
@@ -2635,6 +2675,8 @@ async def run_async(args) -> int:
     columns = {col: Column.columns[col] for col in user_columns}
     if args.thin_columns:
         for col, column in columns.items():
+            if column.min_header:
+                columns[col].header = column.min_header
             columns[col].min_width = len(column.header)
 
     sort_column = args.sort_column or None
@@ -2655,6 +2697,7 @@ async def run_async(args) -> int:
         columns=columns,
         allow_color=not (args.no_color or NO_COLOR),
         filter_query=args.filter,
+        thin_columns=args.thin_columns,
     )
     tasks = [
         create_task(dispatcher.listen_for_events()),

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -211,9 +211,11 @@ UNICODE = bool("utf-8" in environ.get("LC_ALL", "").lower())
 if UNICODE:
     SORT_SIGN_UP = "\u2193"
     SORT_SIGN_DOWN = "\u2191"
+    ELLIPSIS = "\u2026"
 else:
     SORT_SIGN_UP = "^"
     SORT_SIGN_DOWN = "v"
+    ELLIPSIS = "..."
 
 
 def convert_html_color_to_curses(hexadecimal: str):
@@ -1021,9 +1023,16 @@ class Screen:
                     elif data == "NA":
                         color_attr = self.label_colors["gray"]
                 if column.right_justify:
-                    content = str(data).rjust(column.width)
+                    if len(str(data)) > column.width:
+                        # Either a programming error when setting column width
+                        # or the domain is lying about this value and it's
+                        # better to not show it, as it exceeded our
+                        # expectations.
+                        content = ELLIPSIS.rjust(column.width)
+                    else:
+                        content = str(data).rjust(column.width)
                 else:
-                    content = data.ljust(column.width)
+                    content = data.ljust(column.width)[: column.width]
                 content += " "
                 self.write(
                     curr_height,
@@ -2041,7 +2050,7 @@ Column(
     "memory than what has been assigned to it. When the system is under no "
     "memory pressure, this value is close to ``MM``, while when the system is"
     "under memory pressure, the value can be as low as enough for the qube to "
-    "survive."
+    "survive.",
 )
 Column(
     header="MM",
@@ -2049,7 +2058,7 @@ Column(
     width=lambda header: max(len(header), 6),
     doc="How much memory the qube can use from the system. Part of this value "
     "is reserved to videoram, while the rest is up to qmemman to balloon up "
-    "this qube when there is enough free memory on the host."
+    "this qube when there is enough free memory on the host.",
 )
 Column(
     header="MU/MM",

--- a/qubesadmin/tools/qvm_top.py
+++ b/qubesadmin/tools/qvm_top.py
@@ -889,7 +889,12 @@ class Screen:
             [
                 stats
                 for stats in Monitor.entries.values()
-                if (self.show_halted or stats.state != "Halted")
+                if (
+                    self.show_halted
+                    or (
+                        stats.state != "Halted" and stats.vm.klass != "RemoteVM"
+                    )
+                )
                 and stats.vm in Monitor.domains
                 and (
                     (not self.filter_query and not self.filter)

--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -45,7 +45,7 @@ if typing.TYPE_CHECKING:
 # but can be extended
 Klass = str
 PowerState = Literal["Transient", "Running", "Halted", "Paused",
-"Suspended", "Halting", "Dying", "Crashed", "NA"]
+"Suspended", "Halting", "Crashed", "NA"]
 
 
 class QubesVM(qubesadmin.base.PropertyHolder):
@@ -202,7 +202,6 @@ class QubesVM(qubesadmin.base.PropertyHolder):
         ``'Paused'``    Machine is paused.
         ``'Suspended'`` Machine is S3-suspended.
         ``'Halting'``   Machine is in process of shutting down (OS shutdown).
-        ``'Dying'``     Machine is in process of shutting down (cleanup).
         ``'Crashed'``   Machine crashed and is unusable.
         ``'NA'``        Machine is in unknown state.
         =============== ========================================================

--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -44,8 +44,9 @@ if typing.TYPE_CHECKING:
 # ["AppVM", "AdminVM", "TemplateVM", "DispVM", "StandaloneVM"]
 # but can be extended
 Klass = str
-PowerState = Literal["Transient", "Running", "Halted", "Paused",
-"Suspended", "Halting", "Crashed", "NA"]
+POWER_STATES = ["Running", "Transient", "Paused", "Suspended", "Halting",
+                "Halted", "Crashed", "NA"]
+PowerState = Literal[POWER_STATES]
 
 
 class QubesVM(qubesadmin.base.PropertyHolder):

--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -44,17 +44,17 @@ if typing.TYPE_CHECKING:
 # ["AppVM", "AdminVM", "TemplateVM", "DispVM", "StandaloneVM"]
 # but can be extended
 Klass = str
-POWER_STATES = [
-    "Running",
-    "Starting",
-    "Transient",
-    "Paused",
-    "Suspended",
-    "Halting",
-    "Halted",
-    "Crashed",
-    "NA"
-]
+POWER_STATES = {
+    "Running": {"short": "r"},
+    "Starting": {"short": "S"},
+    "Transient": {"short": "S"},
+    "Paused": {"short": "p"},
+    "Suspended": {"short": "s"},
+    "Halting": {"short": "H"},
+    "Halted": {"short": "h"},
+    "Crashed": {"short": "c"},
+    "NA": {"short": "-"},
+}
 PowerState = Literal[POWER_STATES]
 
 

--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -44,8 +44,17 @@ if typing.TYPE_CHECKING:
 # ["AppVM", "AdminVM", "TemplateVM", "DispVM", "StandaloneVM"]
 # but can be extended
 Klass = str
-POWER_STATES = ["Running", "Transient", "Paused", "Suspended", "Halting",
-                "Halted", "Crashed", "NA"]
+POWER_STATES = [
+    "Running",
+    "Starting",
+    "Transient",
+    "Paused",
+    "Suspended",
+    "Halting",
+    "Halted",
+    "Crashed",
+    "NA"
+]
 PowerState = Literal[POWER_STATES]
 
 
@@ -197,8 +206,8 @@ class QubesVM(qubesadmin.base.PropertyHolder):
         return value    meaning
         =============== ========================================================
         ``'Halted'``    Machine is not active.
-        ``'Transient'`` Machine is running, but does not have :program:`guid`
-                        or :program:`qrexec` available.
+        ``'Transient'`` Machine is in progress of starting. This state will be
+                        deprecated in favor of ``'Starting'``.
         ``'Running'``   Machine is ready and running.
         ``'Paused'``    Machine is paused.
         ``'Suspended'`` Machine is S3-suspended.

--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -453,7 +453,7 @@ class QubesVM(qubesadmin.base.PropertyHolder):
         at any level of inheritance.
         """
         result = set(vm.appvms)
-        for appvm in vm.appvms:
+        for appvm in result.copy():
             result.update(QubesVM._get_derived_vms(appvm))
         return result
 


### PR DESCRIPTION
Add top-like monitoring tool

Inspiration and code from qui-domains and visuals from xentop.

- Colors entries according to state
- Footer with clock to show last time the screen was refreshed
- Allows scrolling domain list when it is longer than the screen height,
  with a less-type hint indicating how many lines to scroll
- To scroll, readline style (Emacs) navigation is supported, with some
  Vi keys also supported
- Inexpensive calls using "admin.vm.Stats"

Requires:

- https://github.com/QubesOS/qubes-core-admin/pull/827
- https://github.com/QubesOS/qubes-core-admin/pull/894

This PR is based on top of:

- https://github.com/QubesOS/qubes-core-admin-client/pull/480