### PR TITLE
qvm_shutdown: do not --force if --all --exclude

### DIFF
--- a/doc/manpages/qvm-shutdown.rst
+++ b/doc/manpages/qvm-shutdown.rst
@@ -25,7 +25,8 @@ Options
 
 .. option:: --all
 
-   perform the action on all qubes; implies :option:`--force`
+   perform the action on all qubes; implies :option:`--force` unless
+   :option:`--exclude` is also specified
 
 .. option:: --exclude=EXCLUDE
 

--- a/qubesadmin/tests/tools/qvm_shutdown.py
+++ b/qubesadmin/tests/tools/qvm_shutdown.py
@@ -220,3 +220,32 @@ class TC_00_qvm_shutdown(qubesadmin.tests.QubesTestCase):
             qubesadmin.tools.qvm_shutdown.main(
                 ['--wait', '--all', '--timeout=1'], app=self.app)
         self.assertAllCalled()
+
+    def test_016_all_exclude_noforce(self):
+        '''test --all --exclude does NOT imply --force'''
+        self.app.expected_calls[
+            ('some-vm', 'admin.vm.Shutdown', None, None)] = \
+            b'0\x00'
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.List', None, None)] = \
+            b'0\x00' \
+            b'some-vm class=AppVM state=Running\n' \
+            b'other-vm class=AppVM state=Running\n'
+        qubesadmin.tools.qvm_shutdown.main(['--all', '--exclude', 'other-vm'],
+                                           app=self.app)
+        self.assertAllCalled()
+
+    def test_017_all_exclude_force_explicit(self):
+        '''test --all --exclude --force DOES imply --force'''
+        self.app.expected_calls[
+            ('some-vm', 'admin.vm.Shutdown', 'force', None)] = \
+            b'0\x00'
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.List', None, None)] = \
+            b'0\x00' \
+            b'some-vm class=AppVM state=Running\n' \
+            b'other-vm class=AppVM state=Running\n'
+        qubesadmin.tools.qvm_shutdown.main(['--all', '--exclude', 'other-vm',
+                                            '--force'],
+                                           app=self.app)
+        self.assertAllCalled()

--- a/qubesadmin/tools/qvm_shutdown.py
+++ b/qubesadmin/tools/qvm_shutdown.py
@@ -72,7 +72,7 @@ def failed_domains(vms):
 def main(args=None, app=None):  # pylint: disable=missing-docstring
     args = parser.parse_args(args, app=app)
 
-    force = args.force or bool(args.all_domains)
+    force = args.force or (args.all_domains and not args.exclude)
 
     if have_events:
         loop = asyncio.new_event_loop()


### PR DESCRIPTION
See discussion in https://github.com/QubesOS/qubes-issues/issues/10440
Closes https://github.com/QubesOS/qubes-issues/issues/10440

As described in https://github.com/QubesOS/qubes-issues/issues/10440#issuecomment-3975224829, also requires the following PRs to be merged in the same round:
* https://github.com/QubesOS/qubes-dist-upgrade/pull/24

Note: this IS a breaking change. Scripts using `--all --exclude` and relying on `--force` WILL break.