### PR TITLE
Deserialize device in events only if there is a handler registered

### DIFF
--- a/qubesadmin/events/__init__.py
+++ b/qubesadmin/events/__init__.py
@@ -264,6 +264,15 @@ class EventsDispatcher(object):
             except KeyError:
                 pass
 
+        handlers = [h_func for h_name, h_func_set in self.handlers.items()
+                    for h_func in h_func_set
+                    if fnmatch.fnmatch(event, h_name)]
+
+        # skip deserializing parameters (which may make further Admin API calls)
+        # if no handler is registered for the event
+        if not handlers:
+            return
+
         # deserialize known attributes
         if event.startswith('device-'):
             try:
@@ -292,9 +301,6 @@ class EventsDispatcher(object):
             except (KeyError, ValueError):
                 pass
 
-        handlers = [h_func for h_name, h_func_set in self.handlers.items()
-            for h_func in h_func_set
-            if fnmatch.fnmatch(event, h_name)]
         for handler in handlers:
             try:
                 handler(subject, event, **kwargs)


### PR DESCRIPTION
Deserializing device parameter may trigger a call to get remaining
details. Don't do that if there are no handlers for such event anyway.

Specifically, this avoids calling admin.vm.device.usb.Available (and
others) by sys-audio whenever new device is plugged in.