### PR TITLE
Use qube's default_dispvm as target for @dispvm

### DIFF
--- a/qubesadmin/base.py
+++ b/qubesadmin/base.py
@@ -91,9 +91,16 @@ class PropertyHolder:
             if dest.startswith("@dispvm:"):
                 dest = dest[len("@dispvm:") :]
             else:
-                dest: QubesVM | None = getattr(self.app, "default_dispvm", None)
-                if dest:
-                    dest = dest.name
+                dest: QubesVM | None = getattr(
+                    self.app.domains.get_blind(self.app.local_name),
+                    "default_dispvm",
+                    None
+                )
+                if not dest:
+                    raise qubesadmin.exc.QubesVMNotFoundError(
+                        "%s has empty 'default_dispvm' property, but it is "
+                        "required when target is @dispvm", self.app.local_name
+                    )
         # have the actual implementation at Qubes() instance
         return self.app.qubesd_call(dest, method, arg, payload,
             payload_stream)

--- a/qubesadmin/tests/tools/qvm_run.py
+++ b/qubesadmin/tests/tools/qvm_run.py
@@ -652,7 +652,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
 
     def test_008_dispvm_remote(self):
         self.app.expected_calls[
-            ("dom0", "admin.property.Get", "default_dispvm", None)
+            ("testvm", "admin.vm.property.Get", "default_dispvm", None)
         ] = b"0\x00default=True type=vm default-dvm"
         self.app.expected_calls[
             ("default-dvm", "admin.vm.property.Get", "guivm", None)
@@ -721,7 +721,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             ("disp123", "admin.vm.property.Get", "qrexec_timeout", None)
         ] = b"0\x00default=yes type=int 30"
         self.app.expected_calls[
-            ("dom0", "admin.property.Get", "default_dispvm", None)
+            ("testvm", "admin.vm.property.Get", "default_dispvm", None)
         ] = b"0\x00default=True type=vm default-dvm"
         self.app.expected_calls[
             ("default-dvm", "admin.vm.property.Get", "guivm", None)
@@ -859,7 +859,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             b"0\x00"
         )
         self.app.expected_calls[
-            ("dom0", "admin.property.Get", "default_dispvm", None)
+            ("testvm", "admin.vm.property.Get", "default_dispvm", None)
         ] = b"0\x00default=True type=vm default-dvm"
         self.app.expected_calls[
             ("default-dvm", "admin.vm.property.Get", "guivm", None)
@@ -944,7 +944,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             b"0\x00"
         )
         self.app.expected_calls[
-            ("dom0", "admin.property.Get", "default_dispvm", None)
+            ("testvm", "admin.vm.property.Get", "default_dispvm", None)
         ] = b"0\x00default=True type=vm default-dvm"
         self.app.expected_calls[
             ("default-dvm", "admin.vm.property.Get", "guivm", None)
@@ -1363,7 +1363,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
 
     def test_030_no_shell_dispvm(self):
         self.app.expected_calls[
-            ("dom0", "admin.property.Get", "default_dispvm", None)
+            ("testvm", "admin.vm.property.Get", "default_dispvm", None)
         ] = b"0\x00default=True type=vm test-vm"
         self.app.expected_calls[
             ("test-vm", "admin.vm.feature.CheckWithTemplate", "vmexec", None)
@@ -1392,7 +1392,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
 
     def test_031_argparse_bug_workaround(self):
         self.app.expected_calls[
-            ("dom0", "admin.property.Get", "default_dispvm", None)
+            ("testvm", "admin.vm.property.Get", "default_dispvm", None)
         ] = b"0\x00default=True type=vm test-vm"
         self.app.expected_calls[
             ("test-vm", "admin.vm.feature.CheckWithTemplate", "vmexec", None)


### PR DESCRIPTION
The handling is a bit weird because we haven't accessed the disposable
object yet, therefore, we try to get what would be the disposable
template when calling admin.vm.CreateDisposable.

Raise exception if property is empty, as we can't proceed in that
case.

Fixes: https://github.com/QubesOS/qubes-issues/issues/10747