### PR TITLE
enforce 3.10 interface for `qvm_notes.py`

### DIFF
--- a/qubesadmin/tests/tools/qvm_notes.py
+++ b/qubesadmin/tests/tools/qvm_notes.py
@@ -85,7 +85,7 @@ class TC_00_qvm_notes(qubesadmin.tests.QubesTestCase):
         ] = b"0\x00"
         with tempfile.NamedTemporaryFile(
             mode="w+",
-            delete_on_close=False,
+            delete=False,
         ) as temp:
             temp.write("For Your Eyes Only")
             temp.close()
@@ -235,7 +235,7 @@ class TC_00_qvm_notes(qubesadmin.tests.QubesTestCase):
         )
         with tempfile.NamedTemporaryFile(
             mode="w+",
-            delete_on_close=False,
+            delete=False,
         ) as temp:
             temp.write("New note")
             temp.close()

--- a/qubesadmin/tools/qvm_notes.py
+++ b/qubesadmin/tools/qvm_notes.py
@@ -144,7 +144,7 @@ def main(args=None, app=None):
                     mode="w+",
                     prefix=qube.name + "_qube_",
                     suffix="_notes.txt",
-                    delete_on_close=False,
+                    delete=False,
                 ) as temp:
                     temp.write(qube.get_notes())
                     temp.close()

--- a/qubesadmin/tools/qvm_notes.py
+++ b/qubesadmin/tools/qvm_notes.py
@@ -139,13 +139,16 @@ def main(args=None, app=None):
 
     match args.action:
         case "edit":
+            temp_path = ""
             try:
                 with tempfile.NamedTemporaryFile(
                     mode="w+",
                     prefix=qube.name + "_qube_",
                     suffix="_notes.txt",
+                    # TODO use delete_on_close=False when min python is >=3.12
                     delete=False,
                 ) as temp:
+                    temp_path = temp.name
                     temp.write(qube.get_notes())
                     temp.close()
                     last_modified = os.path.getmtime(temp.name)
@@ -154,10 +157,12 @@ def main(args=None, app=None):
                     if last_modified != os.path.getmtime(temp.name):
                         with open(temp.name, encoding="utf-8") as notes_file:
                             qube.set_notes(notes_file.read())
-                    # os.unlink(temp.name)
             except qubesadmin.exc.QubesException as e:
                 logging.error("Failed to edit qube notes: %s", str(e))
                 exit_code = 1
+            finally: # TODO can be removed once we use delete_on_close=False
+                if temp_path and os.path.exists(temp_path):
+                    os.unlink(temp_path)
         case "print":
             try:
                 print(qube.get_notes())


### PR DESCRIPTION
Closes https://github.com/QubesOS/qubes-issues/issues/10684

The current code is using 3.12 code `delete_on_close`. Reverting to the 3.10 option `delete`.

From what I gather from the docs, this split (in python 3.12) was introduced to fix a subtle issue for windows users, hopefully it shouldn't break anything on our end