### PR TITLE
Improve `qvm-backup-restore --paranoid-mode`

### DIFF
--- a/doc/manpages/qvm-backup-restore.rst
+++ b/doc/manpages/qvm-backup-restore.rst
@@ -101,6 +101,8 @@ Options
     - dom0 home directory (desktop environment settings)
     - PCI devices assignments
 
+  This operation requires `qubes-core-admin-client` package in the DisposableVM
+
 .. option:: --auto-close
 
   When running with --paranoid-mode (see above), automatically close restore

--- a/qubesadmin/backup/dispvm.py
+++ b/qubesadmin/backup/dispvm.py
@@ -276,10 +276,27 @@ class RestoreInDisposableVM:
         lock = qubesadmin.utils.LockFile(LOCKFILE, True)
         lock.acquire()
         try:
+            self.app.log.info("Starting restore process in a DisposableVM...")
             self.create_dispvm()
             self.clear_old_tags()
             self.register_backup_source()
             self.dispvm.start()
+            try:
+                self.app.log.debug(
+                    "Checking for existence of qubes-core-admin-client"
+                )
+                self.dispvm.run("command -v qvm-backup-restore")
+            except subprocess.CalledProcessError:
+                raise qubesadmin.exc.QubesException(
+                    'qvm-backup-restore tool '
+                    'missing in {} template, install qubes-core-admin-client '
+                    'package there'.format(
+                        getattr(self.dispvm.template,
+                                'template',
+                                self.dispvm.template).name)
+                )
+            self.app.log.info("When operation completes, close its window "
+                              "manually.")
             self.dispvm.run_service_for_stdio('qubes.WaitForSession')
             if self.args.pass_file:
                 self.args.pass_file = self.transfer_pass_file(

--- a/qubesadmin/tools/qvm_backup_restore.py
+++ b/qubesadmin/tools/qvm_backup_restore.py
@@ -240,9 +240,6 @@ def main(args=None, app=None):
 
     if args.paranoid_mode:
         args.dom0_home = False
-        args.app.log.info("Starting restore process in a DisposableVM...")
-        args.app.log.info("When operation completes, close its window "
-                          "manually.")
         restore_in_dispvm = RestoreInDisposableVM(args.app, args)
         try:
             backup_log = restore_in_dispvm.run()


### PR DESCRIPTION
Before openning a Shell window in the DispVM, check for availability of `core-admin-client` in the DisposableVM and show error message if not available

resolves: https://github.com/QubesOS/qubes-issues/issues/9962