### PR TITLE
Revert to red label while restoring on missing labels

### DIFF
--- a/qubesadmin/backup/restore.py
+++ b/qubesadmin/backup/restore.py
@@ -2029,6 +2029,14 @@ class BackupRestore(object):
                         label=vm.label,
                         pool=self.options.override_pool,
                         **kwargs)
+                except qubesadmin.exc.QubesLabelNotFoundError:
+                    # do not fail if label is not present. revert to red label
+                    new_vm = self.app.add_new_vm(
+                        vm.klass,
+                        name=vm_name,
+                        label='red',
+                        pool=self.options.override_pool,
+                        **kwargs)
                 except Exception as err:  # pylint: disable=broad-except
                     self.log.error('Error restoring VM %s, skipping: %s',
                         vm.name, err)

--- a/qubesadmin/tests/backup/backupcompatibility.py
+++ b/qubesadmin/tests/backup/backupcompatibility.py
@@ -695,7 +695,7 @@ parsed_qubes_xml_v4 = {
         },
         'test-net': {
             'klass': 'AppVM',
-            'label': 'red',
+            'label': 'scarlet',
             'properties': {
                 'maxmem': '300',
                 'memory': '300',
@@ -1357,7 +1357,31 @@ class TC_10_BackupCompatibility(qubesadmin.tests.backup.BackupTestCase):
             if name == 'dom0':
                 continue
 
-            if self.storage_pool:
+            if self.storage_pool and vm['label'] == 'scarlet':
+                self.app.expected_calls[
+                    ('dom0', 'admin.vm.CreateInPool.' + vm['klass'],
+                     templates_map.get(vm['template'], vm['template']),
+                    'name={} label={} pool={}'.format(
+                        name, 'scarlet', self.storage_pool).encode())] = \
+                    b'2\0QubesLabelNotFoundError\0\0No such label\0'
+                self.app.expected_calls[
+                    ('dom0', 'admin.vm.CreateInPool.' + vm['klass'],
+                     templates_map.get(vm['template'], vm['template']),
+                    'name={} label={} pool={}'.format(
+                        name, 'red', self.storage_pool).encode())] = \
+                    b'0\0'
+            elif vm['label'] == 'scarlet':
+                self.app.expected_calls[
+                    ('dom0', 'admin.vm.Create.' + vm['klass'],
+                     templates_map.get(vm['template'], vm['template']),
+                    'name={} label={}'.format(name, 'scarlet').encode())] =\
+                    b'2\0QubesLabelNotFoundError\0\0No such label\0'
+                self.app.expected_calls[
+                    ('dom0', 'admin.vm.Create.' + vm['klass'],
+                     templates_map.get(vm['template'], vm['template']),
+                    'name={} label={}'.format(name, 'red').encode())] =\
+                    b'0\0'
+            elif self.storage_pool:
                 self.app.expected_calls[
                     ('dom0', 'admin.vm.CreateInPool.' + vm['klass'],
                      templates_map.get(vm['template'], vm['template']),

--- a/qubesadmin/tests/backup/v4-qubes.xml
+++ b/qubesadmin/tests/backup/v4-qubes.xml
@@ -8,6 +8,7 @@
     <label color="0x3465a4" id="label-6">blue</label>
     <label color="0x75507b" id="label-7">purple</label>
     <label color="0x000000" id="label-8">black</label>
+    <label color="0xff2400" id="label-9">scarlet</label>
   </labels>
   <pools>
     <pool driver="lvm_thin" name="lvm" thin_pool="pool3" volume_group="core3"/>
@@ -392,7 +393,7 @@
     </domain>
     <domain id="domain-6" class="AppVM">
       <properties>
-        <property name="label">label-1</property>
+        <property name="label">label-9</property>
         <property name="maxmem">300</property>
         <property name="name">test-net</property>
         <property name="netvm"></property>


### PR DESCRIPTION
If we allow users to create custom labels and they backup such qubes, restore operation will fail on new systems without those custom labels. Fix this by reverting to red label and allow users to restore their backup.

fixes: https://github.com/QubesOS/qubes-issues/issues/9781