### PR TITLE
qvm-pci: optionally list SBDF of listed devices

### DIFF
--- a/doc/manpages/qvm-device.rst
+++ b/doc/manpages/qvm-device.rst
@@ -53,6 +53,11 @@ List devices.
 
    Include info about device assignments, indicated by '*' before qube name.
 
+.. option:: --with-sbdf, --resolve-paths
+
+   For PCI devices list also resolved device path (SBDF). This eases looking up the device with other tools like lspci.
+   The option is ignored when listing non-PCI devices.
+
 .. option:: --all
 
    List devices from all qubes. You can use :option:`--exclude` to limit the


### PR DESCRIPTION
SBDF aka resolved path is what most interfaces use, including lspci, sysfs etc. Include that in listing too, to ease user's life.

Note that 'qvm-pci info' already includes that info.

QubesOS/qubes-issues#8681