### PR TITLE
Minor typo fixes in output when restoring a backup

### DIFF
--- a/qubesadmin/tests/tools/qvm_backup_restore.py
+++ b/qubesadmin/tests/tools/qvm_backup_restore.py
@@ -117,7 +117,7 @@ class TC_00_qvm_backup_restore(qubesadmin.tests.QubesTestCase):
             mock.call.info(
                 'The above VMs will be copied and added to your system.'),
             mock.call.info(
-                'Exisiting VMs will NOT be removed.'),
+                'Existing VMs will NOT be removed.'),
         ])
 
     def assertAppropriateLogging(self, missing_name, action):

--- a/qubesadmin/tools/qvm_backup_restore.py
+++ b/qubesadmin/tools/qvm_backup_restore.py
@@ -156,7 +156,7 @@ def handle_broken(app, args, restore_info):
         app.log.info("Existing VMs will NOT be removed or altered.")
     else:
         app.log.info("The above VMs will be copied and added to your system.")
-        app.log.info("existing VMs will NOT be removed.")
+        app.log.info("Existing VMs will NOT be removed.")
 
     if there_are_missing_templates:
         app.log.warning("*** One or more TemplateVMs are missing on the "

--- a/qubesadmin/tools/qvm_backup_restore.py
+++ b/qubesadmin/tools/qvm_backup_restore.py
@@ -156,7 +156,7 @@ def handle_broken(app, args, restore_info):
         app.log.info("Existing VMs will NOT be removed or altered.")
     else:
         app.log.info("The above VMs will be copied and added to your system.")
-        app.log.info("Exisiting VMs will NOT be removed.")
+        app.log.info("existing VMs will NOT be removed.")
 
     if there_are_missing_templates:
         app.log.warning("*** One or more TemplateVMs are missing on the "


### PR DESCRIPTION
I ran into a typo while using `qvm-backup-restore`, `Exisiting` --> `Existing`

---

This typo also appears in a few other files:
https://github.com/search?q=org%3AQubesOS%20Exisiting&type=code

- [QubesOS/qubes-gui-agent-linux](https://github.com/QubesOS/qubes-gui-agent-linux)
  -  [pulse/pulsecore-0.9.21/aupdate.h](https://github.com/QubesOS/qubes-gui-agent-linux/blob/b1c52ac515556e3bb02c712d60d7105d5b98b994/pulse/pulsecore-0.9.21/aupdate.h#L50)
  - [pulse/pulsecore-0.9.22/aupdate.h](https://github.com/QubesOS/qubes-gui-agent-linux/blob/b1c52ac515556e3bb02c712d60d7105d5b98b994/pulse/pulsecore-0.9.22/aupdate.h#L50)
  - [pulse/pulsecore-0.9.23/aupdate.h](https://github.com/QubesOS/qubes-gui-agent-linux/blob/b1c52ac515556e3bb02c712d60d7105d5b98b994/pulse/pulsecore-0.9.23/aupdate.h#L50)
- [QubesOS/qubes-posts](https://github.com/QubesOS/qubes-posts)
  - [2017-04-26-qubes-compromise-recovery.md](https://github.com/QubesOS/qubes-posts/blob/05a8a728187978bf2d4a4e515f448f4180fef695/2017-04-26-qubes-compromise-recovery.md?plain=1#L286)

But I wasn't sure if these should be edited, or not.