### PR TITLE
Pass recognized boolean values to qubes-guid

### DIFF
--- a/qubesadmin/tests/tools/qvm_start_daemon.py
+++ b/qubesadmin/tests/tools/qvm_start_daemon.py
@@ -784,9 +784,23 @@ HDMI1 connected 2560x1920+0+0 (normal left inverted right x axis y axis) 206mm x
             ('gui-vm', 'admin.vm.feature.Get',
              'gui-default-override-redirect', None)] = \
                  b'0\x00ask'
+        self.app.expected_calls[
+            ('gui-vm', 'admin.vm.feature.Get',
+             'gui-default-allow-fullscreen', None)] = \
+                 b'0\x00True'
+        self.app.expected_calls[
+            ('gui-vm', 'admin.vm.feature.Get',
+             'gui-default-allow-utf8-titles', None)] = \
+                 b'0\x000'
+        self.app.expected_calls[
+            ('gui-vm', 'admin.vm.feature.Get',
+             'gui-default-override-redirect-protection', None)] = \
+                 b'0\x00Maybe'
 
         _args, config = self.run_common_args()
         self.assertEqual(config, '''\
 global: {
+  allow_fullscreen = true;
+  allow_utf8_titles = false;
 }
 ''')

--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -175,7 +175,12 @@ def retrieve_gui_daemon_options(vm, guivm):
             continue
 
         if kind == 'bool':
-            value = bool(feature_value)
+            if feature_value in ["1", "true", "True"]:
+                value = True
+            elif feature_value in ["0", "", "false", "False"]:
+                value = False
+            else:
+                value = feature_value
         elif kind == 'int':
             value = int(feature_value)
         elif kind == 'str':


### PR DESCRIPTION
Since libconfig's `config_setting_get_bool` recognises limited values, convert feature value to something it properly recognises

related: https://github.com/QubesOS/qubes-issues/issues/7730
reference: https://hyperrealm.github.io/libconfig/libconfig_manual.html#Settings