### PR TITLE
Enforce `is not None` for `core2.py`, fix type checker errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ https://www.qubes-os.org/doc/admin-api/ for protocol specification.
 Compatibility
 =============
 
-This package requires Python >= 3.5
+This package requires Python >= 3.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ current-dev = [  # dev-depencencies
     "pylint>=4.0.4",
     "mock>=5.2.0",
     "docutils>=0.22.4",
-    "sphinx>=9.1.0",
+    "sphinx>=3.5.3",
     "setuptools>=82.0.0",
     "black>=26.1.0",
     "mypy>=1.19.1",
@@ -29,9 +29,11 @@ future-dev = [  # those tools are very efficient but not packaged for major dist
 
 [tool.ruff]
 preview = true
+line-length = 80
 
 [tool.ruff.lint]
-select = ["ANN", "RUF045"]  # Require type annotations for every function
+select = ["ANN", "RUF045", # Require type annotations for every function
+            "E501"]  # line-too-long
 ignore = ["ANN003"]  # type annotation for **kwargs
 
 [tool.ruff.lint.flake8-annotations]

--- a/qubesadmin/backup/__init__.py
+++ b/qubesadmin/backup/__init__.py
@@ -28,14 +28,14 @@ from qubesadmin.vm import QubesVM
 class BackupApp(object):
     '''Interface for backup collection'''
     # pylint: disable=too-few-public-methods
-    def __init__(self, qubes_xml: str | None):
+    def __init__(self, qubes_xml: str):
         '''Initialize BackupApp object and load qubes.xml into it'''
         self.store = qubes_xml
         self.domains = {}
         self.globals = {}
         self.load()
 
-    def load(self) -> bool | None:
+    def load(self) -> None:
         '''Load qubes.xml'''
         raise NotImplementedError
 

--- a/qubesadmin/backup/core2.py
+++ b/qubesadmin/backup/core2.py
@@ -354,16 +354,16 @@ class Core2Qubes(qubesadmin.backup.BackupApp):
             options['required'] = True
             vm.devices['pci'][('dom0', port_id)] = options
 
-    def load(self) -> bool | None:
+    def load(self) -> None:
         assert self.store is not None
         with open(self.store, encoding='utf-8') as fh:
             try:
                 # pylint: disable=no-member
                 tree = lxml.etree.parse(fh)
-            except (EnvironmentError,  # pylint: disable=broad-except
+            except (EnvironmentError,
                     xml.parsers.expat.ExpatError) as err:
                 self.log.error(err)
-                return False
+                raise err
 
         self.globals['default_kernel'] = tree.getroot().get("default_kernel")
 

--- a/qubesadmin/backup/core2.py
+++ b/qubesadmin/backup/core2.py
@@ -185,6 +185,7 @@ class Core2Qubes(qubesadmin.backup.BackupApp):
                 if clockvm != "None" else None
 
         default_template = element.get("default_template")
+        assert default_template is not None
         self.globals['default_template'] = self.qid_map[int(default_template)] \
             if default_template.lower() != "none" else None
 
@@ -265,14 +266,17 @@ class Core2Qubes(qubesadmin.backup.BackupApp):
         elif element.get('qid') == '0':
             kwargs['dir_path'] = element.get('dir_path')
             vm.klass = "AdminVM"
-        elif element.get('template_qid').lower() == "none":
-            kwargs['dir_path'] = element.get('dir_path')
-            vm.klass = "StandaloneVM"
         else:
-            kwargs['dir_path'] = element.get('dir_path')
-            vm.template = \
-                self.qid_map[int(element.get('template_qid'))]
-            vm.klass = "AppVM"
+            template_qid = element.get('template_qid')
+            assert template_qid is not None
+            if template_qid.lower() == "none":
+                kwargs['dir_path'] = element.get('dir_path')
+                vm.klass = "StandaloneVM"
+            else:
+                kwargs['dir_path'] = element.get('dir_path')
+                vm.template = \
+                    self.qid_map[int(template_qid)]
+                vm.klass = "AppVM"
 
         vm.backup_content = element.get('backup_content', False) == 'True'
         vm.backup_path = element.get('backup_path', None)
@@ -341,15 +345,17 @@ class Core2Qubes(qubesadmin.backup.BackupApp):
 
         pci_strictreset = element.get('pci_strictreset', True)
         pcidevs = element.get('pcidevs')
+        pcidevs_list = []
         if pcidevs:
-            pcidevs = ast.literal_eval(pcidevs)
-        for pcidev in pcidevs:
+            pcidevs_list = ast.literal_eval(pcidevs)
+        for pcidev in pcidevs_list:
             port_id = pcidev.replace(':', '_')
             options = {'no-strict-reset': True} if not pci_strictreset else {}
             options['required'] = True
             vm.devices['pci'][('dom0', port_id)] = options
 
     def load(self) -> bool | None:
+        assert self.store is not None
         with open(self.store, encoding='utf-8') as fh:
             try:
                 # pylint: disable=no-member

--- a/qubesadmin/backup/core3.py
+++ b/qubesadmin/backup/core3.py
@@ -160,15 +160,15 @@ class Core3Qubes(qubesadmin.backup.BackupApp):
 
         self.domains[vm.name] = vm
 
-    def load(self) -> bool | None:
+    def load(self) -> None:
         with open(self.store, encoding='utf-8') as fh:
             try:
                 # pylint: disable=no-member
                 tree = lxml.etree.parse(fh)
-            except (EnvironmentError,  # pylint: disable=broad-except
+            except (EnvironmentError,
                     xml.parsers.expat.ExpatError) as err:
                 self.log.error(err)
-                return False
+                raise err
 
         self.load_labels(tree.find('./labels'))
 

--- a/qubesadmin/backup/restore.py
+++ b/qubesadmin/backup/restore.py
@@ -1139,6 +1139,8 @@ class BackupRestore(object):
             return hmac_text
         if algorithm is None:
             algorithm = self.header_data.hmac_algorithm
+        assert algorithm is not None
+
         passphrase = self.passphrase.encode('utf-8')
         self.log.debug("Verifying file %s", filename)
 


### PR DESCRIPTION
Follow-up of #412 

This is a very small PR, since it is not clear to me how the maintainers want to proceed (=resolve the choices below) on this kind of work. I'm hoping this will give me a clearer view.


# Changes

## L188

No XML validation is performed whatsoever. As it stands, the code will crash if `default_template` is not defined. Even though *currently* this may not cause a crash, it's likely to produce one down the line if we change what we store in the xml.

Two options to fix it:
* enforce that it's not None `assert default_template is not None`. This is functionally equivalent to the current code, and "fixes" the type checker error, but will still throw an Exception.
* add a fallback `element.get("default_template", "none")`

I chose option 1 here for no good reason - this is not something I can decide myself.

## L270

Likewise, code will crash if `element.get('template_qid')` is not defined.

Same question regarding the resolution. Chose option 2 just to showcase it.

## L349

old code:
```python
        pcidevs = element.get('pcidevs')
        if pcidevs:
            pcidevs = ast.literal_eval(pcidevs)
        for pcidev in pcidevs:
```

this will trivially error if `pcidevs` is not in the XML. Proposed solution is to fallback to `[]`.

## L361

Will trivially fail if `self.store` is not defined

# Remaining errors

`uv run ruff check qubesadmin/backup/core2.py && uv run ty check qubesadmin/backup/core2.py` raises two remaining errors. Those errors are du to missing type hints in other files, and will be fixed down the line.