### PR TITLE
Fix starting audio daemon

### DIFF
--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -779,7 +779,12 @@ class DAEMONLauncher:
 
         :param vm: VM for which start AUDIO daemon
         """
-        pacat_cmd = [PACAT_DAEMON_PATH, "-l", self.pacat_domid(vm), vm.name]
+        pacat_cmd = [
+            PACAT_DAEMON_PATH,
+            "-l",
+            str(self.pacat_domid(vm)),
+            vm.name,
+        ]
         vm.log.info("Starting AUDIO")
 
         await asyncio.create_subprocess_exec(*pacat_cmd)


### PR DESCRIPTION
After https://github.com/QubesOS/qubes-core-admin/pull/689 the type of
the 'xid' property is preserved and it's int now. Fix pacat daemon
parameters to convert it back to string.