### PR TITLE
Raise NotImplementedError instead of returning NotImplemented

### DIFF
--- a/qubesadmin/firewall.py
+++ b/qubesadmin/firewall.py
@@ -405,7 +405,7 @@ class Rule(object):
             return self.rule == other.rule
         if isinstance(other, str):
             return self.rule == str
-        return NotImplemented
+        raise NotImplementedError
 
     def __repr__(self):
         return 'Rule(\'{}\')'.format(self.rule)

--- a/qubesadmin/label.py
+++ b/qubesadmin/label.py
@@ -79,7 +79,7 @@ class Label(object):
     def __eq__(self, other):
         if isinstance(other, Label):
             return self.name == other.name
-        return NotImplemented
+        raise NotImplementedError
 
     def __hash__(self):
         return hash(self.name)

--- a/qubesadmin/storage.py
+++ b/qubesadmin/storage.py
@@ -93,7 +93,7 @@ class Volume(object):
     def __eq__(self, other):
         if isinstance(other, Volume):
             return self.pool == other.pool and self.vid == other.vid
-        return NotImplemented
+        raise NotImplementedError
 
     def __lt__(self, other):
         # pylint: disable=protected-access
@@ -102,7 +102,7 @@ class Volume(object):
                 return (self._vm, self._vm_name) < (other._vm, other._vm_name)
             if self._vid and other._vid:
                 return (self._pool, self._vid) < (other._pool, other._vid)
-        return NotImplemented
+        raise NotImplementedError
 
     @property
     def name(self):
@@ -327,12 +327,12 @@ class Pool(object):
             return self.name == other.name
         if isinstance(other, str):
             return self.name == other
-        return NotImplemented
+        raise NotImplementedError
 
     def __lt__(self, other):
         if isinstance(other, Pool):
             return self.name < other.name
-        return NotImplemented
+        raise NotImplementedError
 
     @property
     def usage_details(self):

--- a/qubesadmin/tests/__init__.py
+++ b/qubesadmin/tests/__init__.py
@@ -51,7 +51,7 @@ class TestVM(object):
     def __lt__(self, other):
         if isinstance(other, TestVM):
             return self.name < other.name
-        return NotImplemented
+        raise NotImplementedError
 
 
 class TestVMCollection(dict):

--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -85,14 +85,14 @@ class QubesVM(qubesadmin.base.PropertyHolder):
     def __lt__(self, other):
         if isinstance(other, QubesVM):
             return self.name < other.name
-        return NotImplemented
+        raise NotImplementedError
 
     def __eq__(self, other):
         if isinstance(other, QubesVM):
             return self.name == other.name
         if isinstance(other, str):
             return self.name == other
-        return NotImplemented
+        raise NotImplementedError
 
     def __hash__(self):
         return hash(self.name)


### PR DESCRIPTION
In a few instance in the code we `return NotImplemented`, but the returned value is not handled anywhere.

I believe this is an error, and should have been `raise NotImplementedError` instead.