### PR TITLE
Add method to solely create disposable

### DIFF
--- a/qubesadmin/tests/tools/qvm_run.py
+++ b/qubesadmin/tests/tools/qvm_run.py
@@ -668,7 +668,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             self.app.service_calls,
             [
                 (
-                    "$dispvm",
+                    "@dispvm",
                     "test.service",
                     {
                         "stdout": subprocess.DEVNULL,
@@ -676,7 +676,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                         "user": None,
                     },
                 ),
-                ("$dispvm", "test.service", b""),
+                ("@dispvm", "test.service", b""),
             ],
         )
         self.assertAllCalled()
@@ -699,7 +699,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             self.app.service_calls,
             [
                 (
-                    "$dispvm:test-vm",
+                    "@dispvm:test-vm",
                     "test.service",
                     {
                         "stdout": subprocess.DEVNULL,
@@ -707,7 +707,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                         "user": None,
                     },
                 ),
-                ("$dispvm:test-vm", "test.service", b""),
+                ("@dispvm:test-vm", "test.service", b""),
             ],
         )
         self.assertAllCalled()
@@ -1150,7 +1150,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
     def test_023_dispvm_no_shell(self):
         self.app.expected_calls[
             (
-                "$dispvm:test-vm",
+                "@dispvm:test-vm",
                 "admin.vm.feature.CheckWithTemplate",
                 "vmexec",
                 None,
@@ -1165,7 +1165,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             self.app.service_calls,
             [
                 (
-                    "$dispvm:test-vm",
+                    "@dispvm:test-vm",
                     "qubes.VMExec+command",
                     {
                         "stdout": subprocess.DEVNULL,
@@ -1173,7 +1173,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                         "user": None,
                     },
                 ),
-                ("$dispvm:test-vm", "qubes.VMExec+command", b""),
+                ("@dispvm:test-vm", "qubes.VMExec+command", b""),
             ],
         )
         self.assertAllCalled()
@@ -1277,7 +1277,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
     def test_027_no_shell_dispvm(self):
         self.app.expected_calls[
             (
-                "$dispvm:test-vm",
+                "@dispvm:test-vm",
                 "admin.vm.feature.CheckWithTemplate",
                 "vmexec",
                 None,
@@ -1292,7 +1292,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             self.app.service_calls,
             [
                 (
-                    "$dispvm:test-vm",
+                    "@dispvm:test-vm",
                     "qubes.VMExec+command+arg",
                     {
                         "stdout": subprocess.DEVNULL,
@@ -1300,7 +1300,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                         "user": None,
                     },
                 ),
-                ("$dispvm:test-vm", "qubes.VMExec+command+arg", b""),
+                ("@dispvm:test-vm", "qubes.VMExec+command+arg", b""),
             ],
         )
         self.assertAllCalled()
@@ -1308,7 +1308,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
     def test_028_argparse_bug_workaround(self):
         self.app.expected_calls[
             (
-                "$dispvm:test-vm",
+                "@dispvm:test-vm",
                 "admin.vm.feature.CheckWithTemplate",
                 "vmexec",
                 None,
@@ -1323,7 +1323,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             self.app.service_calls,
             [
                 (
-                    "$dispvm:test-vm",
+                    "@dispvm:test-vm",
                     "qubes.VMExec+command+----",
                     {
                         "stdout": subprocess.DEVNULL,
@@ -1331,7 +1331,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                         "user": None,
                     },
                 ),
-                ("$dispvm:test-vm", "qubes.VMExec+command+----", b""),
+                ("@dispvm:test-vm", "qubes.VMExec+command+----", b""),
             ],
         )
         self.assertAllCalled()
@@ -1339,7 +1339,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
     def test_029_command_is_dashdash(self):
         self.app.expected_calls[
             (
-                "$dispvm:test-vm",
+                "@dispvm:test-vm",
                 "admin.vm.feature.CheckWithTemplate",
                 "vmexec",
                 None,
@@ -1354,7 +1354,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             self.app.service_calls,
             [
                 (
-                    "$dispvm:test-vm",
+                    "@dispvm:test-vm",
                     "qubes.VMExec+----",
                     {
                         "stdout": subprocess.DEVNULL,
@@ -1362,14 +1362,14 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                         "user": None,
                     },
                 ),
-                ("$dispvm:test-vm", "qubes.VMExec+----", b""),
+                ("@dispvm:test-vm", "qubes.VMExec+----", b""),
             ],
         )
         self.assertAllCalled()
 
     def test_030_no_shell_dispvm(self):
         self.app.expected_calls[
-            ("$dispvm", "admin.vm.feature.CheckWithTemplate", "vmexec", None)
+            ("@dispvm", "admin.vm.feature.CheckWithTemplate", "vmexec", None)
         ] = b"0\x001"
         ret = qubesadmin.tools.qvm_run.main(
             ["--no-gui", "--dispvm", "--", "test-vm", "command", "arg"],
@@ -1380,7 +1380,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             self.app.service_calls,
             [
                 (
-                    "$dispvm",
+                    "@dispvm",
                     "qubes.VMExec+test--vm+command+arg",
                     {
                         "stdout": subprocess.DEVNULL,
@@ -1388,14 +1388,14 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                         "user": None,
                     },
                 ),
-                ("$dispvm", "qubes.VMExec+test--vm+command+arg", b""),
+                ("@dispvm", "qubes.VMExec+test--vm+command+arg", b""),
             ],
         )
         self.assertAllCalled()
 
     def test_031_argparse_bug_workaround(self):
         self.app.expected_calls[
-            ("$dispvm", "admin.vm.feature.CheckWithTemplate", "vmexec", None)
+            ("@dispvm", "admin.vm.feature.CheckWithTemplate", "vmexec", None)
         ] = b"0\x001"
         ret = qubesadmin.tools.qvm_run.main(
             ["--no-gui", "--dispvm", "--", "test-vm", "command", "--"],
@@ -1406,7 +1406,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             self.app.service_calls,
             [
                 (
-                    "$dispvm",
+                    "@dispvm",
                     "qubes.VMExec+test--vm+command+----",
                     {
                         "stdout": subprocess.DEVNULL,
@@ -1414,7 +1414,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                         "user": None,
                     },
                 ),
-                ("$dispvm", "qubes.VMExec+test--vm+command+----", b""),
+                ("@dispvm", "qubes.VMExec+test--vm+command+----", b""),
             ],
         )
         self.assertAllCalled()
@@ -1422,7 +1422,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
     @unittest.expectedFailure
     def test_032_argparse_bug_workaround_unnamed_dispvm(self):
         self.app.expected_calls[
-            ("$dispvm", "admin.vm.feature.CheckWithTemplate", "vmexec", None)
+            ("@dispvm", "admin.vm.feature.CheckWithTemplate", "vmexec", None)
         ] = b"0\x001"
         ret = qubesadmin.tools.qvm_run.main(
             ["--no-gui", "--dispvm", "test-vm", "command", "--"], app=self.app
@@ -1432,7 +1432,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             self.app.service_calls,
             [
                 (
-                    "$dispvm",
+                    "@dispvm",
                     "qubes.VMExec+test--vm+command+----",
                     {
                         "stdout": subprocess.DEVNULL,
@@ -1440,7 +1440,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                         "user": None,
                     },
                 ),
-                ("$dispvm", "qubes.VMExec+test--vm+command+----", b""),
+                ("@dispvm", "qubes.VMExec+test--vm+command+----", b""),
             ],
         )
         self.assertAllCalled()

--- a/qubesadmin/tests/vm/dispvm.py
+++ b/qubesadmin/tests/vm/dispvm.py
@@ -73,8 +73,8 @@ class TC_00_Dispvm(qubesadmin.tests.QubesTestCase):
         vm.run_service_for_stdio('test.service')
         vm.cleanup()
         self.assertEqual(self.app.service_calls, [
-            ('$dispvm', 'test.service', {}),
-            ('$dispvm', 'test.service', b''),
+            ('@dispvm', 'test.service', {}),
+            ('@dispvm', 'test.service', b''),
         ])
         self.assertAllCalled()
 
@@ -83,8 +83,8 @@ class TC_00_Dispvm(qubesadmin.tests.QubesTestCase):
         vm.run_service_for_stdio('test.service')
         vm.cleanup()
         self.assertEqual(self.app.service_calls, [
-            ('$dispvm:test-vm', 'test.service', {}),
-            ('$dispvm:test-vm', 'test.service', b''),
+            ('@dispvm:test-vm', 'test.service', {}),
+            ('@dispvm:test-vm', 'test.service', b''),
         ])
         self.assertAllCalled()
 

--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -465,7 +465,7 @@ class DispVMWrapper(QubesVM):
         """Create disposable if absent and run service."""
         if (
             self.app.qubesd_connection_type == "socket"
-            and self._method_dest.startswith("$dispvm")
+            and self._method_dest.startswith("@dispvm")
         ):
             self.create_disposable()
             # Service call may wait for session start, give it more time
@@ -481,7 +481,7 @@ class DispVMWrapper(QubesVM):
         """
         if (
             self.app.qubesd_connection_type == "socket"
-            and not self._method_dest.startswith("$dispvm")
+            and not self._method_dest.startswith("@dispvm")
         ):
             try:
                 self.kill()
@@ -490,15 +490,15 @@ class DispVMWrapper(QubesVM):
 
     def start(self):
         """Create disposable if absent and start it."""
-        if self._method_dest.startswith("$dispvm"):
+        if self._method_dest.startswith("@dispvm"):
             self.create_disposable()
         super().start()
 
     def create_disposable(self):
         """Create disposable."""
-        if self._method_dest.startswith("$dispvm"):
-            if self._method_dest.startswith("$dispvm:"):
-                method_dest = self._method_dest[len("$dispvm:") :]
+        if self._method_dest.startswith("@dispvm"):
+            if self._method_dest.startswith("@dispvm:"):
+                method_dest = self._method_dest[len("@dispvm:") :]
             else:
                 method_dest = "dom0"
             dispvm = self.app.qubesd_call(
@@ -518,9 +518,9 @@ class DispVM(QubesVM):
         AppVM. If *appvm* is none, use default DispVM template"""
 
         if appvm:
-            method_dest = "$dispvm:" + str(appvm)
+            method_dest = "@dispvm:" + str(appvm)
         else:
-            method_dest = "$dispvm"
+            method_dest = "@dispvm"
 
         wrapper = DispVMWrapper(app, method_dest)
         return wrapper


### PR DESCRIPTION
In line with the qubes module, disposable creation happens on from_appvm(). This change is intended to measure how much time it takes to get a fresh disposable object, improving the performance tests distinction of the from_appvm() phase from the execution/run*() phase.

For: https://github.com/qubesos/qubes-issues/issues/10230
For: https://github.com/qubesos/qubes-issues/issues/1512