### PR TITLE
Show usage instead of exception on missing options

### DIFF
--- a/qubesadmin/tools/qvm_run.py
+++ b/qubesadmin/tools/qvm_run.py
@@ -390,8 +390,10 @@ def main(args=None, app=None):
             for qube in domains:
                 gui_per_domain[qube] = has_gui(qube)
     else:
+        if len(domains) != 1:
+            parser.print_usage(sys.stderr)
+            sys.exit(2)
         if args.gui is None:
-            assert len(domains) == 1
             args.gui = has_gui(domains[0])
     if args.color_output:
         sys.stdout.write("\033[0;{}m".format(args.color_output))


### PR DESCRIPTION
If user passes a single argument, "qvm-run sys-usb", it throws an AssertionError. The "sys-usb" goes to "args.cmd".

I decided to use domains length instead of "args.VMNAME" because "args.domains" is already validated to contain qubes, while "args.VMNAME" might be something else.