### PR TITLE
Escape unsafe fileno()

### DIFF
--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -23,6 +23,7 @@
 Main Qubes() class and related classes.
 """
 import grp
+import io
 import os
 import shlex
 import socket
@@ -955,7 +956,11 @@ class QubesLocal(QubesBase):
         qrexec_opts = ["-d", dest]
         if filter_esc:
             qrexec_opts.extend(["-t"])
-        if filter_esc or os.isatty(sys.stderr.fileno()):
+        try:
+            stderr_isatty = os.isatty(sys.stderr.fileno())
+        except io.UnsupportedOperation:
+            stderr_isatty = False
+        if filter_esc or stderr_isatty:
             qrexec_opts.extend(["-T"])
         if localcmd:
             qrexec_opts.extend(["-l", localcmd])
@@ -1065,9 +1070,11 @@ class QubesRemote(QubesBase):
         qrexec_opts = []
         if filter_esc:
             qrexec_opts.extend(["-t"])
-        if filter_esc or (
-            os.isatty(sys.stderr.fileno()) and "stderr" not in kwargs
-        ):
+        try:
+            stderr_isatty = os.isatty(sys.stderr.fileno())
+        except io.UnsupportedOperation:
+            stderr_isatty = False
+        if filter_esc or (stderr_isatty and "stderr" not in kwargs):
             qrexec_opts.extend(["-T"])
         if not autostart and not self.domains.get_blind(dest).is_running():
             raise qubesadmin.exc.QubesVMNotRunningError(

--- a/qubesadmin/tests/app.py
+++ b/qubesadmin/tests/app.py
@@ -24,6 +24,7 @@ import os
 import shutil
 import socket
 import subprocess
+import sys
 import unittest
 
 import multiprocessing
@@ -1041,8 +1042,10 @@ class TC_20_QubesLocal(unittest.TestCase):
         with open(self.tmpdir + '/payload', 'rb') as payload_f:
             self.assertEqual(payload_f.read(), expected)
 
+    @mock.patch.object(sys, 'stderr')
     @mock.patch('os.isatty', lambda fd: fd == 2)
-    def test_010_run_service(self):
+    def test_010_run_service(self, mock_stderr):
+        mock_stderr.fileno.return_value = 2
         self.listen_and_send(b'0\0')
         with mock.patch('subprocess.Popen') as mock_proc:
             self.app.run_service('some-vm', 'service.name')
@@ -1069,8 +1072,10 @@ class TC_20_QubesLocal(unittest.TestCase):
         self.assertEqual(self.get_request(),
             b'admin.vm.Start+ dom0 name some-vm\0')
 
+    @mock.patch.object(sys, 'stderr')
     @mock.patch('os.isatty', lambda fd: fd == 2)
-    def test_012_run_service_user(self):
+    def test_012_run_service_user(self, mock_stderr):
+        mock_stderr.fileno.return_value = 2
         self.listen_and_send(b'0\0')
         with mock.patch('subprocess.Popen') as mock_proc:
             self.app.run_service('some-vm', 'service.name', user='user')
@@ -1099,6 +1104,9 @@ class TC_30_QubesRemote(unittest.TestCase):
         })
         self.proc_patch = mock.patch('subprocess.Popen', self.proc_mock)
         self.proc_patch.start()
+        self.stderr_patch = mock.patch.object(sys, 'stderr')
+        self.mock_stderr = self.stderr_patch.start()
+        self.mock_stderr.fileno.return_value = 2
         self.app = qubesadmin.app.QubesRemote()
 
     def set_proc_stdout(self, send_data):
@@ -1107,6 +1115,7 @@ class TC_30_QubesRemote(unittest.TestCase):
         })
 
     def tearDown(self):
+        self.stderr_patch.stop()
         self.proc_patch.stop()
         super().tearDown()
 

--- a/qubesadmin/tools/qvm_backup_restore.py
+++ b/qubesadmin/tools/qvm_backup_restore.py
@@ -21,6 +21,7 @@
 '''Console frontend for backup restore code'''
 
 import getpass
+import io
 import os
 import sys
 
@@ -214,11 +215,15 @@ def handle_broken(app, args, restore_info):
 
 def print_backup_log(backup_log):
     """Print a log on stdout, coloring it red if it's a terminal"""
-    if os.isatty(sys.stdout.fileno()):
+    try:
+        stdout_isatty = os.isatty(sys.stdout.fileno())
+    except io.UnsupportedOperation:
+        stdout_isatty = False
+    if stdout_isatty:
         sys.stdout.write('\033[0;31m')
         sys.stdout.flush()
     sys.stdout.buffer.write(backup_log)
-    if os.isatty(sys.stdout.fileno()):
+    if stdout_isatty:
         sys.stdout.write('\033[0m')
         sys.stdout.flush()
 

--- a/qubesadmin/tools/qvm_run.py
+++ b/qubesadmin/tools/qvm_run.py
@@ -21,6 +21,7 @@
 """qvm-run tool"""
 import argparse
 import contextlib
+import io
 import os
 import shlex
 import signal
@@ -129,11 +130,16 @@ parser.add_argument(
     help="disable colouring the stderr",
 )
 
+try:
+    _stdout_isatty = os.isatty(sys.stdout.fileno())
+except io.UnsupportedOperation:
+    _stdout_isatty = False
+
 parser.add_argument(
     "--filter-escape-chars",
     action="store_true",
     dest="filter_esc",
-    default=os.isatty(sys.stdout.fileno()),
+    default=_stdout_isatty,
     help="filter terminal escape sequences (default if output is terminal)",
 )
 
@@ -348,7 +354,11 @@ def main(args=None, app=None):
         if args.color_output is None and args.filter_esc:
             args.color_output = 31
 
-        if args.color_stderr is None and os.isatty(sys.stderr.fileno()):
+        try:
+            stderr_isatty = os.isatty(sys.stderr.fileno())
+        except io.UnsupportedOperation:
+            stderr_isatty = False
+        if args.color_stderr is None and stderr_isatty:
             args.color_stderr = 31
 
     if len(args.domains) > 1 and args.passio and not args.localcmd:


### PR DESCRIPTION
In several places the code uses
```python3
os.isatty(sys.stderr.fileno())
```

but there is no guarantee that `sys.stderr.fileno()` exists in the first place (e.g. pipes, IDE runners, etc.)

Typical case that breaks: Pycharm test runner.