### PR TITLE
tools/qvm-run: translate negative return codes (signals) to positive exit codes

### DIFF
--- a/qubesadmin/tools/qvm_run.py
+++ b/qubesadmin/tools/qvm_run.py
@@ -483,6 +483,9 @@ def main(args=None, app=None):
         try:
             for vm, proc in procs:
                 this_retcode = proc.wait()
+                if this_retcode < 0:
+                    this_retcode = 128 + abs(this_retcode)
+
                 if this_retcode and verbose > 0:
                     print_no_color(
                         "{}: command failed with code: {}".format(
@@ -491,7 +494,7 @@ def main(args=None, app=None):
                         file=sys.stderr,
                         color=args.color_stderr,
                     )
-                retcode = max(retcode, proc.wait())
+                retcode = max(retcode, this_retcode)
         except KeyboardInterrupt:
             for vm, proc in procs:
                 with contextlib.suppress(ProcessLookupError):


### PR DESCRIPTION
When qvm-run is interrupted via SIGINT (ctrl-c), subprocess.wait() 
returns a negative value (-signal). This translates negative return 
codes to positive exit codes using abs(retcode) + 128, consistent 
with shell signal handling conventions.

Fixes QubesOS/qubes-issues#10468