### PR TITLE
Introduce `audio-volume` feature

### DIFF
--- a/doc/manpages/qvm-features.rst
+++ b/doc/manpages/qvm-features.rst
@@ -404,6 +404,14 @@ device instead of audio agent installed in the qube itself. The value is audio
 model to be emulated, supported values are `ich6`, `sb16`, `ac97`, `es1370`.
 Recommended is `ich6`. This is useful to get audio in a Windows qube.
 
+
+audio-initial-volume
+^^^^^^^^^^^^^^^^^^^^
+
+Optionally sets the audio volume of the qube at every launch. Valid values are
+from 0 to 150; or `mute`. Default for `untrusted` and Whonix workstation based
+qubes is mute.
+
 uefi
 ^^^^
 

--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -793,6 +793,26 @@ class DAEMONLauncher:
             str(self.pacat_domid(vm)),
             vm.name,
         ]
+
+        try:
+            volume = vm.features.check_with_template(
+                "audio-initial-volume",
+                self.app.domains[
+                    self.app.local_name
+                ].features.check_with_template(
+                    "audio-initial-volume",
+                    None,
+                ),
+            )
+            if volume:
+                if volume.endswith("%"):
+                    volume = volume[:-1]
+                pacat_cmd.insert(1, "-V")
+                pacat_cmd.insert(2, volume)
+        except qubesadmin.exc.QubesDaemonAccessError:
+            # Most probably within a sys-audio with older policy files
+            pass
+
         vm.log.info("Starting AUDIO")
 
         await asyncio.create_subprocess_exec(*pacat_cmd)


### PR DESCRIPTION
Allowing user to set the default audio volume per qube via `audio-volume` feature. By default it is 100% (except some select qubes which will be always muted).

resolves: https://github.com/QubesOS/qubes-issues/issues/2724