### PR TITLE
Fix typing issues in `events/`

### DIFF
--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -32,6 +32,7 @@ import sys
 
 import logging
 from logging import Logger
+from typing import Literal
 
 import qubesadmin.base
 import qubesadmin.exc
@@ -181,8 +182,7 @@ class QubesBase(qubesadmin.base.PropertyHolder):
     #: storage pools
     pools: qubesadmin.base.WrapperObjectsCollection
     #: type of qubesd connection: either 'socket' or 'qrexec'
-    qubesd_connection_type: str | None = None  # See in PR#416 why we keep
-                                        # =None here to not trip the CI
+    qubesd_connection_type: Literal["socket", "qrexec"]
     #: logger
     log: Logger
     #: do not check for object (VM, label etc) existence before really needed

--- a/qubesadmin/events/__init__.py
+++ b/qubesadmin/events/__init__.py
@@ -246,6 +246,7 @@ class EventsDispatcher:
         elif event in ('domain-pre-start', 'domain-start', 'domain-shutdown',
                        'domain-paused', 'domain-unpaused',
                        'domain-start-failed'):
+            assert subject is not None
             self.app._update_power_state_cache(subject, event, **kwargs)
             subject.devices.clear_cache()
         elif event == 'connection-established':
@@ -257,6 +258,7 @@ class EventsDispatcher:
             "device-unassign",
             "device-assignment-changed"
         ):
+            assert subject is not None
             devclass = event.split(":")[1]
             subject.devices[devclass]._assignment_cache = None
         elif event.split(":")[0] in (
@@ -264,9 +266,11 @@ class EventsDispatcher:
             "device-detach",
             "device-removed"
         ):
+            assert subject is not None
             devclass = event.split(":")[1]
             subject.devices[devclass]._attachment_cache = None
         if event.split(":")[0] in ("device-removed",):
+            assert subject is not None
             devclass = event.split(":")[1]
             port_id = kwargs.get("port", ":").split(":")[1]
             try:

--- a/qubesadmin/events/utils.py
+++ b/qubesadmin/events/utils.py
@@ -24,7 +24,6 @@ import functools
 from typing import Iterable
 
 import qubesadmin.events
-import qubesadmin.exc
 from qubesadmin.events import EventsDispatcher
 from qubesadmin.vm import QubesVM
 

--- a/qubesadmin/tests/__init__.py
+++ b/qubesadmin/tests/__init__.py
@@ -150,6 +150,9 @@ class QubesTest(qubesadmin.app.QubesBase):
     expected_calls = None
     actual_calls = None
     service_calls = None
+    # This is a special value used only for tests
+    # This is not valid / expected outside of tests
+    qubesd_connection_type: str = "none"  # type: ignore
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
Follows #417 

Below: noteworthy discussions

# `qubesd_connection_type=None` in tests

Before de16a67, the CI tests failed with 
```bash
Traceback (most recent call last):
  File "/builds/QubesOS/qubes-core-admin-client/qubesadmin/tests/vm/dispvm.py", line 83, in test_011_remote_create_specific
    vm.run_service_for_stdio('test.service')
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/builds/QubesOS/qubes-core-admin-client/qubesadmin/vm/__init__.py", line 329, in run_service_for_stdio
    p = self.run_service(service, **kwargs)
  File "/builds/QubesOS/qubes-core-admin-client/qubesadmin/vm/__init__.py", line 482, in run_service
    self.app.qubesd_connection_type == "socket"
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/builds/QubesOS/qubes-core-admin-client/qubesadmin/base.py", line 242, in __getattr__
    property_str = self.qubesd_call(
        self._method_dest,
        self._method_prefix + 'Get',
        item,
        None)
  File "/builds/QubesOS/qubes-core-admin-client/qubesadmin/tests/__init__.py", line 175, in qubesd_call
    raise AssertionError('Unexpected call {!r}'.format(call_key))
AssertionError: Unexpected call ('dom0', 'admin.property.Get', 'qubesd_connection_type', None)
```

I believe this is an error in the test design itself.

## Root of the problem

Previously `QubesBase` was defined as
```python
class QubesBase(qubesadmin.base.PropertyHolder):
    #: domains (VMs) collection
    domains = None
    #: labels collection
    labels = None
    #: storage pools
    pools = None
    #: type of qubesd connection: either 'socket' or 'qrexec'
    qubesd_connection_type = None
    #: logger
    log = None
    #: do not check for object (VM, label etc) existence before really needed
    blind_mode = False
    #: cache retrieved properties values
    cache_enabled = False
```

I changed that to
```python
class QubesBase(qubesadmin.base.PropertyHolder):
    # Below: local-only properties (see PropertyHolder._local_properties)
    #: domains (VMs) collection
    domains: VMCollection
    #: labels collection
    labels: qubesadmin.base.WrapperObjectsCollection
    #: storage pools
    pools: qubesadmin.base.WrapperObjectsCollection
    #: type of qubesd connection: either 'socket' or 'qrexec'
    qubesd_connection_type: str
    #: logger
    log: Logger
    #: do not check for object (VM, label etc) existence before really needed
    blind_mode: bool = False
    #: cache retrieved properties values
    cache_enabled: bool = False
```

Notably `domains,labels,pools` are not set to `None` anymore since they're initialized in `__init__.py`.
I also removed `=None` from `qubesd_connection_type` because each of its use assumes it's either `"socket"` or `"qrexec"`.

However, in the testing module, `QubesTest` does not define `qubesd_connection_type`.
```python
class QubesTest(qubesadmin.app.QubesBase):
    expected_service_calls = None
    expected_calls = None
    actual_calls = None
    service_calls = None
```

This causes the tests to fail.

## Why I believe this is an error

The reason why the tests did *not* fail before even though the code does not expect a `None` value is because the code typically does
```python
if qubesd_connection_type=="socket":
   ...
else:
   ...
```

in this order, or the opposite. Having `qubesd_connection_type=None` will not cause an error here, but executes an arbitrary branch of the if block, which is somehow worse.

## Fix

We need to initialize `qubesd_connection_type` in `QubesTest`. I tried both `qubesd_connection_type="socket"` and `="qrexec"` but none passed the tests.
I had to default to `="none"`, which is about as ugly as the current implementation.

I think we should definitely fix the tests in a separate PR (or allow a third value / None for "qubesd_connection_type", but explicitely this time)