### PR TITLE
Fix/enforce typing errors / inconsistencies in `backup/`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ https://www.qubes-os.org/doc/admin-api/ for protocol specification.
 Compatibility
 =============
 
-This package requires Python >= 3.5
+This package requires Python >= 3.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ current-dev = [  # dev-depencencies
     "pylint>=4.0.4",
     "mock>=5.2.0",
     "docutils>=0.22.4",
-    "sphinx>=9.1.0",
+    "sphinx>=3.5.3",
     "setuptools>=82.0.0",
     "black>=26.1.0",
     "mypy>=1.19.1",
@@ -29,9 +29,11 @@ future-dev = [  # those tools are very efficient but not packaged for major dist
 
 [tool.ruff]
 preview = true
+line-length = 80
 
 [tool.ruff.lint]
-select = ["ANN", "RUF045"]  # Require type annotations for every function
+select = ["ANN", "RUF045", # Require type annotations for every function
+            "E501"]  # line-too-long
 ignore = ["ANN003"]  # type annotation for **kwargs
 
 [tool.ruff.lint.flake8-annotations]

--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -31,6 +31,7 @@ import subprocess
 import sys
 
 import logging
+from logging import Logger
 
 import qubesadmin.base
 import qubesadmin.exc
@@ -40,6 +41,7 @@ import qubesadmin.utils
 import qubesadmin.vm
 import qubesadmin.config
 import qubesadmin.device_protocol
+from qubesadmin.vm import QubesVM
 
 try:
     import qubesdb
@@ -101,14 +103,14 @@ class VMCollection(object):
                 self._vm_objects[vm.name] = vm
                 del self._vm_objects[name]
 
-    def __getitem__(self, item):
-        if isinstance(item, qubesadmin.vm.QubesVM):
+    def __getitem__(self, item: str | QubesVM) -> QubesVM:
+        if isinstance(item, QubesVM):
             item = item.name
         if not self.app.blind_mode and item not in self:
             raise KeyError(item)
         return self.get_blind(item)
 
-    def get_blind(self, item):
+    def get_blind(self, item: str) -> QubesVM:
         """
         Get a vm without downloading the list
         and checking if exists
@@ -128,7 +130,7 @@ class VMCollection(object):
             )
         return self._vm_objects[item]
 
-    def get(self, item, default=None):
+    def get(self, item, default=None) -> QubesVM:
         """
         Get a VM object, or return *default* if it can't be found.
         """
@@ -172,19 +174,20 @@ class QubesBase(qubesadmin.base.PropertyHolder):
     """
 
     #: domains (VMs) collection
-    domains = None
+    domains: VMCollection
     #: labels collection
-    labels = None
+    labels: qubesadmin.base.WrapperObjectsCollection
     #: storage pools
-    pools = None
+    pools: qubesadmin.base.WrapperObjectsCollection
     #: type of qubesd connection: either 'socket' or 'qrexec'
-    qubesd_connection_type = None
+    qubesd_connection_type: str | None = None  # See in PR#416 why we keep
+                                        # =None here to not trip the CI
     #: logger
-    log = None
+    log: Logger
     #: do not check for object (VM, label etc) existence before really needed
-    blind_mode = False
+    blind_mode: bool = False
     #: cache retrieved properties values
-    cache_enabled = False
+    cache_enabled: bool = False
 
     def __init__(self):
         super().__init__(self, "admin.property.", "dom0")

--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -173,6 +173,7 @@ class QubesBase(qubesadmin.base.PropertyHolder):
     :py:class:`QubesLocal` or :py:class:`QubesRemote`.
     """
 
+    # Below: local-only properties (see PropertyHolder._local_properties)
     #: domains (VMs) collection
     domains: VMCollection
     #: labels collection

--- a/qubesadmin/backup/__init__.py
+++ b/qubesadmin/backup/__init__.py
@@ -28,14 +28,14 @@ from qubesadmin.vm import QubesVM
 class BackupApp(object):
     '''Interface for backup collection'''
     # pylint: disable=too-few-public-methods
-    def __init__(self, qubes_xml: str | None):
+    def __init__(self, qubes_xml: str):
         '''Initialize BackupApp object and load qubes.xml into it'''
         self.store = qubes_xml
         self.domains = {}
         self.globals = {}
         self.load()
 
-    def load(self) -> bool | None:
+    def load(self) -> None:
         '''Load qubes.xml'''
         raise NotImplementedError
 

--- a/qubesadmin/backup/core2.py
+++ b/qubesadmin/backup/core2.py
@@ -354,16 +354,16 @@ class Core2Qubes(qubesadmin.backup.BackupApp):
             options['required'] = True
             vm.devices['pci'][('dom0', port_id)] = options
 
-    def load(self) -> bool | None:
+    def load(self) -> None:
         assert self.store is not None
         with open(self.store, encoding='utf-8') as fh:
             try:
                 # pylint: disable=no-member
                 tree = lxml.etree.parse(fh)
-            except (EnvironmentError,  # pylint: disable=broad-except
+            except (EnvironmentError,
                     xml.parsers.expat.ExpatError) as err:
                 self.log.error(err)
-                return False
+                raise err
 
         self.globals['default_kernel'] = tree.getroot().get("default_kernel")
 

--- a/qubesadmin/backup/core2.py
+++ b/qubesadmin/backup/core2.py
@@ -185,6 +185,7 @@ class Core2Qubes(qubesadmin.backup.BackupApp):
                 if clockvm != "None" else None
 
         default_template = element.get("default_template")
+        assert default_template is not None
         self.globals['default_template'] = self.qid_map[int(default_template)] \
             if default_template.lower() != "none" else None
 
@@ -265,14 +266,17 @@ class Core2Qubes(qubesadmin.backup.BackupApp):
         elif element.get('qid') == '0':
             kwargs['dir_path'] = element.get('dir_path')
             vm.klass = "AdminVM"
-        elif element.get('template_qid').lower() == "none":
-            kwargs['dir_path'] = element.get('dir_path')
-            vm.klass = "StandaloneVM"
         else:
-            kwargs['dir_path'] = element.get('dir_path')
-            vm.template = \
-                self.qid_map[int(element.get('template_qid'))]
-            vm.klass = "AppVM"
+            template_qid = element.get('template_qid')
+            assert template_qid is not None
+            if template_qid.lower() == "none":
+                kwargs['dir_path'] = element.get('dir_path')
+                vm.klass = "StandaloneVM"
+            else:
+                kwargs['dir_path'] = element.get('dir_path')
+                vm.template = \
+                    self.qid_map[int(template_qid)]
+                vm.klass = "AppVM"
 
         vm.backup_content = element.get('backup_content', False) == 'True'
         vm.backup_path = element.get('backup_path', None)
@@ -341,15 +345,17 @@ class Core2Qubes(qubesadmin.backup.BackupApp):
 
         pci_strictreset = element.get('pci_strictreset', True)
         pcidevs = element.get('pcidevs')
+        pcidevs_list = []
         if pcidevs:
-            pcidevs = ast.literal_eval(pcidevs)
-        for pcidev in pcidevs:
+            pcidevs_list = ast.literal_eval(pcidevs)
+        for pcidev in pcidevs_list:
             port_id = pcidev.replace(':', '_')
             options = {'no-strict-reset': True} if not pci_strictreset else {}
             options['required'] = True
             vm.devices['pci'][('dom0', port_id)] = options
 
     def load(self) -> bool | None:
+        assert self.store is not None
         with open(self.store, encoding='utf-8') as fh:
             try:
                 # pylint: disable=no-member

--- a/qubesadmin/backup/core3.py
+++ b/qubesadmin/backup/core3.py
@@ -170,10 +170,14 @@ class Core3Qubes(qubesadmin.backup.BackupApp):
                 self.log.error(err)
                 raise err
 
-        self.load_labels(tree.find('./labels'))
+        labels = tree.find('./labels')
+        assert labels is not None
+        self.load_labels(labels)
 
         for element in tree.findall('./domains/domain'):
             self.import_core3_vm(element)
 
         # and load other defaults (default netvm, updatevm etc)
-        self.load_globals(tree.find('./properties'))
+        properties = tree.find('./properties')
+        assert properties is not None
+        self.load_globals(properties)

--- a/qubesadmin/backup/core3.py
+++ b/qubesadmin/backup/core3.py
@@ -160,15 +160,15 @@ class Core3Qubes(qubesadmin.backup.BackupApp):
 
         self.domains[vm.name] = vm
 
-    def load(self) -> bool | None:
+    def load(self) -> None:
         with open(self.store, encoding='utf-8') as fh:
             try:
                 # pylint: disable=no-member
                 tree = lxml.etree.parse(fh)
-            except (EnvironmentError,  # pylint: disable=broad-except
+            except (EnvironmentError,
                     xml.parsers.expat.ExpatError) as err:
                 self.log.error(err)
-                return False
+                raise err
 
         self.load_labels(tree.find('./labels'))
 

--- a/qubesadmin/backup/restore.py
+++ b/qubesadmin/backup/restore.py
@@ -1139,6 +1139,8 @@ class BackupRestore(object):
             return hmac_text
         if algorithm is None:
             algorithm = self.header_data.hmac_algorithm
+        assert algorithm is not None
+
         passphrase = self.passphrase.encode('utf-8')
         self.log.debug("Verifying file %s", filename)
 

--- a/qubesadmin/backup/restore.py
+++ b/qubesadmin/backup/restore.py
@@ -521,8 +521,8 @@ class ExtractWorker3(Process):
             return
         if terminate:
             if self.import_process is not None:
-                self.tar2_process.terminate()
                 self.import_process.terminate()
+            self.tar2_process.terminate()
         if wait:
             self.tar2_process.wait()
             if self.import_process is not None:

--- a/qubesadmin/backup/restore.py
+++ b/qubesadmin/backup/restore.py
@@ -180,6 +180,7 @@ class BackupHeader(object):
 
         if header_data is not None:
             self.load(header_data)
+        self.validate()
 
     def load(self, untrusted_header_text: bytes) -> None:
         """Parse backup header file.
@@ -236,8 +237,6 @@ class BackupHeader(object):
                             f=value))
                 raise QubesException("Invalid value for header: {}".format(key))
             setattr(self, header.field, value)
-
-        self.validate()
 
     def validate(self) -> None:
         '''Validate header data, according to header version'''

--- a/qubesadmin/backup/restore.py
+++ b/qubesadmin/backup/restore.py
@@ -361,9 +361,9 @@ class ExtractWorker3(Process):
     # pylint: disable=too-many-instance-attributes
     def __init__(self, queue: Queue, base_dir: str, passphrase: str,
                  encrypted: bool, *,
-                 progress_callback: Callable, vmproc: Popen | None =None,
+                 progress_callback: Callable | None, vmproc: Popen | None =None,
                  compressed: bool=False,
-                 crypto_algorithm: str=DEFAULT_CRYPTO_ALGORITHM,
+                 crypto_algorithm: str | None=DEFAULT_CRYPTO_ALGORITHM,
                  compression_filter: str | None=None, verify_only: bool=False,
                  handlers: dict[str, Callable] | None=None):
         '''Start inner tar extraction worker
@@ -391,6 +391,9 @@ class ExtractWorker3(Process):
         :param bool verify_only: only verify data integrity, do not extract
         :param dict handlers: handlers for actual data
         '''
+        if encrypted:
+            assert crypto_algorithm is not None
+
         super().__init__()
         #: queue with files to extract
         self.queue = queue
@@ -444,6 +447,8 @@ class ExtractWorker3(Process):
         Log errors, process file size if requested.
         This use :py:attr:`tar2_process`.
         '''
+        assert self.tar2_process is not None
+
         if not self.tar2_process.stderr:
             return
 
@@ -489,6 +494,7 @@ class ExtractWorker3(Process):
         :param dirname: directory path to handle (relative to backup root),
             without trailing slash
         '''
+        assert self.handlers is not None
         for fname, data_func in self.handlers.items():
             if not fname.startswith(dirname + '/'):
                 continue
@@ -516,7 +522,7 @@ class ExtractWorker3(Process):
         if terminate:
             if self.import_process is not None:
                 self.tar2_process.terminate()
-            self.import_process.terminate()
+                self.import_process.terminate()
         if wait:
             self.tar2_process.wait()
             if self.import_process is not None:
@@ -536,6 +542,7 @@ class ExtractWorker3(Process):
             # Finished extracting the tar file
             # if that was whole-directory archive, handle
             # relocated files now
+            assert self.tar2_current_file is not None
             inner_name = self.tar2_current_file.rsplit('.', 1)[0] \
                 .replace(self.base_dir + '/', '')
             if os.path.basename(inner_name) == '.':
@@ -640,6 +647,7 @@ class ExtractWorker3(Process):
             self.cleanup_tar2(wait=True, terminate=True)
 
     def __run__(self) -> None:
+        assert self.handlers is not None
         self.log.debug("Started sending thread")
         self.log.debug("Moving to dir %s", self.base_dir)
         os.chdir(self.base_dir)
@@ -658,6 +666,7 @@ class ExtractWorker3(Process):
             if filename.endswith('.000'):
                 # next file
                 if self.tar2_process is not None:
+                    assert input_pipe is not None
                     input_pipe.close()
                     self.cleanup_tar2(wait=True, terminate=False)
 
@@ -708,6 +717,7 @@ class ExtractWorker3(Process):
                 self.log.debug("Running command %s", str(tar2_cmdline))
                 # pylint: disable=consider-using-with
                 if self.encrypted:
+                    assert self.crypto_algorithm is not None
                     # Start decrypt
                     self.decryptor_process = subprocess.Popen(
                         ["openssl", "enc",
@@ -740,6 +750,7 @@ class ExtractWorker3(Process):
                 if inner_name in self.handlers:
                     assert redirect_stdout is subprocess.PIPE
                     data_func = self.handlers[inner_name]
+                    assert input_pipe is not None
                     self.import_process = multiprocessing.Process(
                         target=self._data_import_wrapper,
                         args=([input_pipe.fileno()],
@@ -756,6 +767,7 @@ class ExtractWorker3(Process):
                 continue
             else:
                 # os.path.splitext fails to handle 'something/..000'
+                assert self.tar2_current_file is not None
                 (basename, ext) = self.tar2_current_file.rsplit('.', 1)
                 previous_chunk_number = int(ext)
                 expected_filename = basename + '.%03d' % (
@@ -769,10 +781,12 @@ class ExtractWorker3(Process):
                     continue
 
                 self.log.debug("Releasing next chunk")
+                assert input_pipe is not None
                 self.feed_tar2(filename, input_pipe)
 
             self.tar2_current_file = filename
 
+            assert self.tar2_feeder is not None
             self.tar2_feeder.wait()
             # check if any process failed
             processes = {
@@ -793,6 +807,7 @@ class ExtractWorker3(Process):
             os.remove(filename)
 
         if self.tar2_process is not None:
+            assert input_pipe is not None
             input_pipe.close()
             if filename == QUEUE_ERROR:
                 if self.decryptor_process:
@@ -1138,6 +1153,7 @@ class BackupRestore(object):
 
             return hmac_text
         if algorithm is None:
+            assert self.header_data.hmac_algorithm is not None
             algorithm = self.header_data.hmac_algorithm
         assert algorithm is not None
 
@@ -1168,6 +1184,8 @@ class BackupRestore(object):
 
         with open(os.path.join(self.tmpdir, filename), 'rb') as f_input:
             with subprocess.Popen(
+# TODO what guarantees that `algorithm`
+# TODO (=e.g. self.header_data.hmac_algorithm) is not None ?
                     ["openssl", "dgst", "-" + algorithm, "-hmac", passphrase],
                     stdin=f_input,
                     stdout=subprocess.PIPE,
@@ -1370,28 +1388,28 @@ class BackupRestore(object):
         # Setup worker to extract encrypted data chunks to the restore dirs
         # Create the process here to pass it options extracted from
         # backup header
-        extractor_params = {
-            'queue': queue,
-            'base_dir': self.tmpdir,
-            'passphrase': self.passphrase,
-            'encrypted': self.header_data.encrypted,
-            'compressed': self.header_data.compressed,
-            'crypto_algorithm': self.header_data.crypto_algorithm,
-            'verify_only': self.options.verify_only,
-            'progress_callback': self.progress_callback,
-            'handlers': handlers,
-        }
         self.log.debug(
             'Starting extraction worker in %s, file handlers map: %s',
             self.tmpdir, repr(handlers))
         format_version = self.header_data.version
         if format_version in [3, 4]:
-            extractor_params['compression_filter'] = \
-                self.header_data.compression_filter
+            # asserts Handled by BackupHeader.validate() called by .load()
+            assert self.header_data.compressed is not None
+            assert self.header_data.encrypted is not None
+
+            encrypted = self.header_data.encrypted
             if format_version == 4:
                 # encryption already handled
-                extractor_params['encrypted'] = False
-            extract_proc = ExtractWorker3(**extractor_params)
+                encrypted=False
+            if encrypted:
+                assert self.header_data.crypto_algorithm is not None
+            extract_proc = ExtractWorker3(queue, self.tmpdir,
+                  self.passphrase, encrypted,
+                  progress_callback=self.progress_callback,
+                  compressed=self.header_data.compressed,
+                  crypto_algorithm=self.header_data.crypto_algorithm,
+                  compression_filter=self.header_data.compression_filter,
+                  verify_only=self.options.verify_only, handlers=handlers)
         else:
             raise NotImplementedError(
                 "Backup format version %d not supported" % format_version)
@@ -1545,6 +1563,7 @@ class BackupRestore(object):
                     continue
 
                 if self.header_data.version in [2, 3]:
+                    assert hmacfile is not None
                     self._verify_hmac(filename, hmacfile)
                 else:
                     # _verify_and_decrypt will write output to a file with

--- a/qubesadmin/base.py
+++ b/qubesadmin/base.py
@@ -360,6 +360,9 @@ class PropertyHolder(object):
             for class_ in cls.__mro__:
                 for key in class_.__dict__:
                     props.add(key)
+                if hasattr(class_, "__annotations__"):
+                    for key in class_.__annotations__:
+                        props.add(key)
             cls._local_properties_set = props
 
         return cls._local_properties_set

--- a/qubesadmin/firewall.py
+++ b/qubesadmin/firewall.py
@@ -415,7 +415,7 @@ class Firewall(object):
     '''Firewal manager for a VM'''
     def __init__(self, vm):
         self.vm = vm
-        self._rules = []
+        self._rules: list[Rule] = []
         self._policy = None
         self._loaded = False
 

--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -25,6 +25,7 @@ import shlex
 
 import subprocess
 import warnings
+from logging import Logger
 
 import qubesadmin.base
 import qubesadmin.exc
@@ -39,15 +40,15 @@ import qubesadmin.tags
 class QubesVM(qubesadmin.base.PropertyHolder):
     """Qubes domain."""
 
-    log = None
+    log: Logger
 
-    tags = None
+    tags: qubesadmin.tags.Tags
 
-    features = None
+    features: qubesadmin.features.Features
 
-    devices = None
+    devices: qubesadmin.devices.DeviceManager
 
-    firewall = None
+    firewall: qubesadmin.firewall.Firewall
 
     def __init__(self, app, name, klass=None, power_state=None):
         super().__init__(app, "admin.vm.property.", name)


### PR DESCRIPTION
Follow-up of #413 

Most changes are in the same spirit. Below I list the changes where I need guidance.

# Logical mistake in `cleanup_tar2`

```python
        if terminate:
            if self.import_process is not None:
                self.tar2_process.terminate()
            self.import_process.terminate()
```

The last line will error if `self.import_process` is `None`.

I "fixed" it by moving it into the `if`, but need approval.

# `hmac_algorithm` could be `None`

In `BackupRestore > _verify_hmac() > load_hmac()` we have

```python
        if algorithm is None:
            algorithm = self.header_data.hmac_algorithm
        #...
        with open(os.path.join(self.tmpdir, filename), 'rb') as f_input:
            with subprocess.Popen(
                    ["openssl", "dgst", "-" + algorithm, "-hmac", passphrase],
```

this will error if `self.header_data.hmac_algorithm` is None.
I of course added `assert self.header_data.hmac_algorithm is not None` for the type checker, but am worried that this may be an actual bug, since it is perfectly legal afaik for `header_data.hmac_algorithm` to be `None`:

```python

    def __init__(self,
            header_data: bytes | None=None,
            *,
            version: int | None=None,
            encrypted: bool | None=None,
            compressed: bool | None=None,
            compression_filter: str | None=None,
            hmac_algorithm: str | None=None,
            crypto_algorithm: str | None=None,
            backup_id: str | int | None=None):
        # repeat the list to help code completion...
        self.version = version
        self.encrypted = encrypted
        self.compressed = compressed
        # Options introduced in backup format 3+, which always have a header,
        # so no need for fallback in function parameter
        self.compression_filter = compression_filter
        self.hmac_algorithm = hmac_algorithm
        self.crypto_algorithm = crypto_algorithm
        self.backup_id = backup_id

        init_supported_hmac_and_crypto()

        if header_data is not None:
            self.load(header_data)
```

# Possible `None` fields in `ExtractWorker3` args

In `BackupRestore > _start_inner_extraction_worker()` we have

```python
extractor_params = {
            'queue': queue,
            'base_dir': self.tmpdir,
            'passphrase': self.passphrase,
            'encrypted': self.header_data.encrypted,
            'compressed': self.header_data.compressed,
            'crypto_algorithm': self.header_data.crypto_algorithm,
            'verify_only': self.options.verify_only,
            'progress_callback': self.progress_callback,
            'handlers': handlers,
        }
        self.log.debug(
            'Starting extraction worker in %s, file handlers map: %s',
            self.tmpdir, repr(handlers))
        format_version = self.header_data.version
        if format_version in [3, 4]:
            extractor_params['compression_filter'] = \
                self.header_data.compression_filter
            if format_version == 4:
                # encryption already handled
                extractor_params['encrypted'] = False
            extract_proc = ExtractWorker3(**extractor_params)
```

All of the following: `header_data.crypto_algorithm, header_data.compressed, header_data.encrypted` can be `None` for the same reason as above.
However, `ExtractWorker3` will error if passed any of those as `None`.


# A comment on `qubesadmin.base.PropertyHolder`

Objects inheriting from `qubesadmin.base.PropertyHolder`, such as `QubesBase`, have a very strict rule that is not documented anywhere in their own docstring.

`PropertyHolder` does a very hack-y thing, which is that it considers that local-only parameters are the ones defined in the class attributes. In other terms,

```python
class QubesBase(qubesadmin.base.PropertyHolder):
   my_local_attribute = None
```

was the previous way to declare those. Except this isn't mentioned anywhere in the docstring of `QubesBase` itself - and due to the hack-y (and very unusual) implementation, it's very easy to break it inadvertently. I therefore added a small comment.

However, there remained a main issue: setting `my_local_attribute = None` is very bad for type checking (and overall), since if `my_local_attribute` is initialized in `__init__()`, it will never be`None`.
The correct way to do this is to type-check it instead:

```python
class QubesBase(qubesadmin.base.PropertyHolder):
   my_local_attribute: MyType
```

To make this work, I had to modify PropertyHolder accordingly:

```python
    def _local_properties(cls):
        '''
        Get set of property names that are properties on the Python object,
        and must not be set on the remote object
        '''
        if "_local_properties_set" not in cls.__dict__:
            props = set()
            for class_ in cls.__mro__:
                for key in class_.__dict__:
                    props.add(key)
                if hasattr(class_, "__annotations__"):  # NEW
                    for key in class_.__annotations__:  # NEW
                        props.add(key)  # NEW
            cls._local_properties_set = props

        return cls._local_properties_set
```