### PR TITLE
Upgrade deprecated datetime calls in firewall.py

### DIFF
--- a/qubesadmin/firewall.py
+++ b/qubesadmin/firewall.py
@@ -213,7 +213,8 @@ class Expire(RuleOption):
     '''Rule expire time'''
     def __init__(self, value):
         super().__init__(value)
-        self.datetime = datetime.datetime.utcfromtimestamp(int(value))
+        self.datetime = datetime.datetime.fromtimestamp(int(value),
+                                                        datetime.timezone.utc)
 
     @property
     def rule(self):
@@ -223,12 +224,12 @@ class Expire(RuleOption):
     @property
     def expired(self):
         '''Has this rule expired already?'''
-        return self.datetime < datetime.datetime.utcnow()
+        return self.datetime < datetime.datetime.now(datetime.timezone.utc)
 
     @property
     def pretty_value(self):
         '''Human readable representation'''
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         duration = (self.datetime - now).total_seconds()
         return "{:+.0f}s".format(duration)
 

--- a/qubesadmin/tests/firewall.py
+++ b/qubesadmin/tests/firewall.py
@@ -274,8 +274,10 @@ class TC_06_Expire(qubesadmin.tests.QubesTestCase):
         with self.assertNotRaises(ValueError):
             instance = qubesadmin.firewall.Expire(1463292452)
         self.assertEqual(str(instance), '1463292452')
-        self.assertEqual(instance.datetime,
-            datetime.datetime(2016, 5, 15, 6, 7, 32))
+        self.assertEqual(
+            instance.datetime,
+            datetime.datetime(2016, 5, 15, 6, 7,
+                              32, tzinfo=datetime.timezone.utc))
         self.assertEqual(instance.rule, 'expire=1463292452')
 
     def test_001_str(self):
@@ -283,7 +285,8 @@ class TC_06_Expire(qubesadmin.tests.QubesTestCase):
             instance = qubesadmin.firewall.Expire('1463292452')
         self.assertEqual(str(instance), '1463292452')
         self.assertEqual(instance.datetime,
-            datetime.datetime(2016, 5, 15, 6, 7, 32))
+            datetime.datetime(2016, 5, 15, 6, 7,
+                              32, tzinfo=datetime.timezone.utc))
         self.assertEqual(instance.rule, 'expire=1463292452')
 
     def test_002_invalid(self):


### PR DESCRIPTION
In `firewall.py` we use two deprecated methods `utcfromtimestamp` and `utcnow`.

As per the official docs they have been replaced by `fromtimestamp` and `now`.

# Note: No UTC ?
This raises a question regarding why we are using timezone-unaware datetimes in the first place. I believe we should be using

`.now(timezone.utc)` and `.fromtimestamp(..., timezone.utc)` (and update accordingly the tests)

Otherwise, if the user's timezone changes, the `Expire` rules will be shifted around for no good reason.