### PR TITLE
Include zstd package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -27,6 +27,7 @@ Depends:
  python3-qubesadmin,
  qubes-repo-templates,
  scrypt,
+ zstd,
  qubes-rpm-oxide (>= 0.2.3),
  python3-xlib,
  ${python:Depends},

--- a/rpm_spec/qubes-core-admin-client.spec.in
+++ b/rpm_spec/qubes-core-admin-client.spec.in
@@ -22,6 +22,7 @@ Requires:   python%{python3_pkgversion}-qubesadmin
 Requires:   python%{python3_pkgversion}-yaml
 Requires:   qubes-repo-templates
 Requires:   scrypt
+Requires:   zstd
 Requires:   qubes-rpm-oxide >= 0.2.3
 Requires:   xrandr
 BuildArch:  noarch


### PR DESCRIPTION
zstd compression filter is much faster compared got gzip for backup/restore operations (up to 3 times).

Most distros have already switched to zstd for package compression or initrd compression. Fedora 43 already includes it and uses it for dracut.

resolves: https://github.com/QubesOS/qubes-issues/issues/10489
related: https://github.com/QubesOS/qubes-issues/issues/8211