### PR TITLE
Remove old sphinx<2 fallbacks

### DIFF
--- a/qubesadmin/tools/dochelpers.py
+++ b/qubesadmin/tools/dochelpers.py
@@ -236,9 +236,6 @@ class ManpageCheckVisitor(docutils.nodes.SparseNodeVisitor):
             msg = 'cannot import module for command'
             if log:
                 log.warning(msg)
-            else:
-                # Handle legacy
-                app.warn(msg)
 
             self.parser = None
             return
@@ -298,9 +295,6 @@ def check_man_args(app, doctree, docname):
     msg = 'Checking arguments for {!r}'.format(command)
     if log:
         log.info(msg)
-    else:
-        # Handle legacy
-        app.info(msg)
     doctree.walk(ManpageCheckVisitor(app, command, doctree))
 
 


### PR DESCRIPTION
`docherpers.py` contains two Sphinx <2 fallbacks

```python3
app.warn(msg)
...
app.info(msg)
```

Those were deprecated in Sphinx 1.6 and removed in 2.0.

Current version of Sphinx from `readthedocs.yaml`
```yaml
  os: ubuntu-22.04
  tools:
    python: "3.11"
```

should be [around `Sphinx>=4.3`](https://launchpad.net/ubuntu/jammy/amd64/python3-sphinx) at minimum (note: latest is `9.1`). 