### PR TITLE
Exclude preloaded disposables from `qvm-run --all`

### DIFF
--- a/qubesadmin/tests/tools/qvm_run.py
+++ b/qubesadmin/tests/tools/qvm_run.py
@@ -183,7 +183,15 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             b"0\x00test-vm class=AppVM state=Running\n"
             b"test-vm2 class=AppVM state=Running\n"
             b"test-vm3 class=AppVM state=Halted\n"
+            b"disp007 class=DispVM state=Paused\n"
         )
+        for vm in ["test-vm", "test-vm2"]:
+            self.app.expected_calls[
+                (vm, "admin.vm.feature.Get", "internal", None)
+            ] = b"2\x00QubesFeatureNotFoundError\x00\x00Feature not set\x00"
+        self.app.expected_calls[
+            ("disp007", "admin.vm.feature.Get", "internal", None)
+        ] = b"0\x001x00"
         self.app.expected_calls[
             ("test-vm", "admin.vm.CurrentState", None, None)
         ] = b"0\x00power_state=Running"
@@ -193,6 +201,9 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
         self.app.expected_calls[
             ("test-vm3", "admin.vm.CurrentState", None, None)
         ] = b"0\x00power_state=Halted"
+        self.app.expected_calls[
+            ("disp007", "admin.vm.CurrentState", None, None)
+        ] = b"0\x00power_state=Paused"
         self.app.expected_calls[
             ("test-vm", "admin.vm.feature.CheckWithTemplate", "os", None)
         ] = b"2\x00QubesFeatureNotFoundError\x00\x00Feature 'os' not set\x00"
@@ -787,13 +798,23 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             b"0\x00test-vm class=AppVM state=Running\n"
             b"test-vm2 class=AppVM state=Running\n"
             b"test-vm3 class=AppVM state=Halted\n"
+            b"disp007 class=DispVM state=Paused\n"
         )
+        self.app.expected_calls[
+            ("test-vm", "admin.vm.feature.Get", "internal", None)
+        ] = b"2\x00QubesFeatureNotFoundError\x00\x00Feature not set\x00"
+        self.app.expected_calls[
+            ("disp007", "admin.vm.feature.Get", "internal", None)
+        ] = b"0\x001x00"
         self.app.expected_calls[
             ("test-vm", "admin.vm.CurrentState", None, None)
         ] = b"0\x00power_state=Running"
         self.app.expected_calls[
             ("test-vm3", "admin.vm.CurrentState", None, None)
         ] = b"0\x00power_state=Halted"
+        self.app.expected_calls[
+            ("disp007", "admin.vm.CurrentState", None, None)
+        ] = b"0\x00power_state=Paused"
         self.app.expected_calls[
             ("test-vm", "admin.vm.feature.CheckWithTemplate", "os", None)
         ] = b"2\x00QubesFeatureNotFoundError\x00\x00Feature 'os' not set\x00"

--- a/qubesadmin/tools/qvm_run.py
+++ b/qubesadmin/tools/qvm_run.py
@@ -370,7 +370,13 @@ def main(args=None, app=None):
         domains = [dispvm]
     elif args.all_domains:
         # --all consider only running VMs
-        domains = [vm for vm in domains if vm.is_running()]
+        domains = [
+            vm
+            for vm in domains
+            if vm.is_running()
+            and not vm.features.get("internal")
+            and not vm.is_paused()
+        ]
         if args.gui is None:
             for qube in domains:
                 gui_per_domain[qube] = has_gui(qube)

--- a/qubesadmin/tools/qvm_unpause.py
+++ b/qubesadmin/tools/qvm_unpause.py
@@ -38,7 +38,14 @@ def main(args=None, app=None):
 
     args = parser.parse_args(args, app=app)
     exit_code = 0
-    for domain in args.domains:
+    domains = args.domains
+    if args.all_domains:
+        domains = [
+            vm
+            for vm in domains
+            if not vm.features.get("internal")
+        ]
+    for domain in domains:
         try:
             if domain.is_suspended():
                 domain.resume()


### PR DESCRIPTION
Also exclude all other internal qubes from the same command

fixes: https://github.com/QubesOS/qubes-issues/issues/10314
For: https://github.com/QubesOS/qubes-issues/issues/1512