### PR TITLE
Update the padlock icons reference in qubesadmin/label.py docstring

### DIFF
--- a/qubesadmin/label.py
+++ b/qubesadmin/label.py
@@ -26,7 +26,7 @@ import qubesadmin.exc
 class Label(object):
     '''Label definition for virtual machines
 
-    Label specifies colour of the padlock displayed next to VM's name.
+    Label specifies colour of the qube icon displayed next to VM's name.
 
     :param str color: colour specification as in HTML (``#abcdef``)
     :param str name: label's name like "red" or "green"


### PR DESCRIPTION
As per https://github.com/QubesOS/qubes-issues/issues/5676, replace the old padlock icons reference with the current one, i.e. qube icons.