### PR TITLE
Ignore preload as a dependency

### DIFF
--- a/qubesadmin/utils.py
+++ b/qubesadmin/utils.py
@@ -143,6 +143,7 @@ def vm_dependencies(app, reference_vm):
     for vm in app.domains:
         if vm == reference_vm:
             continue
+        is_preload = getattr(vm, "is_preload", False)
         for prop in vm_properties:
             if not hasattr(vm, prop):
                 continue
@@ -150,7 +151,18 @@ def vm_dependencies(app, reference_vm):
                 is_prop_default = vm.property_is_default(prop)
             except qubesadmin.exc.QubesPropertyAccessError:
                 is_prop_default = False
-            if reference_vm == getattr(vm, prop, None) and not is_prop_default:
+            if (
+                reference_vm == getattr(vm, prop, None)
+                and not is_prop_default
+                and not (
+                    is_preload
+                    and prop == "template"
+                    or (
+                        prop == "default_dispvm"
+                        and getattr(vm, "template", None) == vm
+                    )
+                )
+            ):
                 result.append((vm, prop))
 
     return result


### PR DESCRIPTION
There doesn't seem to be a sane setup that would set a preloaded disposable as a property of another qube or a system property. The core already ignores preloaded disposables in certain cases, do the same on the client to not have derived applications such as Qube Manager having to deal with it.

Fixes: https://github.com/QubesOS/qubes-issues/issues/10227
For: https://github.com/QubesOS/qubes-issues/issues/1512