### PR TITLE
Document `expert-mode`

### DIFF
--- a/doc/manpages/qvm-features.rst
+++ b/doc/manpages/qvm-features.rst
@@ -434,6 +434,13 @@ The entry value can be prefixed by settings to pre-create the resource in
 settings, the feature value must respect the following format:
 ``<file|dir>:<owner>:<group>:<mode>:<absolute path>``.
 
+expert-mode
+^^^^^^^^^^^
+Allows expert mode for specific domain(s) or the entire system if it is enabled
+for the GUIVM (dom0 by default). At the time of writing this documentation, the
+only recognized feature is the `Debug Console` in Qui Domains systray widget.
+
+
 End user specific features
 --------------------------
 


### PR DESCRIPTION
`expert-mode` feature was added to enable Debug Console for Qui Domains systray widget. However, since it might be reused for other purposes, let users know that it might have other uses.

related: https://github.com/QubesOS/qubes-issues/issues/9788