### PR TITLE
Remove `--just-db` option from auto-generated man of qvm-remove

### DIFF
--- a/doc/manpages/qvm-remove.rst
+++ b/doc/manpages/qvm-remove.rst
@@ -14,7 +14,7 @@
 
 Synopsis
 --------
-:command:`qvm-remove` [-h] [--verbose] [--quiet] [--force] [--force-root] [--all] [--exclude *EXCLUDE*] [--just-db] [*VMNAME* [*VMNAME* ...]]
+:command:`qvm-remove` [-h] [--verbose] [--quiet] [--force] [--force-root] [--all] [--exclude *EXCLUDE*] [*VMNAME* [*VMNAME* ...]]
 
 Options
 -------

--- a/doc/manpages/qvm-template.rst
+++ b/doc/manpages/qvm-template.rst
@@ -264,7 +264,7 @@ See Section `Template Spec`_ for an explanation of *TEMPLATESPEC*.
 info
 ^^^^
 
-| :command:`qvm-template list` [-h] [--all] [--installed] [--available] [--extras] [--upgrades] [--machine-readable | --machine-readable-json] [*TEMPLATESPEC* [*TEMPLATESPEC* ...]]
+| :command:`qvm-template info` [-h] [--all] [--installed] [--available] [--extras] [--upgrades] [--machine-readable | --machine-readable-json] [*TEMPLATESPEC* [*TEMPLATESPEC* ...]]
 
 Display details about templates.
 

--- a/doc/manpages/qvm-template.rst
+++ b/doc/manpages/qvm-template.rst
@@ -264,7 +264,7 @@ See Section `Template Spec`_ for an explanation of *TEMPLATESPEC*.
 info
 ^^^^
 
-| :command:`qvm-template info` [-h] [--all] [--installed] [--available] [--extras] [--upgrades] [--machine-readable | --machine-readable-json] [*TEMPLATESPEC* [*TEMPLATESPEC* ...]]
+| :command:`qvm-template list` [-h] [--all] [--installed] [--available] [--extras] [--upgrades] [--machine-readable | --machine-readable-json] [*TEMPLATESPEC* [*TEMPLATESPEC* ...]]
 
 Display details about templates.
 


### PR DESCRIPTION
Remove `--just-db` option from auto-generated man of qvm-remove.
I checked the code, qvm-remove does not support this option.