### PR TITLE
Document preloaded disposables

### DIFF
--- a/doc/manpages/qvm-features.rst
+++ b/doc/manpages/qvm-features.rst
@@ -52,6 +52,8 @@ means :py:obj:`False` and non-empty string (commonly ``'1'``) means
 extension-dependent. In most cases the default value for feature is retrieved
 from a qube template.
 
+Feature managed by the `system` must not be modified by users.
+
 List of known features
 ----------------------
 
@@ -105,7 +107,7 @@ boot-mode.name.\*
 
 The user-visible pretty name for a boot mode. The ID of the boot mode with the
 given pretty name is specified by the last dot-separated word in the feature
-key, while the pretty name is specified by the feature value. 
+key, while the pretty name is specified by the feature value.
 
 gui
 ^^^
@@ -184,8 +186,10 @@ internal
 
 Internal qubes (with this feature set to :py:obj:`True`) are not included in the
 menu, not available in GUI tools (e.g in Global Settings as a default net qube)
-and generally hidden from normal usage. It is not recommended to set this
-feature manually.
+and generally hidden from normal usage (including not showing as a Qrexec target
+for `Ask` rules. It is not recommended to set this feature manually. If this
+feature is set to a template, applications may consider qubes based on this
+template as internal also.
 
 Default: not internal VM
 
@@ -421,6 +425,81 @@ calls. Feature value could contain the rationale for the start ban.
 
 Note: `prohibit-start` for a TemplateVM does not forbid start of AppVMs based
 on it.
+
+preload-dispvm-max
+^^^^^^^^^^^^^^^^^^
+
+Number of disposables to preload. Upon setting, the number of running preloaded
+disposables will be adjusted to match the maximum configured, if there is not
+enough of them and there is enough available memory on the system, new ones will
+be created, if there are more than enough, the excess will be removed.
+
+|
+| **Valid on**: disposable template
+| **Type**: `int`
+| **Default**: `0`
+
+preload-dispvm
+^^^^^^^^^^^^^^
+
+Space separated list of preloaded disposables originated from the disposable
+template. Preloaded disposables are disposables that run in the background
+waiting for use, specially designed for minimal waiting time to open
+applications in a fresh disposable.
+
+Preloaded disposables have its GUI applications entries hidden and are paused to
+avoid user mistakes, as it is not intended to use them directly. To use them,
+target the disposable template to start a service in a disposable, instead of
+creating a new disposable, calls will be redirected to the first preloaded
+disposable in the list. As soon as the preloaded disposable is requested to be
+used, it is removed from the `preload-dispvm` list, GUI applications entries
+become visible, followed by a new disposable being preloaded.
+
+.. warning::
+
+   Applications configured to autostart by the disposable template or the
+   template itself will be interactive before the preloaded disposable can be
+   paused.
+
+|
+| **Managed by**: system
+| **Valid on**: disposable template
+| **Type**: `str`
+| **Default**: empty
+
+preload-dispvm-complete
+^^^^^^^^^^^^^^^^^^^^^^^
+
+If `True`, preloaded disposable has completed all necessary steps to be usable.
+
+|
+| **Managed by**: system
+| **Valid on**: preloaded disposables
+| **Type**: `boolean`
+| **Default**: `False`
+
+preload-dispvm-requested
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+If `True`, preloaded disposable has been requested for use and is running the
+procedures to mark it as used.
+
+|
+| **Managed by**: system
+| **Valid on**: preloaded disposables
+| **Type**: `boolean`
+| **Default**: `False`
+
+preload-dispvm-used
+^^^^^^^^^^^^^^^^^^^
+
+If `True`, preloaded disposable has been used.
+
+|
+| **Managed by**: system
+| **Valid on**: preloaded disposables
+| **Type**: `boolean`
+| **Default**: `False`
 
 custom-persist.*
 ^^^^^^^^^^^^^^^^

--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -43,6 +43,7 @@ import qubesadmin.device_protocol
 
 try:
     import qubesdb
+
     has_qubesdb = True
 except ImportError:
     has_qubesdb = False
@@ -69,22 +70,20 @@ class VMCollection(object):
         """Refresh cached list of VMs"""
         if not force and self._vm_list is not None:
             return
-        vm_list_data = self.app.qubesd_call(
-            'dom0',
-            'admin.vm.List'
-        )
+        vm_list_data = self.app.qubesd_call("dom0", "admin.vm.List")
         new_vm_list = {}
         # FIXME: this will probably change
         for vm_data in vm_list_data.splitlines():
-            vm_name, props = vm_data.decode('ascii').split(' ', 1)
+            vm_name, props = vm_data.decode("ascii").split(" ", 1)
             vm_name = str(vm_name)
-            props = props.split(' ')
+            props = props.split(" ")
             new_vm_list[vm_name] = dict(
-                [vm_prop.split('=', 1) for vm_prop in props])
+                [vm_prop.split("=", 1) for vm_prop in props]
+            )
             # if cache not enabled, drop power state
             if not self.app.cache_enabled:
                 try:
-                    del new_vm_list[vm_name]['state']
+                    del new_vm_list[vm_name]["state"]
                 except KeyError:
                     pass
 
@@ -93,7 +92,7 @@ class VMCollection(object):
             if vm.name not in self._vm_list:
                 # VM no longer exists
                 del self._vm_objects[name]
-            elif vm.klass != self._vm_list[vm.name]['class']:
+            elif vm.klass != self._vm_list[vm.name]["class"]:
                 # VM class have changed
                 del self._vm_objects[name]
             # TODO: some generation ID, to detect VM re-creation
@@ -122,10 +121,11 @@ class VMCollection(object):
             klass = None
             power_state = None
             if self._vm_list and item in self._vm_list:
-                klass = self._vm_list[item]['class']
-                power_state = self._vm_list[item].get('state')
-            self._vm_objects[item] = cls(self.app, item, klass=klass,
-                                         power_state=power_state)
+                klass = self._vm_list[item]["class"]
+                power_state = self._vm_list[item].get("state")
+            self._vm_objects[item] = cls(
+                self.app, item, klass=klass, power_state=power_state
+            )
         return self._vm_objects[item]
 
     def get(self, item, default=None):
@@ -144,7 +144,7 @@ class VMCollection(object):
         return item in self._vm_list
 
     def __delitem__(self, key):
-        self.app.qubesd_call(key, 'admin.vm.Remove')
+        self.app.qubesd_call(key, "admin.vm.Remove")
         self.clear_cache()
 
     def __iter__(self):
@@ -187,27 +187,33 @@ class QubesBase(qubesadmin.base.PropertyHolder):
     cache_enabled = False
 
     def __init__(self):
-        super().__init__(self, 'admin.property.', 'dom0')
+        super().__init__(self, "admin.property.", "dom0")
         self.domains = VMCollection(self)
         self.labels = qubesadmin.base.WrapperObjectsCollection(
-            self, 'admin.label.List', qubesadmin.label.Label)
+            self, "admin.label.List", qubesadmin.label.Label
+        )
         self.pools = qubesadmin.base.WrapperObjectsCollection(
-            self, 'admin.pool.List', qubesadmin.storage.Pool)
+            self, "admin.pool.List", qubesadmin.storage.Pool
+        )
         #: cache for available storage pool drivers and options to create them
         self._pool_drivers = None
-        self.log = logging.getLogger('app')
+        self.log = logging.getLogger("app")
         self._local_name = None
 
     def list_vmclass(self):
         """Call Qubesd in order to obtain the vm classes list"""
-        vmclass = self.qubesd_call('dom0', 'admin.vmclass.List') \
-            .decode().splitlines()
+        vmclass = (
+            self.qubesd_call("dom0", "admin.vmclass.List").decode().splitlines()
+        )
         return sorted(vmclass)
 
     def list_deviceclass(self):
         """Call Qubesd in order to obtain the device classes list"""
-        deviceclasses = self.qubesd_call('dom0', 'admin.deviceclass.List') \
-            .decode().splitlines()
+        deviceclasses = (
+            self.qubesd_call("dom0", "admin.deviceclass.List")
+            .decode()
+            .splitlines()
+        )
         return sorted(deviceclasses)
 
     def _refresh_pool_drivers(self):
@@ -218,29 +224,30 @@ class QubesBase(qubesadmin.base.PropertyHolder):
         """
         if self._pool_drivers is None:
             pool_drivers_data = self.qubesd_call(
-                'dom0', 'admin.pool.ListDrivers', None, None)
-            assert pool_drivers_data.endswith(b'\n')
+                "dom0", "admin.pool.ListDrivers", None, None
+            )
+            assert pool_drivers_data.endswith(b"\n")
             pool_drivers = {}
-            for driver_line in pool_drivers_data.decode('ascii').splitlines():
+            for driver_line in pool_drivers_data.decode("ascii").splitlines():
                 if not driver_line:
                     continue
-                driver_name, driver_options = driver_line.split(' ', 1)
-                pool_drivers[driver_name] = driver_options.split(' ')
+                driver_name, driver_options = driver_line.split(" ", 1)
+                pool_drivers[driver_name] = driver_options.split(" ")
             self._pool_drivers = pool_drivers
 
     @property
     def pool_drivers(self):
-        """ Available storage pool drivers """
+        """Available storage pool drivers"""
         self._refresh_pool_drivers()
         return self._pool_drivers.keys()
 
     def pool_driver_parameters(self, driver):
-        """ Parameters to initialize storage pool using given driver """
+        """Parameters to initialize storage pool using given driver"""
         self._refresh_pool_drivers()
         return self._pool_drivers[driver]
 
     def add_pool(self, name, driver, **kwargs):
-        """ Add a storage pool to config
+        """Add a storage pool to config
 
         :param name: name of storage pool to create
         :param driver: driver to use, see :py:meth:`pool_drivers` for
@@ -249,25 +256,27 @@ class QubesBase(qubesadmin.base.PropertyHolder):
             see :py:meth:`pool_driver_parameters` for a list
         """
         # sort parameters only to ease testing, not required by API
-        payload = 'name={}\n'.format(name) + \
-                  ''.join('{}={}\n'.format(key, value)
-                          for key, value in sorted(kwargs.items()))
-        self.qubesd_call('dom0', 'admin.pool.Add', driver,
-                         payload.encode('utf-8'))
+        payload = "name={}\n".format(name) + "".join(
+            "{}={}\n".format(key, value)
+            for key, value in sorted(kwargs.items())
+        )
+        self.qubesd_call(
+            "dom0", "admin.pool.Add", driver, payload.encode("utf-8")
+        )
 
     def remove_pool(self, name):
-        """ Remove a storage pool """
-        self.qubesd_call('dom0', 'admin.pool.Remove', name, None)
+        """Remove a storage pool"""
+        self.qubesd_call("dom0", "admin.pool.Remove", name, None)
 
     @property
     def local_name(self):
-        """ Get localhost name """
+        """Get localhost name"""
         if not self._local_name:
             local_name = None
             if has_qubesdb:
                 try:
                     local_qdb = qubesdb.QubesDB()
-                    local_name_b = local_qdb.read('/name')
+                    local_name_b = local_qdb.read("/name")
                     if local_name_b:
                         local_name = local_name_b.decode()
                 except qubesdb.Error:
@@ -309,8 +318,9 @@ class QubesBase(qubesadmin.base.PropertyHolder):
 
         return clsname
 
-    def add_new_vm(self, cls, name, label, template=None, pool=None,
-                   pools=None):
+    def add_new_vm(
+        self, cls, name, label, template=None, pool=None, pools=None
+    ):
         """Create new Virtual Machine
 
         Example usage with custom storage pools:
@@ -340,30 +350,42 @@ class QubesBase(qubesadmin.base.PropertyHolder):
         elif template is not None:
             template = str(template)
 
-        if ' ' in name:
-            raise ValueError(f'Qube name could not contain space: {name}')
+        if " " in name:
+            raise ValueError(f"Qube name could not contain space: {name}")
         if pool and pools:
-            raise ValueError('only one of pool= and pools= can be used')
+            raise ValueError("only one of pool= and pools= can be used")
 
-        method_prefix = 'admin.vm.Create.'
-        payload = 'name={} label={}'.format(name, label)
+        method_prefix = "admin.vm.Create."
+        payload = "name={} label={}".format(name, label)
         if pool:
-            payload += ' pool={}'.format(str(pool))
-            method_prefix = 'admin.vm.CreateInPool.'
+            payload += " pool={}".format(str(pool))
+            method_prefix = "admin.vm.CreateInPool."
         if pools:
-            payload += ''.join(' pool:{}={}'.format(vol, str(pool))
-                               for vol, pool in sorted(pools.items()))
-            method_prefix = 'admin.vm.CreateInPool.'
+            payload += "".join(
+                " pool:{}={}".format(vol, str(pool))
+                for vol, pool in sorted(pools.items())
+            )
+            method_prefix = "admin.vm.CreateInPool."
 
-        self.qubesd_call('dom0', method_prefix + cls, template,
-                         payload.encode('utf-8'))
+        self.qubesd_call(
+            "dom0", method_prefix + cls, template, payload.encode("utf-8")
+        )
 
         self.domains.clear_cache()
         return self.domains[name]
 
-    def clone_vm(self, src_vm, new_name, new_cls=None, *, pool=None, pools=None,
-                 ignore_errors=False, ignore_volumes=None,
-                 ignore_devices=False):
+    def clone_vm(
+        self,
+        src_vm,
+        new_name,
+        new_cls=None,
+        *,
+        pool=None,
+        pools=None,
+        ignore_errors=False,
+        ignore_volumes=None,
+        ignore_devices=False,
+    ):
         # pylint: disable=too-many-statements
         """Clone Virtual Machine
 
@@ -391,7 +413,7 @@ class QubesBase(qubesadmin.base.PropertyHolder):
         """
 
         if pool and pools:
-            raise ValueError('only one of pool= and pools= can be used')
+            raise ValueError("only one of pool= and pools= can be used")
 
         if isinstance(src_vm, str):
             src_vm = self.domains[src_vm]
@@ -399,7 +421,7 @@ class QubesBase(qubesadmin.base.PropertyHolder):
         if new_cls is None:
             new_cls = src_vm.klass
 
-        template = getattr(src_vm, 'template', None)
+        template = getattr(src_vm, "template", None)
         if template is not None:
             template = str(template)
 
@@ -413,25 +435,29 @@ class QubesBase(qubesadmin.base.PropertyHolder):
                     continue
                 if ignore_volumes and volume.name in ignore_volumes:
                     continue
-                default_pool = getattr(self.app, 'default_pool_' + volume.name,
-                                       volume.pool)
+                default_pool = getattr(
+                    self.app, "default_pool_" + volume.name, volume.pool
+                )
                 if default_pool != volume.pool:
                     if pools is None:
                         pools = {}
                     pools[volume.name] = volume.pool
 
-        method_prefix = 'admin.vm.Create.'
-        payload = 'name={} label={}'.format(new_name, label)
+        method_prefix = "admin.vm.Create."
+        payload = "name={} label={}".format(new_name, label)
         if pool:
-            payload += ' pool={}'.format(str(pool))
-            method_prefix = 'admin.vm.CreateInPool.'
+            payload += " pool={}".format(str(pool))
+            method_prefix = "admin.vm.CreateInPool."
         if pools:
-            payload += ''.join(' pool:{}={}'.format(vol, str(pool))
-                               for vol, pool in sorted(pools.items()))
-            method_prefix = 'admin.vm.CreateInPool.'
+            payload += "".join(
+                " pool:{}={}".format(vol, str(pool))
+                for vol, pool in sorted(pools.items())
+            )
+            method_prefix = "admin.vm.CreateInPool."
 
-        self.qubesd_call('dom0', method_prefix + new_cls, template,
-                         payload.encode('utf-8'))
+        self.qubesd_call(
+            "dom0", method_prefix + new_cls, template, payload.encode("utf-8")
+        )
 
         self.domains.clear_cache()
         dst_vm = self.domains[new_name]
@@ -439,8 +465,14 @@ class QubesBase(qubesadmin.base.PropertyHolder):
             assert isinstance(dst_vm, qubesadmin.vm.QubesVM)
             for prop in src_vm.property_list():
                 # handled by admin.vm.Create call
-                if prop in ('name', 'qid', 'template', 'label', 'uuid',
-                            'installed_by_rpm'):
+                if prop in (
+                    "name",
+                    "qid",
+                    "template",
+                    "label",
+                    "uuid",
+                    "installed_by_rpm",
+                ):
                     continue
                 if src_vm.property_is_default(prop):
                     continue
@@ -450,18 +482,20 @@ class QubesBase(qubesadmin.base.PropertyHolder):
                     pass
                 except qubesadmin.exc.QubesException as e:
                     dst_vm.log.error(
-                        'Failed to set {!s} property: {!s}'.format(prop, e))
+                        "Failed to set {!s} property: {!s}".format(prop, e)
+                    )
                     if not ignore_errors:
                         raise
 
             for tag in src_vm.tags:
-                if tag.startswith('created-by-'):
+                if tag.startswith("created-by-"):
                     continue
                 try:
                     dst_vm.tags.add(tag)
                 except qubesadmin.exc.QubesException as e:
                     dst_vm.log.error(
-                        'Failed to add {!s} tag: {!s}'.format(tag, e))
+                        "Failed to add {!s} tag: {!s}".format(tag, e)
+                    )
                     if not ignore_errors:
                         raise
 
@@ -470,56 +504,68 @@ class QubesBase(qubesadmin.base.PropertyHolder):
                     dst_vm.features[feature] = value
                 except qubesadmin.exc.QubesException as e:
                     dst_vm.log.error(
-                        'Failed to set {!s} feature: {!s}'.format(feature, e))
+                        "Failed to set {!s} feature: {!s}".format(feature, e)
+                    )
                     if not ignore_errors:
                         raise
 
             try:
                 dst_vm.firewall.save_rules(src_vm.firewall.rules)
             except qubesadmin.exc.QubesException as e:
-                self.log.error('Failed to set firewall: %s', e)
+                self.log.error("Failed to set firewall: %s", e)
                 if not ignore_errors:
                     raise
 
             try:
                 # FIXME: convert to qrexec calls to dom0/GUI VM
-                appmenus_cmd = \
-                    ['qvm-appmenus', '--init', '--update',
-                     '--source', src_vm.name, dst_vm.name]
+                appmenus_cmd = [
+                    "qvm-appmenus",
+                    "--init",
+                    "--update",
+                    "--source",
+                    src_vm.name,
+                    dst_vm.name,
+                ]
                 runas = []
                 if os.getuid() == 0:
                     try:
                         user = self.domains[self.local_name].default_user
                     except (KeyError, qubesadmin.exc.QubesException):
                         try:
-                            user = grp.getgrnam('qubes').gr_mem[0]
+                            user = grp.getgrnam("qubes").gr_mem[0]
                         except KeyError:
                             user = None
                     if not user:
                         raise qubesadmin.exc.QubesException(
-                            'Failed to find local user account')
-                    runas = ['runuser', '-u', user, '--']
+                            "Failed to find local user account"
+                        )
+                    runas = ["runuser", "-u", user, "--"]
 
-                subprocess.check_output(runas + appmenus_cmd,
-                    stderr=subprocess.STDOUT)
+                subprocess.check_output(
+                    runas + appmenus_cmd, stderr=subprocess.STDOUT
+                )
             except OSError as e:
                 # this file needs to be python 2.7 compatible,
                 # so no FileNotFoundError
-                self.log.error('Failed to clone appmenus, qvm-appmenus missing')
+                self.log.error("Failed to clone appmenus, qvm-appmenus missing")
                 if not ignore_errors:
                     raise qubesadmin.exc.QubesException(
-                        'Failed to clone appmenus') from e
+                        "Failed to clone appmenus"
+                    ) from e
             except subprocess.CalledProcessError as e:
-                self.log.error('Failed to clone appmenus: %s',
-                               e.output.decode())
+                self.log.error(
+                    "Failed to clone appmenus: %s", e.output.decode()
+                )
                 if not ignore_errors:
                     raise qubesadmin.exc.QubesException(
-                        'Failed to clone appmenus') from e
+                        "Failed to clone appmenus"
+                    ) from e
             except qubesadmin.exc.QubesException as e:
-                self.log.error('Failed to clone appmenus: %s', e)
+                self.log.error("Failed to clone appmenus: %s", e)
                 if not ignore_errors:
                     raise qubesadmin.exc.QubesException(
-                        'Failed to clone appmenus') from e
+                        "Failed to clone appmenus"
+                    ) from e
 
         except qubesadmin.exc.QubesException:
             if not ignore_errors:
@@ -534,7 +580,7 @@ class QubesBase(qubesadmin.base.PropertyHolder):
                 if ignore_volumes and dst_volume.name in ignore_volumes:
                     continue
                 src_volume = src_vm.volumes[dst_volume.name]
-                dst_vm.log.info('Cloning {} volume'.format(dst_volume.name))
+                dst_vm.log.info("Cloning {} volume".format(dst_volume.name))
                 dst_volume.clone(src_volume)
 
         except qubesadmin.exc.QubesException:
@@ -544,10 +590,12 @@ class QubesBase(qubesadmin.base.PropertyHolder):
         if not ignore_devices:
             try:
                 for devclass in src_vm.devices:
-                    for assignment in (
-                            src_vm.devices[devclass].get_assigned_devices()):
+                    for assignment in src_vm.devices[
+                        devclass
+                    ].get_assigned_devices():
                         new_assignment = assignment.clone(
-                            frontend_domain=dst_vm)
+                            frontend_domain=dst_vm
+                        )
                         dst_vm.devices[devclass].assign(new_assignment)
             except qubesadmin.exc.QubesException:
                 if not ignore_errors:
@@ -556,8 +604,9 @@ class QubesBase(qubesadmin.base.PropertyHolder):
 
         return dst_vm
 
-    def qubesd_call(self, dest, method, arg=None, payload=None,
-                    payload_stream=None):
+    def qubesd_call(
+        self, dest, method, arg=None, payload=None, payload_stream=None
+    ):
         """
         Execute Admin API method.
 
@@ -574,11 +623,22 @@ class QubesBase(qubesadmin.base.PropertyHolder):
         .. warning:: *payload_stream* will get closed by this function
         """
         raise NotImplementedError(
-            'qubesd_call not implemented in QubesBase class; use specialized '
-            'class: qubesadmin.Qubes()')
+            "qubesd_call not implemented in QubesBase class; use specialized "
+            "class: qubesadmin.Qubes()"
+        )
 
-    def run_service(self, dest, service, user=None, *, filter_esc=False,
-                    localcmd=None, wait=True, autostart=True, **kwargs):
+    def run_service(
+        self,
+        dest,
+        service,
+        user=None,
+        *,
+        filter_esc=False,
+        localcmd=None,
+        wait=True,
+        autostart=True,
+        **kwargs,
+    ):
         """Run qrexec service in a given destination
 
         *kwargs* are passed verbatim to :py:meth:`subprocess.Popen`.
@@ -595,8 +655,9 @@ class QubesBase(qubesadmin.base.PropertyHolder):
         :rtype: subprocess.Popen
         """
         raise NotImplementedError(
-            'run_service not implemented in QubesBase class; use specialized '
-            'class: qubesadmin.Qubes()')
+            "run_service not implemented in QubesBase class; use specialized "
+            "class: qubesadmin.Qubes()"
+        )
 
     @staticmethod
     def _call_with_stream(command, payload, payload_stream):
@@ -610,10 +671,11 @@ class QubesBase(qubesadmin.base.PropertyHolder):
         """
 
         with subprocess.Popen(
-                command,
-                stdin=(subprocess.PIPE if payload else payload_stream),
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE) as proc:
+            command,
+            stdin=(subprocess.PIPE if payload else payload_stream),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ) as proc:
             if payload:
                 # It's not strictly correct to write data to stdin in this way,
                 # because the process can get blocked on stdout or stderr pipe.
@@ -661,7 +723,7 @@ class QubesBase(qubesadmin.base.PropertyHolder):
             pass
 
     def _update_power_state_cache(self, subject, event, **kwargs):
-        """ Update cached VM power state.
+        """Update cached VM power state.
 
         This method is designed to be hooked as an event handler for:
         - domain-pre-start
@@ -683,18 +745,18 @@ class QubesBase(qubesadmin.base.PropertyHolder):
         if not self.app.cache_enabled:
             return
 
-        if event == 'domain-pre-start':
-            power_state = 'Transient'
-        elif event == 'domain-start':
-            power_state = 'Running'
-        elif event == 'domain-shutdown':
-            power_state = 'Halted'
-        elif event == 'domain-paused':
-            power_state = 'Paused'
-        elif event == 'domain-unpaused':
-            power_state = 'Running'
-        elif event == 'domain-start-failed':
-            power_state = 'Halted'
+        if event == "domain-pre-start":
+            power_state = "Transient"
+        elif event == "domain-start":
+            power_state = "Running"
+        elif event == "domain-shutdown":
+            power_state = "Halted"
+        elif event == "domain-paused":
+            power_state = "Paused"
+        elif event == "domain-unpaused":
+            power_state = "Running"
+        elif event == "domain-start-failed":
+            power_state = "Halted"
         else:
             # unknown power state change, drop cached power state
             power_state = None
@@ -703,7 +765,7 @@ class QubesBase(qubesadmin.base.PropertyHolder):
         subject._power_state_cache = power_state
 
     def _invalidate_cache_all(self):
-        """ Invalidate all cached data
+        """Invalidate all cached data
 
 
         This method is designed to be hooked as an event handler
@@ -730,10 +792,11 @@ class QubesLocal(QubesBase):
     Used when running in dom0.
     """
 
-    qubesd_connection_type = 'socket'
+    qubesd_connection_type = "socket"
 
-    def qubesd_call(self, dest, method, arg=None, payload=None,
-                    payload_stream=None):
+    def qubesd_call(
+        self, dest, method, arg=None, payload=None, payload_stream=None
+    ):
         """
         Execute Admin API method.
 
@@ -755,16 +818,24 @@ class QubesLocal(QubesBase):
             # service implementation, which may use some optimization there (
             # see admin.vm.volume.Import - actual data handling is done with dd)
             method_path = os.path.join(
-                qubesadmin.config.QREXEC_SERVICES_DIR, method)
+                qubesadmin.config.QREXEC_SERVICES_DIR, method
+            )
             if not os.path.exists(method_path):
                 raise qubesadmin.exc.QubesDaemonCommunicationError(
-                    '{} not found'.format(method_path))
-            command = ['env', 'QREXEC_REMOTE_DOMAIN=dom0',
-                       'QREXEC_REQUESTED_TARGET=' + dest, method_path, arg]
+                    "{} not found".format(method_path)
+                )
+            command = [
+                "env",
+                "QREXEC_REMOTE_DOMAIN=dom0",
+                "QREXEC_REQUESTED_TARGET=" + dest,
+                method_path,
+                arg,
+            ]
             if os.getuid() != 0:
-                command.insert(0, 'sudo')
+                command.insert(0, "sudo")
             (_, stdout, _) = self._call_with_stream(
-                command, payload, payload_stream)
+                command, payload, payload_stream
+            )
             return self._parse_qubesd_response(stdout)
 
         try:
@@ -772,21 +843,32 @@ class QubesLocal(QubesBase):
             client_socket.connect(qubesadmin.config.QUBESD_SOCKET)
         except (IOError, OSError) as e:
             raise qubesadmin.exc.QubesDaemonCommunicationError(
-                'Failed to connect to qubesd service: %s', str(e))
+                "Failed to connect to qubesd service: %s", str(e)
+            )
 
-        call_header = '{}+{} dom0 name {}\0'.format(method, arg or '', dest)
-        client_socket.sendall(call_header.encode('ascii'))
+        call_header = "{}+{} dom0 name {}\0".format(method, arg or "", dest)
+        client_socket.sendall(call_header.encode("ascii"))
         if payload is not None:
             client_socket.sendall(payload)
 
         client_socket.shutdown(socket.SHUT_WR)
 
-        return_data = client_socket.makefile('rb').read()
+        return_data = client_socket.makefile("rb").read()
         client_socket.close()
         return self._parse_qubesd_response(return_data)
 
-    def run_service(self, dest, service, user=None, *, filter_esc=False,
-                    localcmd=None, wait=True, autostart=True, **kwargs):
+    def run_service(
+        self,
+        dest,
+        service,
+        user=None,
+        *,
+        filter_esc=False,
+        localcmd=None,
+        wait=True,
+        autostart=True,
+        **kwargs,
+    ):
         """Run qrexec service in a given destination
 
         :param str dest: Destination - may be a VM name or empty
@@ -801,65 +883,69 @@ class QubesLocal(QubesBase):
         """
 
         if not dest:
-            raise ValueError('Empty destination name allowed only from a VM')
+            raise ValueError("Empty destination name allowed only from a VM")
         if not wait and localcmd:
-            raise ValueError('wait=False incompatible with localcmd')
+            raise ValueError("wait=False incompatible with localcmd")
         if autostart:
             try:
-                self.qubesd_call(dest, 'admin.vm.Start')
+                self.qubesd_call(dest, "admin.vm.Start")
             except qubesadmin.exc.QubesVMNotHaltedError:
                 pass
         elif not self.domains.get_blind(dest).is_running():
             raise qubesadmin.exc.QubesVMNotRunningError(
-                '%s is not running', dest)
+                "%s is not running", dest
+            )
         # pylint: disable=consider-using-with
-        if dest == 'dom0':
+        if dest == "dom0":
             # can't make real dom0->dom0 call
             if filter_esc:
                 raise NotImplementedError(
-                    'filter_esc=True not implemented in dom0->dom0 calls')
+                    "filter_esc=True not implemented in dom0->dom0 calls"
+                )
             if localcmd:
                 raise NotImplementedError(
-                    'localcmd not implemented in dom0->dom0 calls')
+                    "localcmd not implemented in dom0->dom0 calls"
+                )
             if not wait:
                 raise NotImplementedError(
-                    'wait=False not implemented in dom0->dom0 calls')
+                    "wait=False not implemented in dom0->dom0 calls"
+                )
             if user is None:
-                user = grp.getgrnam('qubes').gr_mem[0]
+                user = grp.getgrnam("qubes").gr_mem[0]
 
-            kwargs.setdefault('stdin', subprocess.PIPE)
-            kwargs.setdefault('stdout', subprocess.PIPE)
-            kwargs.setdefault('stderr', subprocess.PIPE)
+            kwargs.setdefault("stdin", subprocess.PIPE)
+            kwargs.setdefault("stdout", subprocess.PIPE)
+            kwargs.setdefault("stderr", subprocess.PIPE)
             # Set default locale to C in order to prevent error msg
             # in subprocess call related to falling back to C locale
             env = os.environ.copy()
-            env['LC_ALL'] = 'C'
-            cmd = '/etc/qubes-rpc/' + service
-            arg = ''
-            if not os.path.exists(cmd) and '+' in service:
-                cmd, arg = cmd.split('+', 1)
+            env["LC_ALL"] = "C"
+            cmd = "/etc/qubes-rpc/" + service
+            arg = ""
+            if not os.path.exists(cmd) and "+" in service:
+                cmd, arg = cmd.split("+", 1)
             p = subprocess.Popen(
-                ['sudo', '-u', user, cmd, arg],
+                ["sudo", "-u", user, cmd, arg],
                 **kwargs,
                 env=env,
             )
             return p
-        qrexec_opts = ['-d', dest]
+        qrexec_opts = ["-d", dest]
         if filter_esc:
-            qrexec_opts.extend(['-t'])
+            qrexec_opts.extend(["-t"])
         if filter_esc or os.isatty(sys.stderr.fileno()):
-            qrexec_opts.extend(['-T'])
+            qrexec_opts.extend(["-T"])
         if localcmd:
-            qrexec_opts.extend(['-l', localcmd])
+            qrexec_opts.extend(["-l", localcmd])
         if user is None:
-            user = 'DEFAULT'
+            user = "DEFAULT"
         if not wait:
-            qrexec_opts.extend(['-e'])
-        if 'connect_timeout' in kwargs:
-            qrexec_opts.extend(['-w', str(kwargs.pop('connect_timeout'))])
-        kwargs.setdefault('stdin', subprocess.PIPE)
-        kwargs.setdefault('stdout', subprocess.PIPE)
-        kwargs.setdefault('stderr', subprocess.PIPE)
+            qrexec_opts.extend(["-e"])
+        if "connect_timeout" in kwargs:
+            qrexec_opts.extend(["-w", str(kwargs.pop("connect_timeout"))])
+        kwargs.setdefault("stdin", subprocess.PIPE)
+        kwargs.setdefault("stdout", subprocess.PIPE)
+        kwargs.setdefault("stderr", subprocess.PIPE)
         proc = subprocess.Popen(
             [qubesadmin.config.QREXEC_CLIENT]
             + qrexec_opts
@@ -879,10 +965,11 @@ class QubesRemote(QubesBase):
     Used when running in VM.
     """
 
-    qubesd_connection_type = 'qrexec'
+    qubesd_connection_type = "qrexec"
 
-    def qubesd_call(self, dest, method, arg=None, payload=None,
-                    payload_stream=None):
+    def qubesd_call(
+        self, dest, method, arg=None, payload=None, payload_stream=None
+    ):
         """
         Execute Admin API method.
 
@@ -900,26 +987,39 @@ class QubesRemote(QubesBase):
         """
         service_name = method
         if arg is not None:
-            service_name += '+' + arg
-        command = [qubesadmin.config.QREXEC_CLIENT_VM,
-                   dest, service_name]
+            service_name += "+" + arg
+        command = [qubesadmin.config.QREXEC_CLIENT_VM, dest, service_name]
         if payload_stream:
             (p, stdout, stderr) = self._call_with_stream(
-                command, payload, payload_stream)
+                command, payload, payload_stream
+            )
         else:
-            with subprocess.Popen(command,
-                                  stdin=subprocess.PIPE,
-                                  stdout=subprocess.PIPE,
-                                  stderr=subprocess.PIPE) as p:
+            with subprocess.Popen(
+                command,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            ) as p:
                 (stdout, stderr) = p.communicate(payload)
         if p.returncode != 0:
             raise qubesadmin.exc.QubesDaemonAccessError(
-                'Service call error: %s', stderr.decode())
+                "Service call error: %s", stderr.decode()
+            )
 
         return self._parse_qubesd_response(stdout)
 
-    def run_service(self, dest, service, user=None, *, filter_esc=False,
-                    localcmd=None, wait=True, autostart=True, **kwargs):
+    def run_service(
+        self,
+        dest,
+        service,
+        user=None,
+        *,
+        filter_esc=False,
+        localcmd=None,
+        wait=True,
+        autostart=True,
+        **kwargs,
+    ):
         """Run qrexec service in a given destination
 
         :param str dest: Destination - may be a VM name or empty
@@ -934,21 +1034,23 @@ class QubesRemote(QubesBase):
         """
         if not autostart and not dest:
             raise ValueError(
-                'autostart=False makes sense only with a defined target')
+                "autostart=False makes sense only with a defined target"
+            )
         if user:
-            raise ValueError(
-                'non-default user not possible for calls from VM')
+            raise ValueError("non-default user not possible for calls from VM")
         if not wait and localcmd:
-            raise ValueError('wait=False incompatible with localcmd')
+            raise ValueError("wait=False incompatible with localcmd")
         qrexec_opts = []
         if filter_esc:
-            qrexec_opts.extend(['-t'])
+            qrexec_opts.extend(["-t"])
         if filter_esc or (
-                os.isatty(sys.stderr.fileno()) and 'stderr' not in kwargs):
-            qrexec_opts.extend(['-T'])
+            os.isatty(sys.stderr.fileno()) and "stderr" not in kwargs
+        ):
+            qrexec_opts.extend(["-T"])
         if not autostart and not self.domains.get_blind(dest).is_running():
             raise qubesadmin.exc.QubesVMNotRunningError(
-                '%s is not running', dest)
+                "%s is not running", dest
+            )
         if not wait:
             # qrexec-client-vm can only request service calls, which are
             # started using MSG_EXEC_CMDLINE qrexec protocol message; this
@@ -958,15 +1060,17 @@ class QubesRemote(QubesBase):
             # MSG_DATA_EXIT_CODE, so implementing wait=False would require
             # some protocol change (or protocol violation).
             raise NotImplementedError(
-                'wait=False not implemented for calls from VM')
-        kwargs.setdefault('stdin', subprocess.PIPE)
-        kwargs.setdefault('stdout', subprocess.PIPE)
-        kwargs.setdefault('stderr', subprocess.PIPE)
+                "wait=False not implemented for calls from VM"
+            )
+        kwargs.setdefault("stdin", subprocess.PIPE)
+        kwargs.setdefault("stdout", subprocess.PIPE)
+        kwargs.setdefault("stderr", subprocess.PIPE)
         # pylint: disable=consider-using-with
         proc = subprocess.Popen(
-            [qubesadmin.config.QREXEC_CLIENT_VM] +
-            qrexec_opts +
-            [dest or '', service] +
-            (shlex.split(localcmd) if localcmd else []),
-            **kwargs)
+            [qubesadmin.config.QREXEC_CLIENT_VM]
+            + qrexec_opts
+            + [dest or "", service]
+            + (shlex.split(localcmd) if localcmd else []),
+            **kwargs,
+        )
         return proc

--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -500,6 +500,11 @@ class QubesBase(qubesadmin.base.PropertyHolder):
                         raise
 
             for feature, value in src_vm.features.items():
+                if (
+                    feature.startswith("preload-dispvm")
+                    and feature != "preload-dispvm-max"
+                ):
+                    continue
                 try:
                     dst_vm.features[feature] = value
                 except qubesadmin.exc.QubesException as e:


### PR DESCRIPTION
For: https://github.com/QubesOS/qubes-issues/issues/1512

---

One thing that I am not happy about is how many times I had to write _preloaded disposables_, _disposable to preload_, mostly because it lacks synonyms and if I start using synonyms, it might cause conflicts or confusion in the future. See the [glossary](https://www.qubes-os.org/doc/glossary/), especially the _previously known as_ lines.