### PR TITLE
Remove legacy disable=too-few-public-methods

### DIFF
--- a/qubesadmin/backup/__init__.py
+++ b/qubesadmin/backup/__init__.py
@@ -27,7 +27,6 @@ from qubesadmin.vm import QubesVM
 
 class BackupApp:
     '''Interface for backup collection'''
-    # pylint: disable=too-few-public-methods
     def __init__(self, qubes_xml: str | None):
         '''Initialize BackupApp object and load qubes.xml into it'''
         self.store = qubes_xml
@@ -41,7 +40,6 @@ class BackupApp:
 
 class BackupVM:
     '''Interface for a single VM in the backup'''
-    # pylint: disable=too-few-public-methods
     def __init__(self) -> None:
         '''Initialize empty BackupVM object'''
         #: VM class

--- a/qubesadmin/backup/core2.py
+++ b/qubesadmin/backup/core2.py
@@ -40,7 +40,6 @@ service_to_feature = {
 
 class Core2VM(qubesadmin.backup.BackupVM):
     '''VM object'''
-    # pylint: disable=too-few-public-methods
     def __init__(self) -> None:
         super().__init__()
         self.backup_content = False

--- a/qubesadmin/backup/core3.py
+++ b/qubesadmin/backup/core3.py
@@ -36,7 +36,6 @@ from qubesadmin.vm import QubesVM
 
 class Core3VM(qubesadmin.backup.BackupVM):
     '''VM object'''
-    # pylint: disable=too-few-public-methods
     @property
     def included_in_backup(self) -> bool:
         return self.backup_path is not None

--- a/qubesadmin/backup/restore.py
+++ b/qubesadmin/backup/restore.py
@@ -856,7 +856,6 @@ def get_supported_crypto_algo(crypto_algorithm: str | None=None)\
 
 class BackupRestoreOptions:
     '''Options for restore operation'''
-    # pylint: disable=too-few-public-methods
     def __init__(self) -> None:
         #: use default NetVM if the one referenced in backup do not exists on
         #  the host
@@ -898,7 +897,6 @@ class BackupRestore:
 
     class VMToRestore:
         '''Information about a single VM to be restored'''
-        # pylint: disable=too-few-public-methods
         #: VM excluded from restore by user
         EXCLUDED = object()
         #: VM with such name already exists on the host
@@ -932,7 +930,6 @@ class BackupRestore:
 
     class Dom0ToRestore(VMToRestore):
         '''Information about dom0 home to restore'''
-        # pylint: disable=too-few-public-methods
         #: backup was performed on system with different dom0 username
         USERNAME_MISMATCH = object()
 

--- a/qubesadmin/device_protocol.py
+++ b/qubesadmin/device_protocol.py
@@ -1223,7 +1223,6 @@ class DeviceInfo(VirtualDevice):
 
 
 class UnknownDevice(DeviceInfo):
-    # pylint: disable=too-few-public-methods
     """Unknown device - for example, exposed by domain not running currently"""
 
     @staticmethod

--- a/qubesadmin/features.py
+++ b/qubesadmin/features.py
@@ -32,7 +32,6 @@ class Features:
     described above. Be aware that assigning the number `0` (which is considered
     false in Python) will result in string `'0'`, which is considered true.
     '''
-    # pylint: disable=too-few-public-methods
 
     def __init__(self, vm):
         super().__init__()

--- a/qubesadmin/firewall.py
+++ b/qubesadmin/firewall.py
@@ -1,5 +1,4 @@
 # -*- encoding: utf8 -*-
-# pylint: disable=too-few-public-methods
 #
 # The Qubes OS Project, http://www.qubes-os.org
 #

--- a/qubesadmin/tags.py
+++ b/qubesadmin/tags.py
@@ -28,7 +28,6 @@ class Tags:
     simple string consisting of ASCII alphanumeric characters, plus `_` and
     `-`.
     '''
-    # pylint: disable=too-few-public-methods
 
     def __init__(self, vm):
         super().__init__()

--- a/qubesadmin/tests/__init__.py
+++ b/qubesadmin/tests/__init__.py
@@ -118,7 +118,7 @@ class _AssertNotRaisesContext:
     """A context manager used to implement TestCase.assertNotRaises methods.
 
     Stolen from unittest and hacked. Regexp support stripped.
-    """ # pylint: disable=too-few-public-methods
+    """
 
     def __init__(self, expected, test_case, expected_regexp=None):
         if expected_regexp is not None:

--- a/qubesadmin/tools/__init__.py
+++ b/qubesadmin/tools/__init__.py
@@ -44,7 +44,6 @@ class QubesAction(argparse.Action):
     ''' Interface providing a convinience method to be called, after
         `namespace.app` is instantiated.
     '''
-    # pylint: disable=too-few-public-methods
     def parse_qubes_app(self, parser, namespace):
         ''' This method is called by :py:class:`qubes.tools.QubesArgumentParser`
             after the `namespace.app` is instantiated. Oerwrite this method when
@@ -56,7 +55,7 @@ class QubesAction(argparse.Action):
 
 class PropertyAction(argparse.Action):
     '''Action for argument parser that stores a property.'''
-    # pylint: disable=redefined-builtin,too-few-public-methods
+    # pylint: disable=redefined-builtin
     def __init__(self,
             option_strings,
             dest,
@@ -84,7 +83,7 @@ class PropertyAction(argparse.Action):
 class SinglePropertyAction(argparse.Action):
     '''Action for argument parser that stores a property.'''
 
-    # pylint: disable=redefined-builtin,too-few-public-methods
+    # pylint: disable=redefined-builtin
     def __init__(self,
             option_strings,
             dest,
@@ -125,7 +124,7 @@ class SinglePropertyAction(argparse.Action):
 class VmNameAction(QubesAction):
     """ Action for parsing one or multiple domains from provided VMNAMEs """
 
-    # pylint: disable=too-few-public-methods,redefined-builtin
+    # pylint: disable=redefined-builtin
     def __init__(self, option_strings, nargs=1, dest='vmnames', help=None,
                  **kwargs):
         if help is None:
@@ -196,7 +195,6 @@ class VmNameAction(QubesAction):
 
 class RunningVmNameAction(VmNameAction):
     ''' Action for argument parser that gets a running domain from VMNAME '''
-    # pylint: disable=too-few-public-methods
 
     def __init__(self, option_strings, nargs=1, dest='vmnames', help=None,
                  **kwargs):
@@ -231,7 +229,6 @@ class VolumeAction(QubesAction):
     ''' Action for argument parser that gets the
         :py:class:``qubes.storage.Volume`` from a POOL_NAME:VOLUME_ID string.
     '''
-    # pylint: disable=too-few-public-methods
 
     def __init__(self, help='A pool & volume id combination',
                  required=True, **kwargs):
@@ -272,7 +269,6 @@ class VMVolumeAction(QubesAction):
     ''' Action for argument parser that gets the
         :py:class:``qubes.storage.Volume`` from a VM:VOLUME string.
     '''
-    # pylint: disable=too-few-public-methods
 
     def __init__(self, help='A pool & volume id combination',
                  required=True, **kwargs):
@@ -309,7 +305,6 @@ class VMVolumeAction(QubesAction):
 
 class PoolsAction(QubesAction):
     ''' Action for argument parser to gather multiple pools '''
-    # pylint: disable=too-few-public-methods
 
     def __call__(self, parser, namespace, values, option_string=None):
         ''' Set ``namespace.vmname`` to ``values`` '''
@@ -480,7 +475,7 @@ class QubesArgumentParser(argparse.ArgumentParser):
 class SubParsersHelpAction(argparse._HelpAction):
     ''' Print help for all options and all subparsers '''
     # source https://stackoverflow.com/a/24122778
-    # pylint: disable=protected-access,too-few-public-methods
+    # pylint: disable=protected-access
 
     @staticmethod
     def _indent(indent, text):
@@ -511,7 +506,7 @@ class SubParsersHelpAction(argparse._HelpAction):
 class AliasedSubParsersAction(argparse._SubParsersAction):
     '''SubParser with support for action aliases'''
     # source https://gist.github.com/sampsyo/471779
-    # pylint: disable=protected-access,too-few-public-methods,missing-docstring
+    # pylint: disable=protected-access,missing-docstring
     class _AliasedPseudoAction(argparse.Action):
         # pylint: disable=redefined-builtin
         def __init__(self, name, aliases, help):

--- a/qubesadmin/tools/qvm_check.py
+++ b/qubesadmin/tools/qvm_check.py
@@ -1,5 +1,3 @@
-# pylint: disable=too-few-public-methods
-
 #
 # The Qubes OS Project, http://www.qubes-os.org
 #

--- a/qubesadmin/tools/qvm_device.py
+++ b/qubesadmin/tools/qvm_device.py
@@ -88,7 +88,6 @@ def prepare_table(dev_list, with_sbdf=False):
 class Line:
     """Helper class to hold single device info for listing"""
 
-    # pylint: disable=too-few-public-methods
     def __init__(self, device: DeviceInfo, assignment=False):
         self.ident = "{!s}:{!s}".format(device.backend_domain, device.port_id)
         self.description = device.description
@@ -485,7 +484,7 @@ class DeviceAction(qubesadmin.tools.QubesAction):
     """Action for argument parser that gets the
     :py:class:``qubesadmin.device_protocol.VirtualDevice`` from a
     BACKEND:PORT_ID:DEVICE_ID string.
-    """  # pylint: disable=too-few-public-methods
+    """
 
     def __init__(
         self,

--- a/qubesadmin/tools/qvm_firewall.py
+++ b/qubesadmin/tools/qvm_firewall.py
@@ -32,7 +32,6 @@ import qubesadmin.tools
 
 
 class RuleAction(argparse.Action):
-    # pylint: disable=too-few-public-methods
     '''Parser action for a single firewall rule. It accept syntax:
         - <action> [<dsthost> [<proto> [<dstports>|<icmptype>]]]
         - action=<action> [specialtarget=dns] [dsthost=<dsthost>]

--- a/qubesadmin/tools/qvm_ls.py
+++ b/qubesadmin/tools/qvm_ls.py
@@ -1,5 +1,3 @@
-# pylint: disable=too-few-public-methods
-
 #
 # The Qubes OS Project, https://www.qubes-os.org/
 #

--- a/qubesadmin/tools/qvm_pool.py
+++ b/qubesadmin/tools/qvm_pool.py
@@ -1,5 +1,3 @@
-# pylint: disable=too-few-public-methods
-
 #
 # The Qubes OS Project, http://www.qubes-os.org
 #

--- a/qubesadmin/tools/qvm_pool_legacy.py
+++ b/qubesadmin/tools/qvm_pool_legacy.py
@@ -1,5 +1,3 @@
-# pylint: disable=too-few-public-methods
-
 #
 # The Qubes OS Project, http://www.qubes-os.org
 #

--- a/qubesadmin/tools/qvm_start.py
+++ b/qubesadmin/tools/qvm_start.py
@@ -34,7 +34,7 @@ import qubesadmin.tools
 class DriveAction(argparse.Action):
     '''Action for argument parser that stores drive image path.'''
 
-    # pylint: disable=redefined-builtin,too-few-public-methods
+    # pylint: disable=redefined-builtin
     def __init__(self,
             option_strings,
             dest='drive',

--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -354,7 +354,6 @@ REGEX_OUTPUT = re.compile(
 class KeyboardLayout:
     """Class to store and parse X Keyboard layout data"""
 
-    # pylint: disable=too-few-public-methods
     def __init__(self, binary_string):
         split_string = binary_string.split(b"\0")
         self.languages = split_string[2].decode().split(",")

--- a/qubesadmin/tools/qvm_template.py
+++ b/qubesadmin/tools/qvm_template.py
@@ -304,7 +304,7 @@ class VersionSelector(enum.Enum):
     """Upgrade to the highest version that is higher than the current one."""
 
 
-# pylint: disable=too-few-public-methods,inherit-non-class
+# pylint: disable=inherit-non-class
 class Template(typing.NamedTuple):
     """Details of a template."""
     name: str
@@ -332,7 +332,7 @@ class DlEntry(typing.NamedTuple):
     dlsize: int
 
 
-# pylint: enable=too-few-public-methods,inherit-non-class
+# pylint: enable=inherit-non-class
 
 
 def build_version_str(evr: typing.Tuple[str, str, str]) -> str:

--- a/qubesadmin/tools/qvm_volume.py
+++ b/qubesadmin/tools/qvm_volume.py
@@ -72,7 +72,6 @@ class VolumeData:
     """ Wrapper object around :py:class:`qubes.storage.Volume`, mainly to track
         the domains a volume is attached to.
     """
-    # pylint: disable=too-few-public-methods
     def __init__(self, volume):
         self.pool = volume.pool
         self.vid = volume.vid

--- a/qubesadmin/tools/xcffibhelpers.py
+++ b/qubesadmin/tools/xcffibhelpers.py
@@ -29,7 +29,6 @@ import xcffib
 class XkbUseExtensionReply(xcffib.Reply):
     """Helper class to parse XkbUseExtensionReply
     Contains hardcoded values based on X11/XKBproto.h"""
-    # pylint: disable=too-few-public-methods
     def __init__(self, unpacker):
         if isinstance(unpacker, xcffib.Protobj):
             unpacker = xcffib.MemoryUnpacker(unpacker.pack())
@@ -47,7 +46,6 @@ class XkbUseExtensionCookie(xcffib.Cookie):
 
 class XkbGetStateReply(xcffib.Reply):
     """Helper class to parse XkbGetState; copy&paste from X11/XKBproto.h"""
-    # pylint: disable=too-few-public-methods
     _typedef = """
         BYTE    type;
         BYTE    deviceID;


### PR DESCRIPTION
None of the removed comments triggered in the first place.

Note: This effectively removed ALL `disable=too-few-public-methods` comments.