### PR TITLE
tests: mock_app: register per-VM admin.vm.List call

### DIFF
--- a/qubesadmin/tests/mock_app.py
+++ b/qubesadmin/tests/mock_app.py
@@ -439,6 +439,10 @@ class MockQube:
         list_call = f"{name} class={klass} state={state}\n".encode()
         vm_list += list_call
         self.qapp.expected_calls[vm_list_call] = vm_list
+        # Also register per-VM admin.vm.List call (used by .klass property)
+        self.qapp.expected_calls[
+            (name, "admin.vm.List", None, None)
+        ] = b"0\x00" + list_call
 
     def update_calls(self):
         """


### PR DESCRIPTION
Commit 84edd42 changed the .klass property to use admin.vm.List directed at a specific VM instead of admin.vm.property.Get+klass. MockQube._add_to_vm_list only registered the global dom0 admin.vm.List call, causing tests to fail with unexpected call errors.

Register the per-VM admin.vm.List expected call for each MockQube so tests work correctly with the updated .klass implementation.

Fixes QubesOS/qubes-issues#10770