### PR TITLE
rtd: remove installing from ci/requirements.txt

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,10 +3,12 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  jobs:
+    post_install:
+    # Since the install step is overridden, pip is no longer updated automatically.
+    - pip install --upgrade pip
+    - pip install -e .
 
 sphinx:
   configuration: doc/conf.py
 
-python:
-  install:
-  - requirements: ci/requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "pyyaml>=6.0",
     "tqdm>=4.67",
     "xcffib>=1.5",
-    "python3-xlib>=0.15",
+    "python-xlib>=0.33",
     "rpm>=0.4.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "tqdm>=4.67",
     "xcffib>=1.5",
     "python3-xlib>=0.15",
+    "rpm>=0.4.0",
 ]
 
 [dependency-groups]
@@ -35,7 +36,6 @@ dev = [
     "setuptools>=82.0.0",
     "black>=26.1.0",
     "mypy>=1.19.1",
-    "rpm>=0.4.0",
 ]
 future-dev = [  # those tools are very efficient but not packaged for major distributions yet
     {include-group = "dev"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pyyaml>=6.0",
     "tqdm>=4.67",
     "xcffib>=1.5",
+    "python3-xlib>=0.15",
 ]
 
 [dependency-groups]
@@ -34,7 +35,6 @@ dev = [
     "setuptools>=82.0.0",
     "black>=26.1.0",
     "mypy>=1.19.1",
-    "python3-xlib>=0.15",
     "rpm>=0.4.0",
 ]
 future-dev = [  # those tools are very efficient but not packaged for major distributions yet


### PR DESCRIPTION
It isn't there anymore. Dependencies are listed in standard
pyproject.toml now.

Fixes: 49c83a8 "transition to modern pyproject.toml build"