### PR TITLE
Disentangle reusable template logic from `qvm-template` CLI

### DIFF
--- a/qubesadmin/exc.py
+++ b/qubesadmin/exc.py
@@ -217,8 +217,13 @@ class BackupRestoreError(QubesException):
         super().__init__(msg)
         self.backup_log = backup_log
 
+
 class SignatureVerificationError(Exception):
     """Package signature is invalid or missing"""
+
+
+class AlreadyRunning(Exception):
+    """Another qvm-template is already running"""
 
 
 # pylint: disable=too-many-ancestors

--- a/qubesadmin/exc.py
+++ b/qubesadmin/exc.py
@@ -217,6 +217,9 @@ class BackupRestoreError(QubesException):
         super().__init__(msg)
         self.backup_log = backup_log
 
+class SignatureVerificationError(Exception):
+    """Package signature is invalid or missing"""
+
 
 # pylint: disable=too-many-ancestors
 class QubesDaemonAccessError(QubesDaemonCommunicationError):

--- a/qubesadmin/templates.py
+++ b/qubesadmin/templates.py
@@ -20,6 +20,8 @@
 """Template management for Qubes OS."""
 
 import os
+import datetime
+import enum
 import fnmatch
 import subprocess
 import tempfile
@@ -28,9 +30,72 @@ import sys
 
 import qubesadmin.exc
 
+DATE_FMT = '%Y-%m-%d %H:%M:%S'
 PATH_PREFIX = '/var/lib/qubes/vm-templates'
 PACKAGE_NAME_PREFIX = 'qubes-template-'
 TAR_HEADER_BYTES = 512
+
+
+class TemplateState(enum.Enum):
+    """Enum representing the state of a template."""
+    INSTALLED = 'installed'
+    AVAILABLE = 'available'
+    EXTRA = 'extra'
+    UPGRADABLE = 'upgradable'
+
+    def title(self) -> str:
+        """Return a long description of the state. Can be used as headings."""
+        # pylint: disable=invalid-name
+        TEMPLATE_TITLES = {
+            TemplateState.INSTALLED: 'Installed Templates',
+            TemplateState.AVAILABLE: 'Available Templates',
+            TemplateState.EXTRA: 'Extra Templates',
+            TemplateState.UPGRADABLE: 'Available Upgrades'
+        }
+        return TEMPLATE_TITLES[self]
+
+
+class VersionSelector(enum.Enum):
+    """Enum representing how the candidate template version is chosen."""
+    LATEST = enum.auto()
+    """Install latest version."""
+    REINSTALL = enum.auto()
+    """Reinstall current version."""
+    LATEST_LOWER = enum.auto()
+    """Downgrade to the highest version that is lower than the current one."""
+    LATEST_HIGHER = enum.auto()
+    """Upgrade to the highest version that is higher than the current one."""
+
+
+# pylint: disable=too-few-public-methods,inherit-non-class
+class Template(typing.NamedTuple):
+    """Details of a template."""
+    name: str
+    epoch: str
+    version: str
+    release: str
+    reponame: str
+    dlsize: int
+    buildtime: datetime.datetime
+    licence: str
+    url: str
+    summary: str
+    description: str
+
+    @property
+    def evr(self):
+        """Return a tuple of (EPOCH, VERSION, RELEASE)"""
+        return self.epoch, self.version, self.release
+
+
+class DlEntry(typing.NamedTuple):
+    """Information about a template to be downloaded."""
+    evr: typing.Tuple[str, str, str]
+    reponame: str
+    dlsize: int
+
+
+# pylint: enable=too-few-public-methods,inherit-non-class
 
 
 def qubes_release() -> str:

--- a/qubesadmin/templates.py
+++ b/qubesadmin/templates.py
@@ -1,0 +1,129 @@
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2019  WillyPillow <wp@nerde.pw>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""Template management for Qubes OS."""
+
+import os
+import subprocess
+import tempfile
+import typing
+import sys
+
+import qubesadmin.exc
+
+PATH_PREFIX = '/var/lib/qubes/vm-templates'
+PACKAGE_NAME_PREFIX = 'qubes-template-'
+TAR_HEADER_BYTES = 512
+
+
+def verify_rpm(path: str, key: str, *, nogpgcheck: bool = False,
+               template_name: typing.Optional[str] = None) -> typing.Any:
+    """Verify the digest and signature of a RPM package and return the package
+    header.
+
+    Note that verifying RPMs this way is prone to TOCTOU. This is okay for
+    local files, but may create problems if multiple instances of
+    **qvm-template** are downloading the same file, so a lock is needed in that
+    case.
+
+    :param path: Location of the RPM package
+    :param key: Path to the GPG key file
+    :param nogpgcheck: Whether to allow invalid GPG signatures
+    :param template_name: expected template name - if specified, verifies if
+           the package name matches expected template name
+
+    :return: RPM package header. If verification fails, raises an exception.
+    """
+    import rpm
+
+    assert isinstance(nogpgcheck, bool), 'Must pass a boolean for nogpgcheck'
+    with open(path, 'rb') as fd:
+        if not nogpgcheck:
+            with tempfile.TemporaryDirectory() as rpmdb_dir:
+                subprocess.check_call(
+                    ['rpmkeys', '--dbpath=' + rpmdb_dir, '--import', key])
+                try:
+                    output = subprocess.check_output([
+                        'rpmkeys',
+                        '--dbpath=' + rpmdb_dir,
+                        '--define=_pkgverify_level all',
+                        '--define=_pkgverify_flags 0x0',
+                        '--checksig',
+                        '-',
+                    ], env={'LC_ALL': 'C', **os.environ}, stdin=fd)
+                except subprocess.CalledProcessError as e:
+                    raise qubesadmin.exc.SignatureVerificationError(
+                        f"Signature verification failed: {e.output.decode()}")
+                if output != b'-: digests signatures OK\n':
+                    raise qubesadmin.exc.SignatureVerificationError(
+                        f"Signature verification failed: {output.decode()}")
+            fd.seek(0)
+        tset = rpm.TransactionSet()
+        tset.setVSFlags(rpm.RPMVSF_MASK_NOSIGNATURES)
+        hdr = tset.hdrFromFdno(fd)
+    if template_name is not None:
+        if hdr[rpm.RPMTAG_NAME] != PACKAGE_NAME_PREFIX + template_name:
+            raise qubesadmin.exc.SignatureVerificationError(
+                'Downloaded package does not match expected template name')
+    return hdr
+
+
+def extract_rpm(name: str, path: str, target: str) -> bool:
+    """Extract a template RPM package.
+
+    If the package contains root.img file split across multiple parts,
+    only the first 512 bytes of the 00 part is retained (tar header) and
+    a symlink to the rpm file is created in target directory.
+
+    :param name: Name of the template
+    :param path: Location of the RPM package
+    :param target: Target path to extract to
+
+    :return: Whether the extraction succeeded
+    """
+    with open(path, 'rb') as pkg_f:
+        with subprocess.Popen(['rpm2archive', "-"],
+                stdin=pkg_f,
+                stdout=subprocess.PIPE) as rpm2archive:
+            with subprocess.Popen([
+                'tar', 'xz', '-C', target, f'.{PATH_PREFIX}/{name}/',
+                '--exclude=root.img.part.?[!0]',
+                '--exclude=root.img.part.[!0]0'
+            ], stdin=rpm2archive.stdout, stdout=subprocess.DEVNULL) as tar:
+                pass
+    if rpm2archive.returncode != 0 or tar.returncode != 0:
+        return False
+
+    part_00_path = f'{target}/{PATH_PREFIX}/{name}/root.img.part.00'
+    if os.path.exists(part_00_path):
+        with subprocess.Popen([
+            'truncate', f'--size={TAR_HEADER_BYTES}', part_00_path
+        ]) as truncate:
+            pass
+        if truncate.returncode != 0:
+            return False
+        link_path = f'{target}/{PATH_PREFIX}/{name}/template.rpm'
+        try:
+            os.symlink(os.path.abspath(path),
+                       f'{target}/{PATH_PREFIX}/{name}/template.rpm')
+        except OSError as e:
+            print(f"Failed to create {link_path} symlink: {e!s}",
+                  file=sys.stderr)
+            return False
+    return True

--- a/qubesadmin/tools/qvm_template.py
+++ b/qubesadmin/tools/qvm_template.py
@@ -54,8 +54,13 @@ import qubesadmin.tools.qvm_kill
 import qubesadmin.tools.qvm_remove
 
 from qubesadmin.templates import (
+    DATE_FMT,
     PACKAGE_NAME_PREFIX,
     PATH_PREFIX,
+    DlEntry,
+    Template,
+    TemplateState,
+    VersionSelector,
     build_version_str,
     is_match_spec,
     qubes_release,
@@ -65,7 +70,6 @@ TEMP_DIR = '/var/tmp'
 CACHE_DIR = os.path.join(xdg.BaseDirectory.xdg_cache_home, 'qvm-template')
 UNVERIFIED_SUFFIX = '.unverified'
 LOCK_FILE = '/run/qubes/qvm-template.lock'
-DATE_FMT = '%Y-%m-%d %H:%M:%S'
 WRAPPER_PAYLOAD_BEGIN = "###!Q!BEGIN-QUBES-WRAPPER!Q!###"
 WRAPPER_PAYLOAD_END = "###!Q!END-QUBES-WRAPPER!Q!###"
 
@@ -245,68 +249,6 @@ def get_parser() -> argparse.ArgumentParser:
 
 
 parser = get_parser()
-
-
-class TemplateState(enum.Enum):
-    """Enum representing the state of a template."""
-    INSTALLED = 'installed'
-    AVAILABLE = 'available'
-    EXTRA = 'extra'
-    UPGRADABLE = 'upgradable'
-
-    def title(self) -> str:
-        """Return a long description of the state. Can be used as headings."""
-        # pylint: disable=invalid-name
-        TEMPLATE_TITLES = {
-            TemplateState.INSTALLED: 'Installed Templates',
-            TemplateState.AVAILABLE: 'Available Templates',
-            TemplateState.EXTRA: 'Extra Templates',
-            TemplateState.UPGRADABLE: 'Available Upgrades'
-        }
-        return TEMPLATE_TITLES[self]
-
-
-class VersionSelector(enum.Enum):
-    """Enum representing how the candidate template version is chosen."""
-    LATEST = enum.auto()
-    """Install latest version."""
-    REINSTALL = enum.auto()
-    """Reinstall current version."""
-    LATEST_LOWER = enum.auto()
-    """Downgrade to the highest version that is lower than the current one."""
-    LATEST_HIGHER = enum.auto()
-    """Upgrade to the highest version that is higher than the current one."""
-
-
-# pylint: disable=too-few-public-methods,inherit-non-class
-class Template(typing.NamedTuple):
-    """Details of a template."""
-    name: str
-    epoch: str
-    version: str
-    release: str
-    reponame: str
-    dlsize: int
-    buildtime: datetime.datetime
-    licence: str
-    url: str
-    summary: str
-    description: str
-
-    @property
-    def evr(self):
-        """Return a tuple of (EPOCH, VERSION, RELEASE)"""
-        return self.epoch, self.version, self.release
-
-
-class DlEntry(typing.NamedTuple):
-    """Information about a template to be downloaded."""
-    evr: typing.Tuple[str, str, str]
-    reponame: str
-    dlsize: int
-
-
-# pylint: enable=too-few-public-methods,inherit-non-class
 
 
 def query_local(vm: qubesadmin.vm.QubesVM) -> Template:

--- a/qubesadmin/tools/qvm_template.py
+++ b/qubesadmin/tools/qvm_template.py
@@ -20,7 +20,6 @@
 """Tool for managing VM templates."""
 
 import argparse
-import base64
 import collections
 import configparser
 import datetime
@@ -61,7 +60,9 @@ from qubesadmin.templates import (
     Template,
     TemplateState,
     VersionSelector,
+    append_keys,
     build_version_str,
+    get_keys_for_repos,
     get_managed_template_vm,
     is_managed_template,
     is_match_spec,
@@ -74,8 +75,6 @@ TEMP_DIR = '/var/tmp'
 CACHE_DIR = os.path.join(xdg.BaseDirectory.xdg_cache_home, 'qvm-template')
 UNVERIFIED_SUFFIX = '.unverified'
 LOCK_FILE = '/run/qubes/qvm-template.lock'
-WRAPPER_PAYLOAD_BEGIN = "###!Q!BEGIN-QUBES-WRAPPER!Q!###"
-WRAPPER_PAYLOAD_END = "###!Q!END-QUBES-WRAPPER!Q!###"
 
 UPDATEVM = str('global UpdateVM')
 
@@ -305,53 +304,6 @@ def qrexec_popen(
         stderr=subprocess.PIPE
     )
 
-def _is_file_in_repo_templates_keys_dir(path: str) -> bool:
-    """Check if the given path is a file located repo-template keys dir"""
-    return os.path.isfile(path) and path.startswith(
-        "/etc/qubes/repo-templates/keys/")
-
-def _encode_key(path):
-    """Base64-encoe a file to be placed in qvm-template payload"""
-    if path.startswith("file://"):
-        path = path[7:]
-
-    if not _is_file_in_repo_templates_keys_dir(path):
-        return ""
-
-    encoded_key = "#" + path + "\n"
-    with open(path, "rb") as key:
-        encoded_key += f"#{base64.b64encode(key.read()).decode('ascii')}\n"
-    return encoded_key
-
-def _replace_dnf_vars(path, releasever):
-    """Replace supported dnf variables in repo"""
-    for var in ["$releasever", "${releasever}"]:
-        path = path.replace(var, releasever)
-    return path
-
-def _append_keys(payload, releasever):
-    """Add GPG key and SSL cert/keys to qvm-template payload"""
-    config = configparser.ConfigParser()
-    try:
-        config.read_string(payload)
-    except RuntimeError:
-        return ""
-
-    file_list = set()
-    for section in config.sections():
-        for option in ["gpgkey", "sslclientcert", "sslclientkey"]:
-            if config.has_option(section, option):
-                file_list.add(
-                    _replace_dnf_vars(config.get(section, option),
-                                      releasever))
-
-    encoded_keys = "".join(
-        [_encode_key(file_path) for file_path in sorted(file_list)])
-    if not encoded_keys:
-        return ""
-
-    return f"\n{WRAPPER_PAYLOAD_BEGIN}\n{encoded_keys}{WRAPPER_PAYLOAD_END}"
-
 def qrexec_payload(args: argparse.Namespace, app: qubesadmin.app.QubesBase,
                    spec: str, refresh: bool) -> str:
     """Return payload string for the ``qubes.Template*`` qrexec calls.
@@ -395,7 +347,7 @@ def qrexec_payload(args: argparse.Namespace, app: qubesadmin.app.QubesBase,
             repo_config += fd.read() + '\n'
     payload += repo_config
 
-    payload += _append_keys(repo_config, args.releasever)
+    payload += append_keys(repo_config, args.releasever)
     return payload
 
 
@@ -558,28 +510,6 @@ def qrexec_download(
                     "qrexec call 'qubes.TemplateDownload' failed.")
             if rpmcanon.wait() != 0:
                 raise ConnectionError("rpmcanon failed")
-
-
-def get_keys_for_repos(repo_files: typing.List[str],
-                       releasever: str) -> typing.Dict[str, str]:
-    """List gpg keys
-
-    Returns a dict reponame -> key path
-    """
-    keys = {}
-    for repo_file in repo_files:
-        repo_config = configparser.ConfigParser()
-        repo_config.read(repo_file)
-        for repo in repo_config.sections():
-            try:
-                gpgkey_url = repo_config.get(repo, 'gpgkey')
-            except configparser.NoOptionError:
-                continue
-            gpgkey_url = gpgkey_url.replace('$releasever', releasever)
-            # support only file:// urls
-            if gpgkey_url.startswith('file://'):
-                keys[repo] = gpgkey_url[len('file://'):]
-    return keys
 
 
 def filter_version(


### PR DESCRIPTION
This extracts the core template management functionality from `qvm_template.py` into a new `qubesadmin.templates` module, separating reusable library code from CLI-specific concerns like argument parsing and terminal output.

These changes primarily move code rather than modify it, meaning the logic should not have changed unless that was required for functionality extraction.

The original code had `parser.error()` calls scattered throughout, resulting in `sys.exit()`. Functions now signal errors and progress in Python rather than just in stdout/stderr. In short, `qvm-template-gui` could avoid parsing/showing the cli tool's output, as with this change it could use the module provide native Qt progress bars etc.

I did cursory testing (both on the cli and with `qvm-template-gui`) and didn't run into issues. Happy to do more if there's interest in merging this but you want more thorough manual testing. I couldn't find an issue that suggested this should happen.