### PR TITLE
Support `pbzip2` compression filter

### DIFF
--- a/qubesadmin/backup/restore.py
+++ b/qubesadmin/backup/restore.py
@@ -66,7 +66,7 @@ DEFAULT_CRYPTO_ALGORITHM = 'aes-256-cbc'
 DEFAULT_HMAC_ALGORITHM = 'scrypt'
 DEFAULT_COMPRESSION_FILTER = 'gzip'
 KNOWN_COMPRESSION_FILTERS = ('gzip', 'bzip2', 'xz')
-OPTIONAL_COMPRESSION_FILTERS = ('lzma', 'pigz', 'zstd', 'zstdmt')
+OPTIONAL_COMPRESSION_FILTERS = ('lzma', 'pbzip2', 'pigz', 'zstd', 'zstdmt')
 # lazy loaded
 KNOWN_CRYPTO_ALGORITHMS = []
 # lazy loaded


### PR DESCRIPTION
Some users (e.g. @andrewdavidwong) use `bzip2` compression filter. Adding support for parallel implementation of bzip2 is relatively easy and should allow them to do their backup/restores much faster.

Reference: https://forum.qubes-os.org/t/qvm-backup-compression-filter-execution-time-and-output-size-comparison/19412/5