### PR TITLE
Change python2 `issubclass` to `isinstance`

### DIFF
--- a/qubesadmin/tools/__init__.py
+++ b/qubesadmin/tools/__init__.py
@@ -427,9 +427,9 @@ class QubesArgumentParser(argparse.ArgumentParser):
 
         for action in self._actions:
             # pylint: disable=protected-access
-            if issubclass(action.__class__, QubesAction):
+            if isinstance(action, QubesAction):
                 action.parse_qubes_app(self, namespace)
-            elif issubclass(action.__class__,
+            elif isinstance(action,
                     argparse._SubParsersAction):  # pylint: disable=no-member
                 assert hasattr(namespace, 'command')
                 command = namespace.command
@@ -437,7 +437,7 @@ class QubesArgumentParser(argparse.ArgumentParser):
                     continue
                 subparser = action._name_parser_map[command]
                 for subaction in subparser._actions:
-                    if issubclass(subaction.__class__, QubesAction):
+                    if isinstance(subaction, QubesAction):
                         subaction.parse_qubes_app(self, namespace)
 
         return namespace

--- a/qubesadmin/tools/dochelpers.py
+++ b/qubesadmin/tools/dochelpers.py
@@ -256,8 +256,7 @@ class ManpageCheckVisitor(docutils.nodes.SparseNodeVisitor):
             if action.help == argparse.SUPPRESS:
                 continue
 
-            if issubclass(action.__class__,
-                          qubesadmin.tools.AliasedSubParsersAction):
+            if isinstance(action, qubesadmin.tools.AliasedSubParsersAction):
                 for cmd, cmd_parser in action._name_parser_map.items():
                     self.sub_commands[cmd] = set()
                     for sub_action in cmd_parser._actions:


### PR DESCRIPTION
Some old (10+ years) parts of the code use `issubclass` (which was standard in python 2)  instead of the more modern `isinstance`.

### Note:

There remains one instance of `issubclass` which I did not change since it's actually valid in its context, in `tests/__init__.py > _AssertNotRaisesContext`
```python3
    def __exit__(self, exc_type, exc_value, traceback_):
        if exc_type is None:
            return True

        if issubclass(exc_type, self.expected):
            raise self.failureException(
                "{!r} raised, traceback:\n{!s}".format(
                    exc_value, ''.join(traceback.format_tb(traceback_))))
        # pass through
        return False
```