### PR TITLE
Add anon-vm tag in MockQube possible tags and fix a bug when using a tag form this list

### DIFF
--- a/qubesadmin/tests/mock_app.py
+++ b/qubesadmin/tests/mock_app.py
@@ -457,6 +457,8 @@ class MockQube:
                     (self.name, "admin.vm.tag.Get", tag, None)] = b"0\x001"
 
         for tag in POSSIBLE_TAGS:
+            if self.tags and tag in self.tags:
+                continue
             self.qapp.expected_calls[
                 (self.name, "admin.vm.tag.Get", tag, None)] = b"0\x000"
 

--- a/qubesadmin/tests/mock_app.py
+++ b/qubesadmin/tests/mock_app.py
@@ -207,7 +207,7 @@ ALL_KNOWN_FEATURES = [
     'boot-mode.name.mode1', 'boot-mode.name.mode2',
 ]
 
-POSSIBLE_TAGS = ['whonix-updatevm', 'anon-gateway']
+POSSIBLE_TAGS = ['whonix-updatevm', 'anon-gateway', 'anon-vm']
 
 
 class VolumeInfo:


### PR DESCRIPTION
This fix adds the ``anon-vm`` tag to the list of ``POSSIBLE_TAGS``. This is required for https://github.com/QubesOS/qubes-issues/issues/8551.  It also fixes a bug when using a MockQube that has a tag contained in ``POSSIBLE_TAGS``. In this case, its value will always be zero.