### PR TITLE
Add boot mode support

### DIFF
--- a/doc/manpages/qubes-prefs.rst
+++ b/doc/manpages/qubes-prefs.rst
@@ -54,6 +54,19 @@ Common properties
 This list is non-exhaustive. For authoritative listing, see
 :option:`--help-properties` and documentation of the source code.
 
+appvm_default_bootmode
+
+    Specifies the boot mode AppVMs based on this VM will start in, unless
+    overridden by the `bootmode` property or the `boot-mode.active` feature.
+    If set to `default`, a fallback boot mode is used. Only present for
+    TemplateVMs. See :manpage:`qvm-features(1)` for details about boot modes.
+
+bootmode
+
+    Specifies the boot mode the VM will start in. If set to `default`, the
+    boot mode specified by the `boot-mode.active` feature will be used. See
+    :manpage:`qvm-features(1)` for details about boot modes.
+
 clockvm
 
     Qube used as a time source for dom0

--- a/doc/manpages/qvm-features.rst
+++ b/doc/manpages/qvm-features.rst
@@ -60,6 +60,53 @@ List of known features
    This list of features may be incomplete, because extensions are free to use any
    values, without registering them anywhere.
 
+boot-mode.\*
+^^^^^^^^^^^^
+
+Boot mode information. Boot modes allow qubes to provide the user features that
+are controlled via kernel parameters. Each boot mode has one or more kernel
+parameters associated with it. If a qube is booted in a particular boot mode,
+that boot mode's kernel parameters are appended to the qube's usual kernel
+command line, activating the corresponding features within the VM. Templates
+that support toggling features in this way can advertise boot modes, which will
+then be shown in the settings dialog of Qube Manager. Templates can also specify
+default boot modes for themselves and for AppVMs based on them.
+
+All VMs have an implicitly defined bootmode, `default`, which appends no
+additional kernel parameters. It is used as a fallback in the event a template
+does not specify any boot modes, or there is no valid bootmode set.
+
+boot-mode.active
+^^^^^^^^^^^^^^^^
+
+The default boot mode this qube will use. This boot mode option is expected to
+be set by the template and should not be modified by the user. The user can
+override this boot mode by setting a boot mode in Qube Manager, or by setting
+the `bootmode` property with `qvm-prefs`.
+
+boot-mode.appvm-default
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The default boot mode AppVMs based on this template will use. This boot mode
+option is expected to be set by the template and should not be modified by the
+user. The user can override this boot mode by setting default boot mode for
+derived AppVMs in Qube Manager, or by setting the `appvm_default_bootmode`
+property with `qvm-prefs`.
+
+boot-mode.kernelopts.\*
+^^^^^^^^^^^^^^^^^^^^^^^
+
+A boot mode supported by this qube. The boot mode's ID is specified by the
+last dot-separated word in the feature key, while the boot mode's kernel
+options are specified by the feature value.
+
+boot-mode.name.\*
+^^^^^^^^^^^^^^^^^
+
+The user-visible pretty name for a boot mode. The ID of the boot mode with the
+given pretty name is specified by the last dot-separated word in the feature
+key, while the pretty name is specified by the feature value. 
+
 gui
 ^^^
 

--- a/qubesadmin/tests/mock_app.py
+++ b/qubesadmin/tests/mock_app.py
@@ -107,10 +107,12 @@ class Property:
 
 
 DEFAULT_VM_PROPERTIES = {
+    "appvm_default_bootmode": Property("default", "str", True),
     "audiovm": Property("dom0", "vm", True),
     "auto_cleanup": Property("False", "bool", True),
     "autostart": Property("False", "bool", True),
     "backup_timestamp": Property("", "int", True),
+    "bootmode": Property("default", "str", True),
     "debug": Property("False", "bool", True),
     "default_dispvm": Property("default-dvm", "vm", False),
     "default_user": Property("user", "str", True),
@@ -199,7 +201,10 @@ ALL_KNOWN_FEATURES = [
     'supported-service.shutdown-idle', 'os', 'gui-allow-fullscreen',
     'gui-allow-utf8-titles', 'qubes-firewall', 'service.shutdown-idle',
     'supported-service.qubes-updates-proxy', 'service.clocksync',
-    'supported-service.clocksync', 'skip-update'
+    'supported-service.clocksync', 'skip-update', 'boot-mode.active',
+    'boot-mode.appvm-default', 'boot-mode.name.default',
+    'boot-mode.kernelopts.mode1', 'boot-mode.kernelopts.mode2',
+    'boot-mode.name.mode1', 'boot-mode.name.mode2',
 ]
 
 POSSIBLE_TAGS = ['whonix-updatevm', 'anon-gateway']
@@ -383,8 +388,10 @@ class MockQube:
 
         # create all propertyget calls
         for prop, value in self.properties.items():
-            if prop == 'template' and \
-                    self.klass in ("TemplateVM", "StandaloneVM"):
+            if ((prop == 'template') and \
+                    self.klass in ("TemplateVM", "StandaloneVM")) \
+                    or ((prop == 'appvm_default_bootmode') and \
+                    self.klass in ("AppVM",)):
                 self.qapp.expected_calls[
                     (self.name, "admin.vm.property.Get", prop, None)] = \
                     b'2\x00QubesNoSuchPropertyError\x00\x00No such property\x00'


### PR DESCRIPTION
Boot modes provide a way for VMs to advertise that they can have their behavior changed by booting them with a predefined combination of additional kernel parameters set. This allows qubes to offer features like a secure system maintenance mode in a way that works seemlessly with Qubes OS.

This commit documents the features and properties used in boot mode support, and fixes some automated tests.