### PR TITLE
debian: add hwdata to dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -41,6 +41,7 @@ Description: Qubes administrative tools
 Package: python3-qubesadmin
 Architecture: any
 Depends:
+ hwdata,
  python3-docutils,
  python3-lxml,
  python3-qubesdb,


### PR DESCRIPTION
It's used for device classification.

QubesOS/qubes-issues#8841