### PR TITLE
Refine logic in SinglePropertyAction

### DIFF
--- a/qubesadmin/tests/tools/init.py
+++ b/qubesadmin/tests/tools/init.py
@@ -133,7 +133,16 @@ class TC_01_SinglePropertyAction(qubesadmin.tests.QubesTestCase):
         self.assertIn(
             ('testprop', 'testvalue'), args.properties.items())
 
-    def test_104_set_prop_positional(self):
+    def test_104_set_prop_const_override(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--testprop', '-T',
+            action=qubesadmin.tools.SinglePropertyAction,
+            const='testvalue')
+        args = parser.parse_args(['-T', 'override'])
+        self.assertIn(
+            ('testprop', 'override'), args.properties.items())
+
+    def test_105_set_prop_positional(self):
         parser = argparse.ArgumentParser()
         parser.add_argument('testprop',
             action=qubesadmin.tools.SinglePropertyAction)

--- a/qubesadmin/tools/__init__.py
+++ b/qubesadmin/tools/__init__.py
@@ -38,9 +38,6 @@ import qubesadmin.log
 import qubesadmin.exc
 import qubesadmin.vm
 
-#: constant returned when some action should be performed on all qubes
-VM_ALL = object()
-
 class QubesAction(argparse.Action):
     """
     Custom Action for Qubes

--- a/qubesadmin/tools/__init__.py
+++ b/qubesadmin/tools/__init__.py
@@ -31,7 +31,8 @@ import logging
 import os
 import subprocess
 import sys
-import textwrap
+from argparse import Namespace
+from collections.abc import Sequence
 
 import qubesadmin.log
 import qubesadmin.exc
@@ -41,84 +42,99 @@ import qubesadmin.vm
 VM_ALL = object()
 
 class QubesAction(argparse.Action):
-    ''' Interface providing a convinience method to be called, after
-        `namespace.app` is instantiated.
-    '''
-    # pylint: disable=too-few-public-methods
+    """
+    Custom Action for Qubes
+    """
     def parse_qubes_app(self, parser, namespace):
-        ''' This method is called by :py:class:`qubes.tools.QubesArgumentParser`
-            after the `namespace.app` is instantiated. Oerwrite this method when
-            extending :py:class:`qubes.tools.QubesAction` to initialized values
-            based on the `namespace.app`
-        '''
+        """
+        This method is called by :py:class:`qubes.tools.QubesArgumentParser`
+        after `namespace.app` is instantiated.
+
+        Used to initialize values based on `namespace.app`.
+        """
         raise NotImplementedError
 
 
 class PropertyAction(argparse.Action):
-    '''Action for argument parser that stores a property.'''
-    # pylint: disable=redefined-builtin,too-few-public-methods
+    """Action for argument parser that stores a property.
+    Format: `--<option_name> property=value`
+    """
+    # pylint: disable=redefined-builtin
     def __init__(self,
-            option_strings,
-            dest,
+            option_strings: list[str],
+            dest: str,
             *,
-            metavar='NAME=VALUE',
-            required=False,
-            help='set property to a value'):
+            metavar: str='NAME=VALUE',
+            required: bool=False,
+            help: str='set property to a value'):
         super().__init__(option_strings, 'properties',
-            metavar=metavar, default={}, help=help)
+            metavar=metavar, help=help, required=required)
 
-    def __call__(self, parser, namespace, values, option_string=None):
+    def __call__(self, parser: argparse.ArgumentParser, namespace: Namespace,
+                 values: str | Sequence | None,
+                 option_string: str | None=None) -> None:
+        if not isinstance(values, str):
+            parser.error(f'Invalid property token: {values!r}')
         try:
             prop, value = values.split('=', 1)
         except ValueError:
-            parser.error('invalid property token: {!r}'.format(values))
+            parser.error('Invalid property token: {!r}'.format(values))
 
         properties = getattr(namespace, self.dest)
-        # copy it, to not modify _mutable_ self.default
-        if not properties:
-            properties = properties.copy()
+        if properties is None:
+            properties = {}
         properties[prop] = value
         setattr(namespace, self.dest, properties)
 
 
 class SinglePropertyAction(argparse.Action):
-    '''Action for argument parser that stores a property.'''
+    """Action for argument parser that stores a property.
+    Format: `--property_name value` or `--property_name`
+    """
 
-    # pylint: disable=redefined-builtin,too-few-public-methods
+    # pylint: disable=redefined-builtin
     def __init__(self,
             option_strings,
             dest,
             *,
-            metavar='VALUE',
-            const=None,
-            nargs=None,
-            required=False,
-            help=None):
+            metavar: str='VALUE',
+            const: object=None,
+            nargs: int | str | None=None,
+            required: bool=False,
+            help: str | None=None):
         if help is None:
             help = 'set {!r} property to a value'.format(dest)
             if const is not None:
                 help += ' {!r}'.format(const)
 
-        if const is not None:
-            nargs = 0
+        if const is not None and nargs is None:
+            nargs = argparse.OPTIONAL
 
-        super().__init__(option_strings, 'properties',
-            metavar=metavar, help=help, default={}, const=const,
-            nargs=nargs)
+        super().__init__(option_strings, 'properties', required=required,
+            metavar=metavar, help=help, const=const, nargs=nargs)
 
         self.name = dest
 
 
-    def __call__(self, parser, namespace, values, option_string=None):
-        if values is self.default and self.default == {}:
-            return
+    def __call__(self, parser: argparse.ArgumentParser,
+                 namespace: Namespace, values: str | Sequence | None,
+                 option_string: str | None=None)\
+            -> None:
+        if not values:
+            # If we omit the argument and it's optional, __call__ will
+            #  not be called.
+            # If we omit it and it's positional, `values` will be either
+            #  `None` or `[]` depending on `nargs`.
+            # We don't want to modify `propertie` in either case, unless
+            #  `const` is set.
+            if self.const is None or self.const == []:
+                return
+            values = self.const
 
         properties = getattr(namespace, self.dest)
-        # copy it, to not modify _mutable_ self.default
-        if not properties:
-            properties = properties.copy()
-        properties[self.name] = values \
-            if self.const is None else self.const
+        if properties is None:
+            properties = {}
+        properties[self.name] = values or self.const
         setattr(namespace, self.dest, properties)
 
 


### PR DESCRIPTION
### Main point
- replace the `default={}` `properties = properties.copy()` mutable hack by non-mutable `default=None`
- allow `SinglePropertyAction` to handle optional values with `const!=None`

The previous implementation either accepts `const=None` (`--my-arg value`) or `const=val` (`--my_arg`). It is not possible to add a default value if the flag has no argument, or use the provided value if there is any.

The new implementation allows that.
- Cleanup logic in `SinglePropertyAction.__call__` if we set `const`

At the top of `__call__` we had
```python3
        if values is self.default and self.default == {}:
            return
```

1) This breaks the expected argument type of `values` which is supposed to be `str | Sequence | None`
2) If `self.const` was set during `__init__`, then we still will not set the property to this value, which is very counter-intuitive.

### Minor points
- Re-add non-forwarded `required` argument to `__init__`
- Reword some docstrings in a way that imo is clearer - but that is subjective
- Add typing hints, since this is a cherry-pick from https://github.com/hippalectryon-0/qubes-core-admin-client which is fully typed
- I took the liberty to remove `VM_ALL`. It's not used anywhere, it comes from a `qubes-core-admin` file that was last modified in 2016:
```bash
> git log -S "VM_ALL"
commit d4c74d210f7f139748d311cec4b94914f3da6544
Author: Bahtiar `kalkin-` Gadimov <bahtiar@gadimov.de>
Date:   Wed May 18 17:18:54 2016 +0200

    Implement vmname parsing

commit adbca5c0f663f2bd010bead8ccc909d65d6b6543
Author: Wojtek Porczyk <woju@invisiblethingslab.com>
Date:   Mon Apr 18 22:54:55 2016 +0200

    qubes/tools/qvm_run: fix --all/--passio exclusion

commit f1a0b1af3947a71269763e37eaba7809f59376b7
Author: Wojtek Porczyk <woju@invisiblethingslab.com>
Date:   Mon Dec 28 18:14:37 2015 +0100

    qubes/tools: add qvm-run, qvm-{,un}pause
    
    Also change convention of calling main(): now command returns its
    numeric value instead of bool.
    
    Also fixed QSB#13
    
    fixes QubesOS/qubes-issues#1226
```