### PR TITLE
Cache GUIVM keyboard layout in `qvm-start-daemon`

### DIFF
--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -363,6 +363,7 @@ class KeyboardLayout:
         self.options = ",".join(
             opt for opt in self.options.split(",") if not opt.startswith("grp:")
         )
+        self.current_layout = None
 
     def get_property(self, layout_num):
         """Return the selected keyboard layout as formatted for keyboard_layout
@@ -449,10 +450,9 @@ class XWatcher:
         """Update current vm's keyboard_layout property"""
         new_property = self.keyboard_layout.get_property(self.selected_layout)
 
-        current_property = self.current_vm.keyboard_layout
-
-        if new_property != current_property:
+        if new_property != self.keyboard_layout.current_layout:
             self.current_vm.keyboard_layout = new_property
+            self.keyboard_layout.current_layout = new_property
 
     def event_reader(self, callback):
         """Poll for X events related to keyboard layout"""


### PR DESCRIPTION
On XFCE systems with multiple keyboard layouts and with XFCE Keyboard Layout widget, X raises two `XKLAVIER_ALLOW_SECONDARY` events shortly after each other (see 1st issue).

The current intended behaviour is to ignore the 2nd event by checking if the GUIVMs current layout is similar to the new requested layout. Unfortunately, after setting the GUIVM's keyboard layout, Qubes Core goes to this loop to propagate the new layout to all child qubes: https://github.com/QubesOS/qubes-core-admin/blob/main/qubes/ext/gui.py#L162-L170

And even if we move the condition after that loop just before it, it is still too slow to report back the new layout via qubesdb for `qvm-stat-daemon` use.

In order to avoid this race condition, it would be better to cache the layout within `qvm-start-daemon` itself.

fixes: https://github.com/QubesOS/qubes-issues/issues/8441
fixes: https://github.com/QubesOS/qubes-issues/issues/6517