### PR TITLE
Cache device assignments/attachments

### DIFF
--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -797,8 +797,10 @@ class QubesBase(qubesadmin.base.PropertyHolder):
         # pylint: disable=protected-access
         self.domains.clear_cache()
         for vm in self.domains._vm_objects.values():
+            assert isinstance(vm, qubesadmin.vm.QubesVM)
             vm._power_state_cache = None
             vm._properties_cache = {}
+            vm.devices.clear_cache()
         self._properties_cache = {}
 
 

--- a/qubesadmin/tools/qvm_device.py
+++ b/qubesadmin/tools/qvm_device.py
@@ -757,6 +757,7 @@ def get_parser(device_class=None):
 def main(args=None, app=None):
     """Main routine of :program:`qvm-block`."""
     app = app or qubesadmin.Qubes()
+    app.cache_enabled = True
 
     basename = os.path.basename(sys.argv[0])
     devclass = None


### PR DESCRIPTION
Those are enumerated several times when listing devices, but they change 
rarely (most qubes don't get any devices attached usually). Cache both 
assignments and attachments to speed things up. And similarly to properties
and power state cache - invalidate the cache based on events.

Fixes QubesOS/qubes-issues#10380