### PR TITLE
Enable more common compression filters for restoring

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ checks:tests:
   - ci/codecov-wrapper
   before_script:
   - sudo dnf install -y openssl python3-rpm sequoia-sqv python3-xlib libnotify
+  - sudo dnf install -y zstd
   - sudo dnf install -y --enablerepo=qubes-host-r4.3-current-testing scrypt
   - pip3 install --quiet -r ci/requirements.txt
   - git config --global --add safe.directory "$PWD"

--- a/qubesadmin/tests/backup/backupcompatibility.py
+++ b/qubesadmin/tests/backup/backupcompatibility.py
@@ -2048,6 +2048,83 @@ class TC_10_BackupCompatibility(qubesadmin.tests.backup.BackupTestCase):
 
     @unittest.skipUnless(shutil.which('scrypt'),
         "scrypt not installed")
+    def test_230_r4_optional_compression(self):
+        self.create_v4_backup("zstdmt")
+
+        self.app.expected_calls[('dom0', 'admin.vm.List', None, None)] = (
+            b'0\0dom0 class=AdminVM state=Running\n'
+            b'fedora-25 class=TemplateVM state=Halted\n'
+            b'testvm class=AppVM state=Running\n'
+            b'sys-net class=AppVM state=Running\n'
+        )
+        self.app.expected_calls[
+            ('dom0', 'admin.property.Get', 'default_template', None)] = \
+            b'0\0default=no type=vm fedora-25'
+        self.app.expected_calls[
+            ('sys-net', 'admin.vm.property.Get', 'provides_network', None)] = \
+            b'0\0default=no type=bool True'
+        self.setup_expected_calls(parsed_qubes_xml_v4, templates_map={
+            'debian-8': 'fedora-25'
+        })
+        firewall_data = (
+            'action=accept specialtarget=dns\n'
+            'action=accept proto=icmp\n'
+            'action=accept proto=tcp dstports=22-22\n'
+            'action=accept proto=tcp dsthost=www.qubes-os.org '
+            'dstports=443-443\n'
+            'action=accept proto=tcp dst4=192.168.0.0/24\n'
+            'action=drop\n'
+        )
+        self.app.expected_calls[
+            ('test-work', 'admin.vm.firewall.Set', None,
+            firewall_data.encode())] = b'0\0'
+
+        qubesd_calls_queue = multiprocessing.Queue()
+
+        dummy_timestamp = time.strftime("test-%Y-%m-%d-%H%M%S")
+        patches = [
+            mock.patch('qubesadmin.storage.Volume',
+                staticmethod(
+                    functools.partial(MockVolume, qubesd_calls_queue, 0)),
+                ),
+            mock.patch(
+                'qubesadmin.backup.restore.BackupRestore._handle_appmenus_list',
+                staticmethod(
+                    functools.partial(self.mock_appmenus, qubesd_calls_queue)),
+                ),
+            mock.patch(
+                'qubesadmin.firewall.Firewall',
+                staticmethod(
+                    functools.partial(MockFirewall, qubesd_calls_queue)),
+                ),
+            mock.patch(
+                'time.strftime',
+                return_value=dummy_timestamp)
+        ]
+        for patch in patches:
+            patch.start()
+        try:
+            self.restore_backup(self.fullpath("backup.bin"), options={
+                'use-default-template': True,
+                'use-default-netvm': True,
+            })
+        finally:
+            for patch in patches:
+                patch.stop()
+
+        # retrieve calls from other multiprocess.Process instances
+        while not qubesd_calls_queue.empty():
+            call_args = qubesd_calls_queue.get()
+            with contextlib.suppress(qubesadmin.exc.QubesException):
+                self.app.qubesd_call(*call_args)
+        qubesd_calls_queue.close()
+
+        self.assertAllCalled()
+
+        self.assertDom0Restored(dummy_timestamp)
+
+    @unittest.skipUnless(shutil.which('scrypt'),
+        "scrypt not installed")
     def test_300_r4_no_space(self):
         self.create_v4_backup("", big=True)
         self.app.expected_calls[('dom0', 'admin.vm.List', None, None)] = (

--- a/qubesadmin/tests/backup/backupcompatibility.py
+++ b/qubesadmin/tests/backup/backupcompatibility.py
@@ -1563,13 +1563,19 @@ class TC_10_BackupCompatibility(qubesadmin.tests.backup.BackupTestCase):
         dummy_timestamp = time.strftime("test-%Y-%m-%d-%H%M%S")
         patches = [
             mock.patch('qubesadmin.storage.Volume',
-                functools.partial(MockVolume, qubesd_calls_queue, 0)),
+                staticmethod(
+                    functools.partial(MockVolume, qubesd_calls_queue, 0))
+                ),
             mock.patch(
                 'qubesadmin.backup.restore.BackupRestore._handle_appmenus_list',
-                functools.partial(self.mock_appmenus, qubesd_calls_queue)),
+                staticmethod(
+                    functools.partial(self.mock_appmenus, qubesd_calls_queue))
+                ),
             mock.patch(
                 'qubesadmin.firewall.Firewall',
-                functools.partial(MockFirewall, qubesd_calls_queue)),
+                staticmethod(
+                    functools.partial(MockFirewall, qubesd_calls_queue))
+                ),
             mock.patch(
                 'time.strftime',
                 return_value=dummy_timestamp)
@@ -1632,13 +1638,19 @@ class TC_10_BackupCompatibility(qubesadmin.tests.backup.BackupTestCase):
         dummy_timestamp = time.strftime("test-%Y-%m-%d-%H%M%S")
         patches = [
             mock.patch('qubesadmin.storage.Volume',
-                functools.partial(MockVolume, qubesd_calls_queue, 0)),
+                staticmethod(
+                    functools.partial(MockVolume, qubesd_calls_queue, 0))
+                ),
             mock.patch(
                 'qubesadmin.backup.restore.BackupRestore._handle_appmenus_list',
-                functools.partial(self.mock_appmenus, qubesd_calls_queue)),
+                staticmethod(
+                    functools.partial(self.mock_appmenus, qubesd_calls_queue))
+                ),
             mock.patch(
                 'qubesadmin.firewall.Firewall',
-                functools.partial(MockFirewall, qubesd_calls_queue)),
+                staticmethod(
+                    functools.partial(MockFirewall, qubesd_calls_queue))
+                ),
             mock.patch(
                 'time.strftime',
                 return_value=dummy_timestamp)
@@ -1700,13 +1712,19 @@ class TC_10_BackupCompatibility(qubesadmin.tests.backup.BackupTestCase):
         dummy_timestamp = time.strftime("test-%Y-%m-%d-%H%M%S")
         patches = [
             mock.patch('qubesadmin.storage.Volume',
-                functools.partial(MockVolume, qubesd_calls_queue, 0)),
+                staticmethod(
+                    functools.partial(MockVolume, qubesd_calls_queue, 0))
+                ),
             mock.patch(
                 'qubesadmin.backup.restore.BackupRestore._handle_appmenus_list',
-                functools.partial(self.mock_appmenus, qubesd_calls_queue)),
+                staticmethod(
+                    functools.partial(self.mock_appmenus, qubesd_calls_queue))
+                ),
             mock.patch(
                 'qubesadmin.firewall.Firewall',
-                functools.partial(MockFirewall, qubesd_calls_queue)),
+                staticmethod(
+                    functools.partial(MockFirewall, qubesd_calls_queue))
+                ),
             mock.patch(
                 'time.strftime',
                 return_value=dummy_timestamp)
@@ -1769,13 +1787,19 @@ class TC_10_BackupCompatibility(qubesadmin.tests.backup.BackupTestCase):
         dummy_timestamp = time.strftime("test-%Y-%m-%d-%H%M%S")
         patches = [
             mock.patch('qubesadmin.storage.Volume',
-                functools.partial(MockVolume, qubesd_calls_queue, 0)),
+                staticmethod(
+                    functools.partial(MockVolume, qubesd_calls_queue, 0))
+                ),
             mock.patch(
                 'qubesadmin.backup.restore.BackupRestore._handle_appmenus_list',
-                functools.partial(self.mock_appmenus, qubesd_calls_queue)),
+                staticmethod(
+                    functools.partial(self.mock_appmenus, qubesd_calls_queue))
+                ),
             mock.patch(
                 'qubesadmin.firewall.Firewall',
-                functools.partial(MockFirewall, qubesd_calls_queue)),
+                staticmethod(
+                    functools.partial(MockFirewall, qubesd_calls_queue))
+                ),
             mock.patch(
                 'time.strftime',
                 return_value=dummy_timestamp)
@@ -1840,13 +1864,19 @@ class TC_10_BackupCompatibility(qubesadmin.tests.backup.BackupTestCase):
         dummy_timestamp = time.strftime("test-%Y-%m-%d-%H%M%S")
         patches = [
             mock.patch('qubesadmin.storage.Volume',
-                functools.partial(MockVolume, qubesd_calls_queue, 0)),
+                staticmethod(
+                    functools.partial(MockVolume, qubesd_calls_queue, 0)),
+                ),
             mock.patch(
                 'qubesadmin.backup.restore.BackupRestore._handle_appmenus_list',
-                functools.partial(self.mock_appmenus, qubesd_calls_queue)),
+                staticmethod(
+                    functools.partial(self.mock_appmenus, qubesd_calls_queue)),
+                ),
             mock.patch(
                 'qubesadmin.firewall.Firewall',
-                functools.partial(MockFirewall, qubesd_calls_queue)),
+                staticmethod(
+                    functools.partial(MockFirewall, qubesd_calls_queue)),
+                ),
             mock.patch(
                 'time.strftime',
                 return_value=dummy_timestamp)
@@ -1911,13 +1941,19 @@ class TC_10_BackupCompatibility(qubesadmin.tests.backup.BackupTestCase):
         dummy_timestamp = time.strftime("test-%Y-%m-%d-%H%M%S")
         patches = [
             mock.patch('qubesadmin.storage.Volume',
-                functools.partial(MockVolume, qubesd_calls_queue, 0)),
+                staticmethod(
+                    functools.partial(MockVolume, qubesd_calls_queue, 0)),
+                ),
             mock.patch(
                 'qubesadmin.backup.restore.BackupRestore._handle_appmenus_list',
-                functools.partial(self.mock_appmenus, qubesd_calls_queue)),
+                staticmethod(
+                    functools.partial(self.mock_appmenus, qubesd_calls_queue)),
+                ),
             mock.patch(
                 'qubesadmin.firewall.Firewall',
-                functools.partial(MockFirewall, qubesd_calls_queue)),
+                staticmethod(
+                    functools.partial(MockFirewall, qubesd_calls_queue)),
+                ),
             mock.patch(
                 'time.strftime',
                 return_value=dummy_timestamp)
@@ -1954,13 +1990,19 @@ class TC_10_BackupCompatibility(qubesadmin.tests.backup.BackupTestCase):
         dummy_timestamp = time.strftime("test-%Y-%m-%d-%H%M%S")
         patches = [
             mock.patch('qubesadmin.storage.Volume',
-                functools.partial(MockVolume, qubesd_calls_queue, 0)),
+                staticmethod(
+                    functools.partial(MockVolume, qubesd_calls_queue, 0)),
+                ),
             mock.patch(
                 'qubesadmin.backup.restore.BackupRestore._handle_appmenus_list',
-                functools.partial(self.mock_appmenus, qubesd_calls_queue)),
+                staticmethod(
+                    functools.partial(self.mock_appmenus, qubesd_calls_queue)),
+                ),
             mock.patch(
                 'qubesadmin.firewall.Firewall',
-                functools.partial(MockFirewall, qubesd_calls_queue)),
+                staticmethod(
+                    functools.partial(MockFirewall, qubesd_calls_queue)),
+                ),
             mock.patch(
                 'time.strftime',
                 return_value=dummy_timestamp)
@@ -1977,7 +2019,7 @@ class TC_10_BackupCompatibility(qubesadmin.tests.backup.BackupTestCase):
 
     @unittest.skipUnless(shutil.which('scrypt'),
         "scrypt not installed")
-    def test_230_r4_uncommon_cmpression_forced(self):
+    def test_230_r4_uncommon_compression_forced(self):
         self.create_v4_backup("less")
 
         self.app.expected_calls[('dom0', 'admin.vm.List', None, None)] = (
@@ -2013,13 +2055,19 @@ class TC_10_BackupCompatibility(qubesadmin.tests.backup.BackupTestCase):
         dummy_timestamp = time.strftime("test-%Y-%m-%d-%H%M%S")
         patches = [
             mock.patch('qubesadmin.storage.Volume',
-                functools.partial(MockVolume, qubesd_calls_queue, 0)),
+                staticmethod(
+                    functools.partial(MockVolume, qubesd_calls_queue, 0)),
+                ),
             mock.patch(
                 'qubesadmin.backup.restore.BackupRestore._handle_appmenus_list',
-                functools.partial(self.mock_appmenus, qubesd_calls_queue)),
+                staticmethod(
+                    functools.partial(self.mock_appmenus, qubesd_calls_queue)),
+                ),
             mock.patch(
                 'qubesadmin.firewall.Firewall',
-                functools.partial(MockFirewall, qubesd_calls_queue)),
+                staticmethod(
+                    functools.partial(MockFirewall, qubesd_calls_queue)),
+                ),
             mock.patch(
                 'time.strftime',
                 return_value=dummy_timestamp)
@@ -2160,13 +2208,19 @@ class TC_10_BackupCompatibility(qubesadmin.tests.backup.BackupTestCase):
         dummy_timestamp = time.strftime("test-%Y-%m-%d-%H%M%S")
         patches = [
             mock.patch('qubesadmin.storage.Volume',
-                functools.partial(MockVolume, qubesd_calls_queue, 30)),
+                staticmethod(
+                    functools.partial(MockVolume, qubesd_calls_queue, 30))
+                ),
             mock.patch(
                 'qubesadmin.backup.restore.BackupRestore._handle_appmenus_list',
-                functools.partial(self.mock_appmenus, qubesd_calls_queue)),
+                staticmethod(
+                    functools.partial(self.mock_appmenus, qubesd_calls_queue))
+                ),
             mock.patch(
                 'qubesadmin.firewall.Firewall',
-                functools.partial(MockFirewall, qubesd_calls_queue)),
+                staticmethod(
+                    functools.partial(MockFirewall, qubesd_calls_queue))
+                ),
             mock.patch(
                 'time.strftime',
                 return_value=dummy_timestamp),


### PR DESCRIPTION
Since some users want pigz, zstd and some other compressions which might not be installed by default, enable them if they are installed.

Related: https://github.com/QubesOS/qubes-issues/issues/8291
Related: https://github.com/QubesOS/qubes-issues/issues/8211