### PR TITLE
qvm_ls.py : add template tree mode

### DIFF
--- a/qubesadmin/tools/qvm_ls.py
+++ b/qubesadmin/tools/qvm_ls.py
@@ -485,7 +485,8 @@ class Table(object):
                     domains.remove(dom)
                 except ValueError:
                     pass
-            if len(domains) >= last_len: raise Exception("Fuck You")
+            if len(domains) >= last_len:
+                raise Exception("sort_to_ttree: While loop is stuck!")
             level += 1
 
         return tree


### PR DESCRIPTION
Add template tree mode (`-T`), because I like it.

Almost exactly as network tree, but returns tree of templates, i.e.:
```
NAME                             STATE    CLASS         LABEL   TEMPLATE                 NETVM
sys-tmpl                         Halted   TemplateVM    black   -                        -
└─sys-net                        Running  AppVM         red     sys-tmpl                 -
└─sys-dvm                        Halted   AppVM         red     sys-tmpl                 sys-firewall
  └─sys-usb                      Running  DispVM        red     sys-dvm                  -
  └─sys-firewall                 Running  DispVM        green   sys-dvm                  sys-net
```

This is by no means complete, I pretty much just crammed my code the same way `sort_to_tree` is integrated into the program. What would be a good, logical, maintainable way to add this?

Another unsolved part is UX. What flag should be used for this? Or maybe something similar to `--format FORMAT` would be better?

Also sorry for pr'ing to `release4.2`, I don't have dev setup, so no testing with `main` or `release4.3` can be done by me. (Unless there is a way to somehow install these packages over 4.2 stuff without breaking anything?)

Also, I've noticed that `sort_to_tree` says that it returns a list of sets, which isn't true, it returns a list of tuples.