### PR TITLE
Assure `multiprocess` start method is `fork`

### DIFF
--- a/qubesadmin/backup/restore.py
+++ b/qubesadmin/backup/restore.py
@@ -55,6 +55,10 @@ from qubesadmin.exc import QubesException
 from qubesadmin.utils import size_to_human
 
 
+# Python 3.14 in Fedora 43 changes the default start method away from fork
+if multiprocessing.get_start_method(allow_none=True) != "fork":
+    multiprocessing.set_start_method("fork")
+
 # must be picklable
 QUEUE_FINISHED = "!!!FINISHED"
 QUEUE_ERROR = "!!!ERROR"


### PR DESCRIPTION
Python 3.14 in Fedora 43 changes the default start method for multiprocessing away from fork. We set it back to `fork`.

resolves: https://github.com/QubesOS/qubes-issues/issues/10225