### PR TITLE
Add type hints for `qubesadmin/backup`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+
+# Note: we're not using a "standard" pyproject.toml with a [project] section to avoid
+# clashing with the old-school setup.py build (for now... hopefully will be upgraded later ?)
+[dependency-groups]
+current-deps = [  # project dependencies
+    "lxml>=6.0.2",
+    "python-daemon>=3.1.2",
+    "pyxdg>=0.28",
+    "pyyaml>=6.0.3",
+    "tqdm>=4.67.3",
+    "xcffib>=1.12.0",
+]
+current-dev = [  # dev-depencencies
+    "types-lxml>=2026.1.1",
+    "pylint>=4.0.4",
+    "mock>=5.2.0",
+    "docutils>=0.22.4",
+    "sphinx>=9.1.0",
+    "setuptools>=82.0.0",
+    "black>=26.1.0",
+    "mypy>=1.19.1",
+]
+future-dev = [  # those tools are very efficient but not packaged for major distributions yet
+    "ruff>=0.15.1",
+    "ty>=0.0.16",
+]
+
+[tool.ty.rules]
+
+[tool.ruff]
+preview = true
+
+[tool.ruff.lint]
+select = ["ANN", "RUF045"]  # Require type annotations for every function
+ignore = ["ANN003"]  # type annotation for **kwargs
+
+[tool.ruff.lint.flake8-annotations]
+mypy-init-return = true  # do not require __init__ return annotation `->None` if there's at least one typed argument

--- a/qubesadmin/backup/__init__.py
+++ b/qubesadmin/backup/__init__.py
@@ -20,26 +20,29 @@
 
 '''Qubes backup'''
 import collections
+import io
+
+from qubesadmin.vm import QubesVM
 
 
 class BackupApp(object):
     '''Interface for backup collection'''
     # pylint: disable=too-few-public-methods
-    def __init__(self, qubes_xml):
+    def __init__(self, qubes_xml: str | None):
         '''Initialize BackupApp object and load qubes.xml into it'''
         self.store = qubes_xml
         self.domains = {}
         self.globals = {}
         self.load()
 
-    def load(self):
+    def load(self) -> bool | None:
         '''Load qubes.xml'''
         raise NotImplementedError
 
 class BackupVM(object):
     '''Interface for a single VM in the backup'''
     # pylint: disable=too-few-public-methods
-    def __init__(self):
+    def __init__(self) -> None:
         '''Initialize empty BackupVM object'''
         #: VM class
         self.klass = 'AppVM'
@@ -64,14 +67,14 @@ class BackupVM(object):
         self.size = 0
 
     @property
-    def included_in_backup(self):
+    def included_in_backup(self) -> bool:
         '''Report whether a VM is included in the backup'''
         return False
 
-    def handle_firewall_xml(self, vm, stream):
+    def handle_firewall_xml(self, vm: QubesVM, stream: io.BytesIO) -> None:
         '''Import appropriate format of firewall.xml'''
         raise NotImplementedError
 
-    def handle_notes_txt(self, vm, stream):
+    def handle_notes_txt(self, vm: QubesVM, stream: io.BytesIO) -> None:
         '''Import qubes notes.txt'''
         raise NotImplementedError  # pragma: no cover

--- a/qubesadmin/backup/core3.py
+++ b/qubesadmin/backup/core3.py
@@ -24,12 +24,14 @@ import xml.parsers.expat
 import logging
 import lxml.etree
 
+from lxml.etree import _Element
+
 import qubesadmin.backup
 import qubesadmin.firewall
 from qubesadmin import device_protocol
-from lxml.etree import _Element
-
 from qubesadmin.vm import QubesVM
+
+
 
 
 class Core3VM(qubesadmin.backup.BackupVM):

--- a/qubesadmin/backup/dispvm.py
+++ b/qubesadmin/backup/dispvm.py
@@ -29,14 +29,12 @@ import string
 import subprocess
 import typing
 from argparse import Namespace
-from typing import Any
 
-#import typing
 import qubesadmin
 import qubesadmin.exc
 import qubesadmin.utils
 import qubesadmin.vm
-from qubesadmin.app import QubesLocal, QubesBase
+from qubesadmin.app import QubesBase
 from qubesadmin.vm import QubesVM
 
 LOCKFILE = '/var/run/qubes/backup-paranoid-restore.lock'

--- a/qubesadmin/backup/restore.py
+++ b/qubesadmin/backup/restore.py
@@ -274,7 +274,9 @@ class BackupHeader(object):
                     continue
                 f_header.write("{!s}={!s}\n".format(key, getattr(self, attr)))
 
-def launch_proc_with_pty(args: list[str], stdin: int | None=None, stdout: int | None=None, stderr: int | None=None, echo: bool=True) -> tuple[Popen, FileIO]:
+def launch_proc_with_pty(args: list[str], stdin: int | None=None,
+                         stdout: int | None=None, stderr: int | None=None,
+                         echo: bool=True) -> tuple[Popen, FileIO]:
     """Similar to pty.fork, but handle stdin/stdout according to parameters
     instead of connecting to the pty
 
@@ -299,7 +301,8 @@ def launch_proc_with_pty(args: list[str], stdin: int | None=None, stdout: int | 
     os.close(pty_slave)
     return p, open(pty_master, 'wb+', buffering=0)
 
-def launch_scrypt(action: str, input_name: str, output_name: str, passphrase: str) -> Popen:
+def launch_scrypt(action: str, input_name: str, output_name: str,
+                  passphrase: str) -> Popen:
     '''
     Launch 'scrypt' process, pass passphrase to it and return
     subprocess.Popen object.
@@ -356,10 +359,13 @@ def _fix_threading_after_fork() -> None:
 class ExtractWorker3(Process):
     '''Process for handling inner tar layer of backup archive'''
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, queue: Queue, base_dir: str, passphrase: str, encrypted: bool, *,
+    def __init__(self, queue: Queue, base_dir: str, passphrase: str,
+                 encrypted: bool, *,
                  progress_callback: Callable, vmproc: Popen | None =None,
-                 compressed: bool=False, crypto_algorithm: str=DEFAULT_CRYPTO_ALGORITHM,
-                 compression_filter: str | None=None, verify_only: bool=False, handlers: dict[str, Callable] | None=None):
+                 compressed: bool=False,
+                 crypto_algorithm: str=DEFAULT_CRYPTO_ALGORITHM,
+                 compression_filter: str | None=None, verify_only: bool=False,
+                 handlers: dict[str, Callable] | None=None):
         '''Start inner tar extraction worker
 
         The purpose of this class is to process files extracted from outer
@@ -538,7 +544,9 @@ class ExtractWorker3(Process):
             self.tar2_current_file = None
         self.tar2_process = None
 
-    def _data_import_wrapper(self, close_fds: Iterable[int], data_func: Callable[..., T], tar2_process: Popen) -> T:
+    def _data_import_wrapper(self, close_fds: Iterable[int],
+                             data_func: Callable[..., T],
+                             tar2_process: Popen) -> T:
         '''Close not needed file descriptors, handle output size reported
         by tar (if needed) then call data_func(tar2_process.stdout).
 
@@ -598,7 +606,8 @@ class ExtractWorker3(Process):
         self.tar2_feeder = subprocess.Popen(['cat', filename],
             stdout=input_pipe)
 
-    def check_processes(self, processes: dict[str, None | Process | Popen]) -> None:
+    def check_processes(self,
+                        processes:dict[str, None | Process | Popen]) -> None:
         '''Check if any process failed.
 
         And if so, wait for other relevant processes to cleanup.
@@ -795,7 +804,8 @@ class ExtractWorker3(Process):
         self.log.debug('Finished extracting thread')
 
 
-def get_supported_hmac_algo(hmac_algorithm: str | None=None) -> Generator[str, None, None]:
+def get_supported_hmac_algo(hmac_algorithm: str | None=None)\
+        -> Generator[str, None, None]:
     '''Generate a list of supported hmac algorithms
 
     :param hmac_algorithm: default algorithm, if given, it is placed as a
@@ -819,7 +829,8 @@ def get_supported_hmac_algo(hmac_algorithm: str | None=None) -> Generator[str, N
             yield algo.strip().lower()
 
 
-def get_supported_crypto_algo(crypto_algorithm: str | None=None) -> Generator[str, None, None]:
+def get_supported_crypto_algo(crypto_algorithm: str | None=None)\
+        -> Generator[str, None, None]:
     '''Generate a list of supported hmac algorithms
 
     :param crypto_algorithm: default algorithm, if given, it is placed as a
@@ -931,8 +942,10 @@ class BackupRestore(object):
                 self.subdir = subdir
                 self.username = os.path.basename(subdir)
 
-    def __init__(self, app: QubesBase, backup_location: str, backup_vm: QubesVM, passphrase: str, *,
-                 location_is_service: bool=False, force_compression_filter: str | None=None,
+    def __init__(self, app: QubesBase, backup_location: str,
+                 backup_vm: QubesVM, passphrase: str, *,
+                 location_is_service: bool=False,
+                 force_compression_filter: str | None=None,
                  tmpdir: str | None=None):
         super().__init__()
 
@@ -1000,7 +1013,9 @@ class BackupRestore(object):
             if os.path.exists(self.tmpdir):
                 shutil.rmtree(self.tmpdir)
 
-    def _start_retrieval_process(self, filelist: list[str], limit_count: int | str, limit_bytes: int) -> tuple[Popen, IO, IO]:
+    def _start_retrieval_process(self, filelist: list[str],
+                                 limit_count: int | str,
+                                 limit_bytes: int) -> tuple[Popen, IO, IO]:
         """Retrieve backup stream and extract it to :py:attr:`tmpdir`
 
         :param filelist: list of files to extract; listing directory name
@@ -1089,7 +1104,8 @@ class BackupRestore(object):
             error_pipe = typing.cast(IO, command.stderr)
         return command, filelist_pipe, error_pipe
 
-    def _verify_hmac(self, filename: str, hmacfile: str, algorithm: str | None=None) -> bool:
+    def _verify_hmac(self, filename: str, hmacfile: str,
+                     algorithm: str | None=None) -> bool:
         '''Verify hmac of a file using given algorithm.
 
         If algorithm is not specified, use the one from backup header (
@@ -1176,7 +1192,8 @@ class BackupRestore(object):
             "Is the passphrase correct?".
             format(filename, load_hmac(hmac_stdout.decode('ascii'))))
 
-    def _verify_and_decrypt(self, filename: str, output: str | None=None) -> str:
+    def _verify_and_decrypt(self, filename: str,
+                            output: str | None=None) -> str:
         '''Handle scrypt-wrapped file
 
         Decrypt the file, and verify its integrity - both tasks handled by
@@ -1221,7 +1238,9 @@ class BackupRestore(object):
         os.unlink(fullname)
         return origname
 
-    def _retrieve_backup_header_files(self, files: list[str], allow_none: bool=False) -> list[str] | None:
+    def _retrieve_backup_header_files(self, files: list[str],
+                                      allow_none: bool=False)\
+            -> list[str] | None:
         '''Retrieve backup header.
 
         Start retrieval process (possibly involving network access from
@@ -1336,7 +1355,9 @@ class BackupRestore(object):
 
         return header_data
 
-    def _start_inner_extraction_worker(self, queue: Queue, handlers: dict[str, Callable]) -> ExtractWorker3:
+    def _start_inner_extraction_worker(self, queue: Queue,
+                                       handlers: dict[str, Callable])\
+            -> ExtractWorker3:
         """Start a worker process, extracting inner layer of bacup archive,
         extract them to :py:attr:`tmpdir`.
         End the data by pushing QUEUE_FINISHED or QUEUE_ERROR to the queue.
@@ -1423,7 +1444,8 @@ class BackupRestore(object):
         os.unlink(qubes_xml_path)
         return backup_app
 
-    def _restore_vm_data(self, vms_dirs: list[str], vms_size: int, handlers: dict[str, Callable]) -> None:
+    def _restore_vm_data(self, vms_dirs: list[str], vms_size: int,
+                         handlers: dict[str, Callable]) -> None:
         '''Restore data of VMs
 
         :param vms_dirs: list of directories to extract (skip others)
@@ -1591,7 +1613,8 @@ class BackupRestore(object):
                 "unable to extract the qubes backup. "
                 "Check extracting process errors.")
 
-    def new_name_for_conflicting_vm(self, orig_name: str, restore_info: dict) -> str | None:
+    def new_name_for_conflicting_vm(self, orig_name: str,
+                                    restore_info: dict) -> str | None:
         '''Generate new name for conflicting VM
 
         Add a number suffix, until the name is unique. If no unique name can
@@ -1906,7 +1929,9 @@ class BackupRestore(object):
             self.log.error(
                 'Failed to set application list for %s: %s', vm.name, e)
 
-    def _handle_volume_data(self, vm: QubesVM, volume: Volume, stream: BytesIO, *, file_size: int | None=None) -> None:
+    def _handle_volume_data(self, vm: QubesVM, volume: Volume,
+                            stream: BytesIO, *, file_size: int | None=None)\
+            -> None:
         '''Wrap volume data import with logging'''
         try:
             if file_size is None:
@@ -2011,7 +2036,8 @@ class BackupRestore(object):
             self.log.info("-> Please install updates for all the restored "
                           "templates.")
 
-    def _restore_property(self, vm: QubesVM, prop: str, value: typing.Any) -> None:  # noqa: ANN401
+    def _restore_property(self, vm: QubesVM, prop: str,
+                          value: typing.Any) -> None:  # noqa: ANN401
         '''Restore a single VM property, logging exceptions'''
         try:
             setattr(vm, prop, value)


### PR DESCRIPTION
This PR should in principle add no functional changes.

The vast majority of changes are pure typing.
The rest are small refactors to help typing checkers, typically:
- explicitely indicating that `Popen` has `stdin/out`: `p.stderr` -> `typing.cast(IO, p.stderr)`
- using getattr / setattr on unexpected field accessions rather than `object.field`
- splitting variables when types are mixed and type checks complain
```python
# before
a: byte = some_value()
a = a.decode()  # a: str
f(a)
# after
a = some_value
a_str = a.decode()
f(a_str)
```
- etc...

Note: as noted in `pyproject.toml` this bumps the minimum python version to `3.10`.
Note: running a type checker on this code reveals many errors and warnings. After manual review, most of those errors are either 1) complex logic where the type checker is not able to reduce type unions (=> can be fixed by e.g. `assert var is not None`, but I want to keep that in a separate PR since that may add some functional changes or 2) what i believe to be actual errors in the code, e.g. value that actually can be None where they shouldn't be. Same, I'll keep that for a separate PR.

----

Some additional info concerning the type checking environment:

I use a combination of [ty](https://docs.astral.sh/ty/) and [ruff](https://docs.astral.sh/ruff/).

As written in `pyproject.toml`:
- `ruff` enforces that everything in `backup/` is type-checked (`select = ["ANN", "RUF045"]`), except for `**kwargs` (`select = ["ANN", "RUF045"]`) and `__init__` returns (`mypy-init-return = true`)
- `ty` is the actual type checker, with all the default rules

Note that `ANN` also enforces that by default `typing.Any` is forbidden, unless explicitly ignored `# noqa: ANN401`