### PR TITLE
devices: invalidate device cache on device-removed event

### DIFF
--- a/qubesadmin/events/__init__.py
+++ b/qubesadmin/events/__init__.py
@@ -257,6 +257,12 @@ class EventsDispatcher(object):
         ):
             devclass = event.split(":")[1]
             subject.devices[devclass]._attachment_cache = None
+        elif event.split(":")[0] in ("device-removed",):
+            devclass = event.split(":")[1]
+            try:
+                subject.devices[devclass]._dev_cache[kwargs["port"]]
+            except KeyError:
+                pass
 
         # deserialize known attributes
         if event.startswith('device-'):


### PR DESCRIPTION
Avoid returning old device when it got removed already. This also
(hopefully) fixes event handlers getting VirtualDevice instead of real
one:

    Failed to handle event: sys-usb, device-added:usb, {'device': sys-usb+4-1:0bda:8179:00E04C0001:uffffff}
    Traceback (most recent call last):
      File "/usr/lib/python3.13/site-packages/qubesadmin/events/__init__.py", line 278, in handle
        kwargs['device'] = plugged
        ^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.13/site-packages/qui/devices/device_widget.py", line 262, in device_added
        dev = backend.Device(device, self)
      File "/usr/lib/python3.13/site-packages/qui/devices/backend.py", line 156, in __init__
        for interface in dev.interfaces:
                         ^^^^^^^^^^^^^^
    AttributeError: 'VirtualDevice' object has no attribute 'interfaces'