### PR TITLE
tools: fix qvm-run -u root on template imported from R4.2

### DIFF
--- a/qubesadmin/tools/qvm_run.py
+++ b/qubesadmin/tools/qvm_run.py
@@ -284,15 +284,19 @@ def run_command_single(args, vm):
             service = "qubes.VMShell"
             if args.gui and args.dispvm:
                 service += "+WaitForSession"
-            elif args.user == "root":
-                service = "qubes.VMRootShell"
-                args.user = None
+            # if there is no vmexec, surely qubes.VMRootShell is also too old
+            # - see comment below
             shell_cmd = " ".join(shlex.quote(arg) for arg in all_args)
     else:
         service = "qubes.VMShell"
         if args.gui and args.dispvm:
             service += "+WaitForSession"
-        elif args.user == "root":
+        elif args.user == "root" and vm.features.check_with_template(
+                "supported-rpc.qubes.VMRootExec", False
+        ):
+            # The above intentionally checks for VMRootExec, not VMRootShell.
+            # When VMRootExec was introduced, both VMRootExec and VMRootShell
+            # got also force-user=root setting necessary for the below to work.
             service = "qubes.VMRootShell"
             args.user = None
         shell_cmd = args.cmd


### PR DESCRIPTION
Template imported from R4.2 already has qubes.VMRootShell service, but
it isn't really running as root by default. It's only R4.3+ when both
qubes.VMRootShell and qubes.VMRootExec got also force-user=root setting.
Since the check for VMRootExec is already needed anyway, use the same to
check if using qubes.VMRootShell makes sense, as both changes were
introduced at the same time in core-agent-linux:

    1c538af2 Use rpc-config for running qubes.VMRoot* services as root
    563a9cfa Add qubes.VMRootExec service

This is more flexible method than hardcoding version check.

Fixes QubesOS/qubes-issues#10590