### PR TITLE
Remove old denylist from qvm-device + minor mockAPi fix

### DIFF
--- a/qubesadmin/devices.py
+++ b/qubesadmin/devices.py
@@ -45,9 +45,6 @@ from qubesadmin.device_protocol import (
 )
 
 
-DEVICE_DENY_LIST = "/etc/qubes/device-deny.list"
-
-
 class DeviceCollection:
     """Bag for devices.
 

--- a/qubesadmin/tests/mock_app.py
+++ b/qubesadmin/tests/mock_app.py
@@ -132,6 +132,7 @@ DEFAULT_VM_PROPERTIES = {
     "installed_by_rpm": Property("False", "bool", True),
     "ip": Property("10.137.0.2", "str", True),
     "ip6": Property("", "str", True),
+    "is_preload": Property("False", bool, False),
     "kernel": Property("5.15.52-1.fc32", "str", True),
     "kernelopts": Property("", "str", True),
     "keyboard_layout": Property("us++", "str", True),

--- a/qubesadmin/tests/tools/qvm_device.py
+++ b/qubesadmin/tests/tools/qvm_device.py
@@ -25,7 +25,6 @@
 
 """ Tests for the `qvm-device` tool. """
 
-from unittest import mock
 import qubesadmin.tests
 import qubesadmin.tests.tools
 import qubesadmin.device_protocol
@@ -320,6 +319,12 @@ class TC_00_qvm_device(qubesadmin.tests.QubesTestCase):
         self.app.expected_calls[(
             'test-vm2', 'admin.vm.device.testclass.Attached', None, None
         )] = b'0\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.GetAll', None, None
+        )] = b'2\0QubesDaemonNoResponseError\0\0err\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.Get', 'devices_denied', None
+        )] = b'0\0default=False type=str '
         qubesadmin.tools.qvm_device.main(
             ['testclass', 'assign', 'test-vm2', 'test-vm1:dev1'], app=self.app)
         self.assertAllCalled()
@@ -337,6 +342,12 @@ class TC_00_qvm_device(qubesadmin.tests.QubesTestCase):
         self.app.expected_calls[(
             'test-vm2', 'admin.vm.device.testclass.Attached', None, None
         )] = b'0\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.GetAll', None, None
+        )] = b'2\0QubesDaemonNoResponseError\0\0err\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.Get', 'devices_denied', None
+        )] = b'0\0default=False type=str '
         qubesadmin.tools.qvm_device.main(
             ['testclass', 'assign', '--required', 'test-vm2', 'test-vm1:dev1'],
             app=self.app)
@@ -355,6 +366,12 @@ class TC_00_qvm_device(qubesadmin.tests.QubesTestCase):
         self.app.expected_calls[(
             'test-vm2', 'admin.vm.device.testclass.Attached', None, None
         )] = b'0\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.GetAll', None, None
+        )] = b'2\0QubesDaemonNoResponseError\0\0err\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.Get', 'devices_denied', None
+        )] = b'0\0default=False type=str '
         with qubesadmin.tests.tools.StdoutBuffer() as buf:
             qubesadmin.tools.qvm_device.main(
                 ['testclass', 'assign', '--ro', '--ask', 'test-vm2',
@@ -407,6 +424,12 @@ class TC_00_qvm_device(qubesadmin.tests.QubesTestCase):
             b"mode='auto-attach' frontend_domain='test-vm2'"
         )] = b'0\0'
         self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.GetAll', None, None
+        )] = b'2\0QubesDaemonNoResponseError\0\0err\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.Get', 'devices_denied', None
+        )] = b'0\0default=False type=str '
+        self.app.expected_calls[(
             'test-vm2', 'admin.vm.device.testclass.Attached', None, None
         )] = b'0\0'
         qubesadmin.tools.qvm_device.main(
@@ -424,6 +447,12 @@ class TC_00_qvm_device(qubesadmin.tests.QubesTestCase):
             b"devclass='testclass' backend_domain='test-vm1' "
             b"mode='auto-attach' frontend_domain='test-vm2'"
         )] = b'0\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.GetAll', None, None
+        )] = b'2\0QubesDaemonNoResponseError\0\0err\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.Get', 'devices_denied', None
+        )] = b'0\0default=False type=str '
         self.app.expected_calls[(
             'test-vm2', 'admin.vm.device.testclass.Attached', None, None
         )] = b'0\0'
@@ -445,6 +474,12 @@ class TC_00_qvm_device(qubesadmin.tests.QubesTestCase):
         self.app.expected_calls[(
             'test-vm2', 'admin.vm.device.testclass.Attached', None, None
         )] = b'0\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.GetAll', None, None
+        )] = b'2\0QubesDaemonNoResponseError\0\0err\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.Get', 'devices_denied', None
+        )] = b'0\0default=False type=str '
         qubesadmin.tools.qvm_device.main(
             ['testclass', 'assign', 'test-vm2', 'test-vm1:dev1', '--device'],
             app=self.app)
@@ -460,6 +495,12 @@ class TC_00_qvm_device(qubesadmin.tests.QubesTestCase):
             b"devclass='testclass' backend_domain='test-vm1' "
             b"mode='auto-attach' frontend_domain='test-vm2'"
         )] = b'0\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.GetAll', None, None
+        )] = b'2\0QubesDaemonNoResponseError\0\0err\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.Get', 'devices_denied', None
+        )] = b'0\0default=False type=str '
         qubesadmin.tools.qvm_device.main(
             ['testclass', 'assign', 'test-vm2',
              'test-vm1:dev1:cafe:cafe::0123456u654321'], app=self.app)
@@ -475,15 +516,19 @@ class TC_00_qvm_device(qubesadmin.tests.QubesTestCase):
             b"devclass='testclass' backend_domain='test-vm1' "
             b"mode='auto-attach' frontend_domain='test-vm2'"
         )] = b'0\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.GetAll', None, None
+        )] = b'2\0QubesDaemonNoResponseError\0\0err\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.Get', 'devices_denied', None
+        )] = b'0\0default=False type=str '
         qubesadmin.tools.qvm_device.main(
             ['testclass', 'assign', 'test-vm2',
              'test-vm1:dev1:cafe:cafe::0123456u654321', '--device'],
             app=self.app)
         self.assertAllCalled()
 
-    @mock.patch("builtins.open", new_callable=mock.mock_open,
-                read_data="test-vm2 u012345, *543210")
-    def test_041_assign_denied_device(self, _mock_deny_list):
+    def test_041_assign_denied_device(self):
         """ Test user warning """
         self.app.domains['test-vm2'].is_running = lambda: False
         self.app.expected_calls[(
@@ -493,6 +538,12 @@ class TC_00_qvm_device(qubesadmin.tests.QubesTestCase):
             b"devclass='testclass' backend_domain='test-vm1' "
             b"mode='ask-to-attach' frontend_domain='test-vm2'"
         )] = b'0\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.GetAll', None, None
+        )] = b'2\0QubesDaemonNoResponseError\0\0err\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.Get', 'devices_denied', None
+        )] = b'0\0default=False type=str u012345*543210'
         with qubesadmin.tests.tools.StdoutBuffer() as buf:
             qubesadmin.tools.qvm_device.main(
                 ['testclass', 'assign', '--ask', 'test-vm2', 'test-vm1:dev1'],


### PR DESCRIPTION
Replaced old deny_list file it with appropriate property (devices_denied). Found on the way to fixing QubesOS/qubes-issues#10356

Also fixes minor mock_app oversight: adds is_preload property.