### PR TITLE
Skip restoration of undesirable preload feature

### DIFF
--- a/qubesadmin/backup/restore.py
+++ b/qubesadmin/backup/restore.py
@@ -2103,6 +2103,11 @@ class BackupRestore(object):
                 self._restore_property(new_vm, prop, value)
 
             for feature, value in vm.features.items():
+                if (
+                    feature.startswith('preload-dispvm')
+                    and feature != 'preload-dispvm-max'
+                ):
+                    continue
                 try:
                     new_vm.features[feature] = value
                 except Exception as err:  # pylint: disable=broad-except


### PR DESCRIPTION
For: https://github.com/QubesOS/qubes-issues/issues/1512

---

Untested and might be superseded by:

- https://github.com/QubesOS/qubes-core-admin/pull/720

Is there a reason for the restore utility to enforce this seeing the PR above? I can't find one, closing.