### PR TITLE
Initialize asyncio event loop before using it

### DIFF
--- a/qubesadmin/tools/qvm_backup.py
+++ b/qubesadmin/tools/qvm_backup.py
@@ -205,7 +205,8 @@ def main(args=None, app=None):
         with open(profile_path, 'w', encoding='utf-8') as f_profile:
             write_backup_profile(f_profile, args, passphrase)
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     if have_events:
         # pylint: disable=no-member
         events_dispatcher = qubesadmin.events.EventsDispatcher(args.app)

--- a/qubesadmin/tools/qvm_shutdown.py
+++ b/qubesadmin/tools/qvm_shutdown.py
@@ -75,7 +75,8 @@ def main(args=None, app=None):  # pylint: disable=missing-docstring
     force = args.force or bool(args.all_domains)
 
     if have_events:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
     remaining_domains = args.domains
     for _ in range(len(args.domains)):
         this_round_domains = set(remaining_domains)

--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -1138,7 +1138,8 @@ def main():
             print(os.getpid(), file=lock_f)
             lock_f.flush()
             lock_f.truncate()
-            loop = asyncio.get_event_loop()
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
             # pylint: disable=no-member
             events = qubesadmin.events.EventsDispatcher(args.app)
             # pylint: enable=no-member
@@ -1183,7 +1184,8 @@ def main():
         except (FileNotFoundError, ValueError) as e:
             parser.error(f"Cannot open pidfile {pidfile_path}: {str(e)}")
     else:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
         tasks = []
         for vm in args.domains:
             if vm.is_running():

--- a/qubesadmin/tools/qvm_template_postprocess.py
+++ b/qubesadmin/tools/qvm_template_postprocess.py
@@ -454,7 +454,8 @@ def main(args=None, app=None):
     if not args.really:
         parser.error('Do not call this tool directly.')
     if args.action == 'post-install':
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
         try:
             loop.run_until_complete(post_install(args))
             loop.stop()


### PR DESCRIPTION
Python 3.14 (in Fedora 43) throws RunetimeError if event loop is not initialized before using it.

Resolves: https://github.com/QubesOS/qubes-issues/issues/10188