### PR TITLE
use qubes.VMRootExec/qubes.VMRootShell services when root needed

### DIFF
--- a/qubesadmin/tools/qvm_run.py
+++ b/qubesadmin/tools/qvm_run.py
@@ -271,16 +271,27 @@ def run_command_single(args, vm):
             service = "qubes.VMExec"
             if args.gui and args.dispvm:
                 service = "qubes.VMExecGUI"
+            elif args.user == "root" and vm.features.check_with_template(
+                "supported-rpc.qubes.VMRootExec", False
+            ):
+                service = "qubes.VMRootExec"
+                args.user = None
             service += "+" + qubesadmin.utils.encode_for_vmexec(all_args)
         else:
             service = "qubes.VMShell"
             if args.gui and args.dispvm:
                 service += "+WaitForSession"
+            elif args.user == "root":
+                service = "qubes.VMRootShell"
+                args.user = None
             shell_cmd = " ".join(shlex.quote(arg) for arg in all_args)
     else:
         service = "qubes.VMShell"
         if args.gui and args.dispvm:
             service += "+WaitForSession"
+        elif args.user == "root":
+            service = "qubes.VMRootShell"
+            args.user = None
         shell_cmd = args.cmd
 
     proc = vm.run_service(service, user=args.user, **run_kwargs)

--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -355,8 +355,12 @@ class QubesVM(qubesadmin.base.PropertyHolder):
         """Run a shell command inside the domain using qubes.VMShell qrexec."""
         # pylint: disable=redefined-builtin
         try:
+            service = "qubes.VMShell"
+            if kwargs.get("user", None) == "root":
+                kwargs.pop("user")
+                service = "qubes.VMRootShell"
             return self.run_service_for_stdio(
-                "qubes.VMShell",
+                service,
                 input=self.prepare_input_for_vmshell(command, input),
                 **kwargs
             )
@@ -374,9 +378,15 @@ class QubesVM(qubesadmin.base.PropertyHolder):
         """  # pylint: disable=redefined-builtin
         if self.features.check_with_template("vmexec", False):
             try:
+                service = "qubes.VMExec+"
+                if kwargs.get("user", None) == "root":
+                    if self.features.check_with_template(
+                        "supported-rpc.qubes.VMRootExec", False
+                    ):
+                        kwargs.pop("user")
+                        service = "qubes.VMRootExec+"
                 return self.run_service_for_stdio(
-                    "qubes.VMExec+" + qubesadmin.utils.encode_for_vmexec(args),
-                    **kwargs
+                    service + qubesadmin.utils.encode_for_vmexec(args), **kwargs
                 )
             except subprocess.CalledProcessError as e:
                 e.cmd = str(args)


### PR DESCRIPTION
When running a command as root is requested, use
qubes.VMRootExec/qubes.VMRootShell services, instead of specifying
target user directly. The explicit target user can be specified only
from dom0, but alternative qrexec service can be used also from GUI
domain - if policy allows of course.

QubesOS/qubes-issues#4186