### PR TITLE
qvm_ls.py : add template tree mode

### DIFF
--- a/qubesadmin/tools/qvm_ls.py
+++ b/qubesadmin/tools/qvm_ls.py
@@ -404,14 +404,15 @@ class Table(object):
     :param list colnames: Names of the columns (need not to be uppercase).
     '''
     def __init__(self, domains, colnames, spinner, *, raw_data=False,
-                tree_sorted=False, sort_order='NAME', reverse_sort=False,
-                ignore_case=False):
+                tree_sorted=False, ttree_sorted=False, sort_order='NAME',
+                reverse_sort=False, ignore_case=False):
         self.domains = domains
         self.columns = tuple(Column.columns[col.upper().replace('_', '-')]
                 for col in colnames)
         self.spinner = spinner
         self.raw_data = raw_data
         self.tree_sorted = tree_sorted
+        self.ttree_sorted = ttree_sorted
         self.sort_order = sort_order
         self.reverse_sort = reverse_sort
         self.ignore_case = ignore_case
@@ -424,7 +425,7 @@ class Table(object):
         '''Get single table row data (all columns for one domain).'''
         ret = []
         for col in self.columns:
-            if self.tree_sorted and col.ls_head == 'NAME':
+            if (self.tree_sorted or self.ttree_sorted) and col.ls_head == 'NAME':
                 ret.append(col.cell(vm, insertion))
             else:
                 ret.append(col.cell(vm))
@@ -474,6 +475,43 @@ class Table(object):
 
         return tree
 
+    def sort_to_ttree(self, domains):
+        '''Sort domains as a template tree. It returns a list of tuples. Each
+        tuple stores the level of the tree and the vm object.
+
+        :param list() domains: The domains which will be sorted
+        :return list(tuple()) tree: returns a list of tuple(level, vm)
+        '''
+        tree=[]
+        for dom in sorted(domains):
+            try:
+                if not dom.template:
+                    tree.append((0,dom))
+                    domains.remove(dom)
+            except AttributeError:
+                tree.append((0,dom))
+                domains.remove(dom)
+
+        level = 0
+        while len(domains) > 0:
+            last_len = len(domains)
+            for dom in sorted(domains):
+                try:
+                    # Insert before (index of the template entry) + 1,
+                    # i.e. after parent. What if parent entry is the last entry?
+                    tree.insert(
+                        tree.index((level,dom.template))+1,
+                        (level+1,dom))
+                    domains.remove(dom)
+                # Pass if parent isn't in the tree yet
+                except ValueError:
+                    pass
+            if len(domains) >= last_len:
+                raise Exception("sort_to_ttree: While loop is stuck!")
+            level += 1
+
+        return tree
+
     def write_table(self, stream=sys.stdout):
         '''Sort & write whole table to file-like object.
 
@@ -498,6 +536,10 @@ class Table(object):
                 #FIXME: handle qubesadmin.exc.QubesVMNotFoundError
                 #       (see QubesOS/qubes-issues#5105)
                 insertion_vm_list = self.sort_to_tree(self.domains)
+                for insertion, vm in insertion_vm_list:
+                    table_data.append(self.get_row(vm, insertion))
+            elif self.ttree_sorted:
+                insertion_vm_list = self.sort_to_ttree(self.domains)
                 for insertion, vm in insertion_vm_list:
                     table_data.append(self.get_row(vm, insertion))
             else:
@@ -650,6 +692,10 @@ def get_parser():
     parser_format.add_argument('--tree', '-t',
         action='store_const', const='tree',
         help='sort domain list as network tree')
+
+    parser.add_argument('--ttree', '-T',
+        action='store_const', const='ttree',
+        help='sort domain list as template tree')
 
     parser_format.add_argument('--raw-data', action='store_true',
         help='Display specify data of specified VMs. Intended for '
@@ -906,7 +952,7 @@ def main(args=None, app=None):
                if matches_power_states(d, **pwrstates)]
 
     table = Table(domains=domains, colnames=columns, spinner=spinner,
-        raw_data=args.raw_data, tree_sorted=args.tree,
+        raw_data=args.raw_data, tree_sorted=args.tree, ttree_sorted=args.tree,
         sort_order=args.sort.upper(), reverse_sort=args.reverse,
         ignore_case=args.ignore_case)
     table.write_table(sys.stdout)


### PR DESCRIPTION
Add template tree mode (`-T`), because I like it.

Almost exactly as network tree, but returns tree of templates, i.e.:
```
NAME                             STATE    CLASS         LABEL   TEMPLATE                 NETVM
sys-tmpl                         Halted   TemplateVM    black   -                        -
└─sys-net                        Running  AppVM         red     sys-tmpl                 -
└─sys-dvm                        Halted   AppVM         red     sys-tmpl                 sys-firewall
  └─sys-usb                      Running  DispVM        red     sys-dvm                  -
  └─sys-firewall                 Running  DispVM        green   sys-dvm                  sys-net
```

This is by no means complete, I pretty much just crammed my code the same way `sort_to_tree` is integrated into the program.

### To do:
- [ ] Edit manual once we agree on UX

### Maybe do, if people want it:
- [ ] Choose a good exception for the while loop getting stuck / somehow get rid of the while loop
- [ ] Find a better way to integrate this functionality. Having multiple tree "modes" seems more logical than two separate tree-producing functions.
- [ ] UX: What flag should be used, and how? Again, maybe something similar to `--tree TYPE` is a better choice than `--tree` and `--ttree`?

### What I would personally like to do, but probably won't get there:
- [ ] Make better tree-drawing algorithm, this one isn't very comprehensible. Programs like `tree` do it better.

I don't have a dev setup, so no testing with `main` or `release4.3` can be done by me, but similar change to 4.2 version of `qvm_ls.py` works.
(Is there a way to somehow install these packages over 4.2 stuff without breaking anything?)

Also, I've noticed that `sort_to_tree` says that it returns a list of sets, which isn't true, it returns a list of tuples.