### PR TITLE
Allow S3 suspend via `qvm-pause --suspend`

### DIFF
--- a/doc/manpages/qvm-pause.rst
+++ b/doc/manpages/qvm-pause.rst
@@ -6,7 +6,7 @@
 Synopsis
 --------
 
-:command:`qvm-pause` [-h] [--verbose] [--quiet] *VMNAME*
+:command:`qvm-pause` [-h] [--all] [--exclude EXCLUDE] [--verbose] [--quiet] [--suspend] [*VMNAME* ...]
 
 Options
 -------
@@ -30,6 +30,10 @@ Options
 .. option:: --exclude=EXCLUDE
 
    Exclude the qube from :option:`--all`.
+
+.. option:: --suspend, -S
+
+   Put the qube to (S3) suspend mode instead of emergency pause
 
 .. option:: --version
 

--- a/qubesadmin/tests/tools/qvm_pause.py
+++ b/qubesadmin/tests/tools/qvm_pause.py
@@ -83,3 +83,12 @@ class TC_00_qvm_pause(qubesadmin.tests.QubesTestCase):
                 app=self.app),
             0)
         self.assertAllCalled()
+
+    def test_005_suspend_vm(self):
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.List', None, None)] = \
+            b'0\x00some-vm class=AppVM state=Running\n'
+        self.app.expected_calls[
+            ('some-vm', 'admin.vm.Suspend', None, None)] = b'0\x00'
+        qubesadmin.tools.qvm_pause.main(['some-vm', '--suspend'], app=self.app)
+        self.assertAllCalled()

--- a/qubesadmin/tests/tools/qvm_unpause.py
+++ b/qubesadmin/tests/tools/qvm_unpause.py
@@ -30,6 +30,9 @@ class TC_00_qvm_unpause(qubesadmin.tests.QubesTestCase):
             ('dom0', 'admin.vm.List', None, None)] = \
             b'0\x00some-vm class=AppVM state=Running\n'
         self.app.expected_calls[
+            ('some-vm', 'admin.vm.CurrentState', None, None)] = \
+            b'0\x00power_state=Running\n'
+        self.app.expected_calls[
             ('some-vm', 'admin.vm.Unpause', None, None)] = b'0\x00'
         qubesadmin.tools.qvm_unpause.main(['some-vm'], app=self.app)
         self.assertAllCalled()
@@ -61,6 +64,9 @@ class TC_00_qvm_unpause(qubesadmin.tests.QubesTestCase):
         self.app.expected_calls[
             ('dom0', 'admin.vm.List', None, None)] = \
             b'0\x00some-vm class=AppVM state=Halted\n'
+        self.app.expected_calls[
+            ('some-vm', 'admin.vm.CurrentState', None, None)] = \
+            b'0\x00power_state=Halted\n'
         self.assertEqual(
             qubesadmin.tools.qvm_unpause.main(['some-vm'], app=self.app),
             1)
@@ -74,6 +80,12 @@ class TC_00_qvm_unpause(qubesadmin.tests.QubesTestCase):
             ('other-vm', 'admin.vm.Unpause', None, None)] = \
             b'0\x00'
         self.app.expected_calls[
+            ('some-vm', 'admin.vm.CurrentState', None, None)] = \
+            b'0\x00power_state=Running\n'
+        self.app.expected_calls[
+            ('other-vm', 'admin.vm.CurrentState', None, None)] = \
+            b'0\x00power_state=Running\n'
+        self.app.expected_calls[
             ('dom0', 'admin.vm.List', None, None)] = \
             b'0\x00some-vm class=AppVM state=Running\n' \
             b'other-vm class=AppVM state=Running\n'
@@ -81,4 +93,16 @@ class TC_00_qvm_unpause(qubesadmin.tests.QubesTestCase):
             qubesadmin.tools.qvm_unpause.main(['some-vm', 'other-vm'],
                 app=self.app),
             0)
+        self.assertAllCalled()
+
+    def test_005_resume_vm(self):
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.List', None, None)] = \
+            b'0\x00some-vm class=AppVM state=Suspended\n'
+        self.app.expected_calls[
+            ('some-vm', 'admin.vm.CurrentState', None, None)] = \
+            b'0\x00power_state=Suspended\n'
+        self.app.expected_calls[
+            ('some-vm', 'admin.vm.Resume', None, None)] = b'0\x00'
+        qubesadmin.tools.qvm_unpause.main(['some-vm'], app=self.app)
         self.assertAllCalled()

--- a/qubesadmin/tests/vm/actions.py
+++ b/qubesadmin/tests/vm/actions.py
@@ -20,8 +20,6 @@
 
 # pylint: disable=missing-docstring
 
-import unittest
-
 import qubesadmin.tests.vm
 
 
@@ -61,7 +59,6 @@ class TC_00_Actions(qubesadmin.tests.vm.VMTestCase):
         self.vm.unpause()
         self.assertAllCalled()
 
-    @unittest.skip('Not part of the mgmt API yet')
     def test_005_suspend(self):
         self.app.expected_calls[
             ('test-vm', 'admin.vm.Suspend', None, None)] = \
@@ -69,7 +66,6 @@ class TC_00_Actions(qubesadmin.tests.vm.VMTestCase):
         self.vm.suspend()
         self.assertAllCalled()
 
-    @unittest.skip('Not part of the mgmt API yet')
     def test_006_resume(self):
         self.app.expected_calls[
             ('test-vm', 'admin.vm.Resume', None, None)] = \

--- a/qubesadmin/tests/vm/properties.py
+++ b/qubesadmin/tests/vm/properties.py
@@ -258,6 +258,7 @@ class TC_01_SpecialCases(qubesadmin.tests.vm.VMTestCase):
         self.assertTrue(self.vm.is_running())
         self.assertFalse(self.vm.is_halted())
         self.assertFalse(self.vm.is_paused())
+        self.assertFalse(self.vm.is_suspended())
 
     def test_011_power_state_paused(self):
         self.app.expected_calls[
@@ -267,6 +268,7 @@ class TC_01_SpecialCases(qubesadmin.tests.vm.VMTestCase):
         self.assertTrue(self.vm.is_running())
         self.assertFalse(self.vm.is_halted())
         self.assertTrue(self.vm.is_paused())
+        self.assertFalse(self.vm.is_suspended())
 
     def test_012_power_state_halted(self):
         self.app.expected_calls[
@@ -276,6 +278,7 @@ class TC_01_SpecialCases(qubesadmin.tests.vm.VMTestCase):
         self.assertFalse(self.vm.is_running())
         self.assertTrue(self.vm.is_halted())
         self.assertFalse(self.vm.is_paused())
+        self.assertFalse(self.vm.is_suspended())
 
     def test_012_power_state_transient(self):
         self.app.expected_calls[
@@ -285,6 +288,17 @@ class TC_01_SpecialCases(qubesadmin.tests.vm.VMTestCase):
         self.assertTrue(self.vm.is_running())
         self.assertFalse(self.vm.is_halted())
         self.assertFalse(self.vm.is_paused())
+        self.assertFalse(self.vm.is_suspended())
+
+    def test_013_power_state_suspended(self):
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.CurrentState', None, None)] = \
+            b'0\x00power_state=Suspended'
+        self.assertEqual(self.vm.get_power_state(), 'Suspended')
+        self.assertTrue(self.vm.is_running())
+        self.assertFalse(self.vm.is_halted())
+        self.assertFalse(self.vm.is_paused())
+        self.assertTrue(self.vm.is_suspended())
 
     def test_015_mem(self):
         self.app.expected_calls[

--- a/qubesadmin/tools/qvm_pause.py
+++ b/qubesadmin/tools/qvm_pause.py
@@ -28,6 +28,13 @@ parser = qubesadmin.tools.QubesArgumentParser(vmname_nargs='+',
     description='pause a qube',
     epilog='Paused qubes will be killed on system shutdown.')
 
+parser.add_argument(
+    "--suspend",
+    "-S",
+    action="store_true",
+    help="Put the qube to (S3) suspend mode instead of emergency pause",
+)
+
 
 def main(args=None, app=None):
     '''Main routine of :program:`qvm-pause`.
@@ -40,7 +47,10 @@ def main(args=None, app=None):
     exit_code = 0
     for domain in args.domains:
         try:
-            domain.pause()
+            if args.suspend:
+                domain.suspend()
+            else:
+                domain.pause()
         except (IOError, OSError, qubesadmin.exc.QubesException) as e:
             exit_code = 1
             parser.print_error(str(e))

--- a/qubesadmin/tools/qvm_unpause.py
+++ b/qubesadmin/tools/qvm_unpause.py
@@ -40,7 +40,10 @@ def main(args=None, app=None):
     exit_code = 0
     for domain in args.domains:
         try:
-            domain.unpause()
+            if domain.is_suspended():
+                domain.resume()
+            else:
+                domain.unpause()
         except (IOError, OSError, qubesadmin.exc.QubesException) as e:
             exit_code = 1
             parser.print_error(str(e))

--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -150,6 +150,26 @@ class QubesVM(qubesadmin.base.PropertyHolder):
         '''
         self.qubesd_call(self._method_dest, 'admin.vm.Unpause')
 
+    def suspend(self):
+        '''
+        Suspend domain.
+
+        Suspend domain (S3). Pauses it if it does not suspend.
+
+        :return:
+        '''
+        self.qubesd_call(self._method_dest, 'admin.vm.Suspend')
+
+    def resume(self):
+        '''
+        Resume domain (from S3).
+
+        Opposite to :py:meth:`suspend`.
+
+        :return:
+        '''
+        self.qubesd_call(self._method_dest, 'admin.vm.Resume')
+
     def get_power_state(self):
         '''Return power state description string.
 
@@ -223,6 +243,16 @@ class QubesVM(qubesadmin.base.PropertyHolder):
         '''
 
         return self.get_power_state() == 'Paused'
+
+    def is_suspended(self):
+        '''Check whether this domain is suspended.
+
+        :returns: :py:obj:`True` if this domain is suspended, \
+            :py:obj:`False` otherwise.
+        :rtype: bool
+        '''
+
+        return self.get_power_state() == 'Suspended'
 
     def is_running(self):
         '''Check whether this domain is running.


### PR DESCRIPTION
The PR uses `admin.vm.Suspend` & `admin.vm.Resume` API calls to allow S3 suspend/resume via `qvm-pause --suspend` (as well as via `qubesadmin.vm.Suspend` & `qubesadmin.vm.Resume` interfaces)

requires: https://github.com/QubesOS/qubes-core-admin/pull/679
related: https://github.com/QubesOS/qubes-issues/issues/9918