### PR TITLE
qvm-template-postprocess: add installation complete message

### DIFF
--- a/qubesadmin/tools/qvm_template_postprocess.py
+++ b/qubesadmin/tools/qvm_template_postprocess.py
@@ -346,6 +346,8 @@ async def post_install(args):
             subprocess.call(['sync', '-f', os.path.dirname(args.dir)])
             subprocess.call(['fstrim', os.path.dirname(args.dir)])
 
+    vm.log.info("Template '%s' installation complete", vm.name)
+
     return 0
 
 


### PR DESCRIPTION
Currently, the final user-facing log during template installation is `"Importing data ..."`, which leaves users uncertain if the background post-installation tasks have finished.

Add an explicit info log at the end of the `post_install` function to provide a clear, unmistakable signal that the template installation is fully complete.

Fixes QubesOS/qubes-issues#10753