### PR TITLE
Remove obsolete python 2.x `object` inheritance in classes

### DIFF
--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -49,7 +49,7 @@ except ImportError:
     has_qubesdb = False
 
 
-class VMCollection(object):
+class VMCollection:
     """Collection of VMs objects"""
 
     def __init__(self, app):

--- a/qubesadmin/backup/__init__.py
+++ b/qubesadmin/backup/__init__.py
@@ -22,7 +22,7 @@
 import collections
 
 
-class BackupApp(object):
+class BackupApp:
     '''Interface for backup collection'''
     # pylint: disable=too-few-public-methods
     def __init__(self, qubes_xml):
@@ -36,7 +36,7 @@ class BackupApp(object):
         '''Load qubes.xml'''
         raise NotImplementedError
 
-class BackupVM(object):
+class BackupVM:
     '''Interface for a single VM in the backup'''
     # pylint: disable=too-few-public-methods
     def __init__(self):

--- a/qubesadmin/backup/restore.py
+++ b/qubesadmin/backup/restore.py
@@ -114,7 +114,7 @@ def validate_compression_filter(compressor: str):
         return True
     return False
 
-class BackupHeader(object):
+class BackupHeader:
     '''Structure describing backup-header file included as the first file in
     backup archive
     '''
@@ -833,7 +833,7 @@ def get_supported_crypto_algo(crypto_algorithm=None):
             yield algo.strip().lower()
 
 
-class BackupRestoreOptions(object):
+class BackupRestoreOptions:
     '''Options for restore operation'''
     # pylint: disable=too-few-public-methods
     def __init__(self):
@@ -865,7 +865,7 @@ class BackupRestoreOptions(object):
         #: ignore size limit calculated from backup metadata
         self.ignore_size_limit = False
 
-class BackupRestore(object):
+class BackupRestore:
     """Usage:
 
     >>> restore_op = BackupRestore(...)
@@ -875,7 +875,7 @@ class BackupRestore(object):
     >>> restore_op.restore_do(restore_info)
     """
 
-    class VMToRestore(object):
+    class VMToRestore:
         '''Information about a single VM to be restored'''
         # pylint: disable=too-few-public-methods
         #: VM excluded from restore by user

--- a/qubesadmin/base.py
+++ b/qubesadmin/base.py
@@ -25,7 +25,7 @@ import qubesadmin.exc
 DEFAULT = object()
 
 
-class PropertyHolder(object):
+class PropertyHolder:
     '''A base class for object having properties retrievable using mgmt API.
 
     Warning: each (non-private) local attribute needs to be defined at class
@@ -406,7 +406,7 @@ class PropertyHolder(object):
             raise qubesadmin.exc.QubesPropertyAccessError(name)
 
 
-class WrapperObjectsCollection(object):
+class WrapperObjectsCollection:
     '''Collection of simple named objects'''
     def __init__(self, app, list_method, object_class):
         '''

--- a/qubesadmin/events/__init__.py
+++ b/qubesadmin/events/__init__.py
@@ -29,7 +29,7 @@ import qubesadmin.exc
 from qubesadmin.device_protocol import VirtualDevice, Port, UnknownDevice
 
 
-class EventsDispatcher(object):
+class EventsDispatcher:
     ''' Events dispatcher, responsible for receiving events and calling
     appropriate handlers'''
     def __init__(self, app, api_method='admin.Events', enable_cache=True):

--- a/qubesadmin/features.py
+++ b/qubesadmin/features.py
@@ -21,7 +21,7 @@
 '''VM features interface'''
 
 
-class Features(object):
+class Features:
     '''Manager of the features.
 
     Features can have three distinct values: no value (not present in mapping,

--- a/qubesadmin/firewall.py
+++ b/qubesadmin/firewall.py
@@ -26,7 +26,7 @@ import socket
 import string
 
 
-class RuleOption(object):
+class RuleOption:
     '''Base class for a single rule element'''
     def __init__(self, value):
         self._value = str(value)
@@ -241,7 +241,7 @@ class Comment(RuleOption):
         return 'comment=' + str(self)
 
 
-class Rule(object):
+class Rule:
     '''A single firewall rule'''
 
     def __init__(self, rule, **kwargs):
@@ -411,7 +411,7 @@ class Rule(object):
         return 'Rule(\'{}\')'.format(self.rule)
 
 
-class Firewall(object):
+class Firewall:
     '''Firewal manager for a VM'''
     def __init__(self, vm):
         self.vm = vm

--- a/qubesadmin/label.py
+++ b/qubesadmin/label.py
@@ -23,7 +23,7 @@
 import qubesadmin.exc
 
 
-class Label(object):
+class Label:
     '''Label definition for virtual machines
 
     Label specifies colour of the qube icon displayed next to VM's name.

--- a/qubesadmin/spinner.py
+++ b/qubesadmin/spinner.py
@@ -43,7 +43,7 @@ import itertools
 CHARSET = '-\\|/'
 ENTERPRISE_CHARSET = CHARSET * 4 + '-._.-^' * 2
 
-class AbstractSpinner(object):
+class AbstractSpinner:
     '''The base class for all Spinners
 
     :param stream: file-like object with ``.write()`` method

--- a/qubesadmin/storage.py
+++ b/qubesadmin/storage.py
@@ -22,7 +22,7 @@
 import qubesadmin.exc
 
 
-class Volume(object):
+class Volume:
     """Storage volume."""
     def __init__(self, app, pool=None, vid=None, vm=None, vm_name=None):
         """Construct a Volume object.
@@ -305,7 +305,7 @@ class Volume(object):
         self._qubesd_call('CloneTo', payload=token)
 
 
-class Pool(object):
+class Pool:
     """ A Pool is used to manage different kind of volumes (File
         based/LVM/Btrfs/...).
     """

--- a/qubesadmin/tags.py
+++ b/qubesadmin/tags.py
@@ -21,7 +21,7 @@
 '''VM tags interface'''
 
 
-class Tags(object):
+class Tags:
     '''Manager of the tags.
 
     Tags are simple: tag either can be present on qube or not. Tag is a

--- a/qubesadmin/tests/__init__.py
+++ b/qubesadmin/tests/__init__.py
@@ -32,7 +32,7 @@ import qubesadmin.app
 
 QREXEC_ALLOWED_CHARS = string.ascii_letters + string.digits + "_-+."
 
-class TestVM(object):
+class TestVM:
     def __init__(self, name, **kwargs):
         self.name = name
         self.klass = 'TestVM'
@@ -61,7 +61,7 @@ class TestVMCollection(dict):
     get_blind = dict.get
 
 
-class TestProcess(object):
+class TestProcess:
     def __init__(self, input_callback=None, stdout=None, stderr=None,
             stdout_data=None):
         self.input_callback = input_callback
@@ -114,7 +114,7 @@ class TestProcess(object):
         return self.returncode
 
 
-class _AssertNotRaisesContext(object):
+class _AssertNotRaisesContext:
     """A context manager used to implement TestCase.assertNotRaises methods.
 
     Stolen from unittest and hacked. Regexp support stripped.

--- a/qubesadmin/tests/backup/backupcompatibility.py
+++ b/qubesadmin/tests/backup/backupcompatibility.py
@@ -778,7 +778,7 @@ class TC_00_QubesXML(qubesadmin.tests.QubesTestCase):
         self.assertCorrectlyConverted(backup_app, parsed_qubes_xml_v4)
 
 # backup code use multiprocessing, synchronize with main process
-class AppProxy(object):
+class AppProxy:
     def __init__(self, app, sync_queue, delay_stream=0):
         self._app = app
         self._sync_queue = sync_queue

--- a/qubesadmin/tests/tools/__init__.py
+++ b/qubesadmin/tests/tools/__init__.py
@@ -26,7 +26,7 @@ import sys
 import asyncio
 
 
-class StdoutBuffer(object):
+class StdoutBuffer:
     def __init__(self):
         self.orig_stdout = None
         if sys.version_info[0] >= 3:
@@ -44,7 +44,7 @@ class StdoutBuffer(object):
         return False
 
 
-class StderrBuffer(object):
+class StderrBuffer:
     def __init__(self):
         self.orig_stderr = None
         if sys.version_info[0] >= 3:
@@ -61,7 +61,7 @@ class StderrBuffer(object):
         sys.stderr = self.orig_stderr
         return False
 
-class MockEventsReader(object):
+class MockEventsReader:
     def __init__(self, events, delay=0.05):
         self.events = events
         self.delay = delay

--- a/qubesadmin/tests/tools/qvm_ls.py
+++ b/qubesadmin/tests/tools/qvm_ls.py
@@ -33,7 +33,7 @@ import qubesadmin.tests.tools
 from qubesadmin.tests import TestVM, TestVMCollection
 
 
-class TestApp(object):
+class TestApp:
     def __init__(self):
         self.domains = TestVMCollection(
             [

--- a/qubesadmin/tools/qvm_ls.py
+++ b/qubesadmin/tools/qvm_ls.py
@@ -44,7 +44,7 @@ import qubesadmin.exc
 # columns
 #
 
-class Column(object):
+class Column:
     '''A column in qvm-ls output characterised by its head and a way
     to fetch a parameter describing the domain.
 
@@ -397,7 +397,7 @@ SORT_NUMERIC = ['MEMORY', 'DISK', 'PRIV-CURR', 'PRIV-MAX', 'ROOT-CURR', 'XID', \
                 'ROOT-MAX', 'MAXMEM', 'QREXEC-TIMEOUT', 'SHUTDOWN-TIMEOUT', \
                 'VCPUS', 'PRIV-USED', 'ROOT-USED']
 
-class Table(object):
+class Table:
     '''Table that is displayed to the user.
 
     :param domains: Domains to include in the table.

--- a/qubesadmin/tools/qvm_volume.py
+++ b/qubesadmin/tools/qvm_volume.py
@@ -68,7 +68,7 @@ def prepare_table(vd_list, full=False):
     return output
 
 
-class VolumeData(object):
+class VolumeData:
     """ Wrapper object around :py:class:`qubes.storage.Volume`, mainly to track
         the domains a volume is attached to.
     """

--- a/qubesadmin/utils.py
+++ b/qubesadmin/utils.py
@@ -184,7 +184,7 @@ def encode_for_vmexec(args):
         parts.append(part)
     return b'+'.join(parts).decode('ascii')
 
-class LockFile(object):
+class LockFile:
     """Simple locking context manager. It opens a file with an advisory lock
     taken (fcntl.lockf)"""
     def __init__(self, path, nonblock=False):

--- a/test-packages/dbus.py
+++ b/test-packages/dbus.py
@@ -1,8 +1,8 @@
 class DBusException(Exception):
     pass
 
-class SystemBus(object):
+class SystemBus:
     pass
 
-class SessionBus(object):
+class SessionBus:
     pass


### PR DESCRIPTION
As indicated in the title:

```python
# before
def class(object):
   ...
# after
def class():
   ...
```

Inheriting from `object` does not have any use in python3 afaik.