### PR TITLE
Update docstring to better reflect difference between qvm-kill and qvm-shutdown --force

### DIFF
--- a/qubesadmin/tools/qvm_kill.py
+++ b/qubesadmin/tools/qvm_kill.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU Lesser General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-'''qvm-kill - forceful shutdown'''
+'''Immediately terminate a qube without a graceful shutdown sequence.'''
 
 
 import sys
@@ -26,7 +26,9 @@ import qubesadmin.exc
 import qubesadmin.tools
 
 parser = qubesadmin.tools.QubesArgumentParser(
-    description='forceful shutdown of a domain', vmname_nargs='+')
+    description='immediately terminate a qube without a graceful shutdown'
+                ' sequence',
+    vmname_nargs='+')
 
 def main(args=None, app=None):
     '''Main routine of :program:`qvm-kill`.

--- a/qubesadmin/tools/qvm_shutdown.py
+++ b/qubesadmin/tools/qvm_shutdown.py
@@ -53,7 +53,9 @@ parser.add_argument('--timeout',
 parser.add_argument(
     '--force',
     action='store_true', default=False,
-    help='force shutdown regardless of connected domains; use with caution')
+    help='shut down even if other qubes depend on this one (e.g. as NetVM'
+         ' or AudioVM); does not affect how the qube itself is shut down;'
+         ' use with caution')
 
 parser.add_argument(
     '--dry-run',


### PR DESCRIPTION
Meant to address the first half of https://github.com/QubesOS/qubes-issues/issues/10726

(note: after reading https://github.com/QubesOS/qubes-issues/issues/10650#issuecomment-3888949050 it seems that the above-mentioned issue is actually not about manpages but about the qubes-docs - still I believe this is helpful)