### PR TITLE
Fix outdated cache on domain restart to fix audio-vm connection for restarted VMs

### DIFF
--- a/qubesadmin/events/__init__.py
+++ b/qubesadmin/events/__init__.py
@@ -264,7 +264,7 @@ class EventsDispatcher(object):
         elif event in ('domain-pre-start', 'domain-start', 'domain-shutdown',
                        'domain-paused', 'domain-unpaused',
                        'domain-start-failed'):
-            self.app._update_power_state_cache(subject, event, **kwargs)
+            self.app.domains.clear_cache(invalidate_name=subject)
         elif event == 'connection-established':
             # on (re)connection, clear cache completely - we don't have
             # guarantee about not missing any events before this point


### PR DESCRIPTION
The AudioVM connection for restarted Qubes was broken after the domain started. After some debugging, I found that the XID was not properly updated in the cache. As a result, the AudioVM daemon attempted to connect to the restarted Qube using the outdated XID.

I'm not certain if this is the appropriate place to address the issue, but clearing the cache resolves the problem.

Please let me know if there's a better way or place to handle this, and I’ll be happy to update the PR accordingly.