### PR TITLE
Typehint label / log / spinner / storage

### DIFF
--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -148,8 +148,15 @@ class VMCollection:
 
     T = TypeVar("T")
 
-    def get(self, item: str | QubesVM, default: QubesVM | T=None)\
-            -> QubesVM | T:
+    @typing.overload
+    def get(self, item: str | QubesVM) -> QubesVM:
+        ...
+    @typing.overload
+    def get(self, item: str | QubesVM, default: T) -> QubesVM | T:
+        ...
+    # Overloaded to handle default None return type
+    def get(self, item: str | QubesVM, default: object=None)\
+            -> object:
         """
         Get a VM object, or return *default* if it can't be found.
         """

--- a/qubesadmin/backup/core2.py
+++ b/qubesadmin/backup/core2.py
@@ -87,7 +87,7 @@ class Core2VM(qubesadmin.backup.BackupVM):
 
         expire = node.get('expire')
 
-        kwargs = {
+        kwargs: dict[str, object] = {
             'action': action,
         }
         if dsthost:

--- a/qubesadmin/backup/restore.py
+++ b/qubesadmin/backup/restore.py
@@ -1438,7 +1438,7 @@ class BackupRestore:
         queue.put(QUEUE_FINISHED)
 
         qubes_xml_path = os.path.join(self.tmpdir, 'qubes-restored.xml')
-        handlers = {
+        handlers: dict[str, Callable] = {
             'qubes.xml': functools.partial(self._save_qubes_xml, qubes_xml_path)
             }
         extract_proc = self._start_inner_extraction_worker(queue, handlers)

--- a/qubesadmin/device_protocol.py
+++ b/qubesadmin/device_protocol.py
@@ -513,7 +513,8 @@ class VirtualDevice:
                 other.port, AnyPort
             ):
                 return False
-            reprs = {self: [self.port], other: [other.port]}
+            reprs: dict[VirtualDevice | DeviceAssignment, list[Port | str]] \
+                = {self: [self.port], other: [other.port]}
             for obj, obj_repr in reprs.items():
                 if obj.device_id != "*":
                     obj_repr.append(obj.device_id)

--- a/qubesadmin/label.py
+++ b/qubesadmin/label.py
@@ -19,8 +19,13 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 '''VM Labels'''
+from __future__ import annotations
+from typing import TYPE_CHECKING
 
 import qubesadmin.exc
+
+if TYPE_CHECKING:
+    from qubesadmin.app import QubesBase
 
 
 class Label:
@@ -32,14 +37,14 @@ class Label:
     :param str name: label's name like "red" or "green"
     '''
 
-    def __init__(self, app, name):
+    def __init__(self, app: QubesBase, name: str):
         self.app = app
         self._name = name
-        self._color = None
-        self._index = None
+        self._color: str | None = None
+        self._index: int | None = None
 
     @property
-    def color(self):
+    def color(self) -> str:
         '''color specification as in HTML (``#abcdef``)'''
         if self._color is None:
             try:
@@ -51,18 +56,18 @@ class Label:
         return self._color
 
     @property
-    def name(self):
+    def name(self) -> str:
         '''label's name like "red" or "green"'''
         return self._name
 
     @property
-    def icon(self):
+    def icon(self) -> str:
         '''freedesktop icon name, suitable for use in
         :py:meth:`PyQt4.QtGui.QIcon.fromTheme`'''
         return 'appvm-' + self.name
 
     @property
-    def index(self):
+    def index(self) -> int:
         '''label numeric identifier'''
         if self._index is None:
             try:
@@ -73,13 +78,13 @@ class Label:
             self._index = int(qubesd_response.decode())
         return self._index
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self._name
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Label):
             return self.name == other.name
         return NotImplemented
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.name)

--- a/qubesadmin/log.py
+++ b/qubesadmin/log.py
@@ -37,7 +37,7 @@ formatter_log = logging.Formatter(FORMAT_LOG)
 formatter_debug = logging.Formatter(FORMAT_DEBUG)
 
 
-def enable():
+def enable() -> None:
     '''Enable global logging
 
     Use :py:mod:`logging` module from standard library to log messages.
@@ -58,7 +58,7 @@ def enable():
     logging.root.setLevel(logging.INFO)
 
 
-def enable_debug():
+def enable_debug() -> None:
     '''Enable debug logging
 
     Enable more messages and additional info to message format.

--- a/qubesadmin/spinner.py
+++ b/qubesadmin/spinner.py
@@ -39,9 +39,11 @@ sheltering branches? Why are you bothered by its uselessness?”
 import curses
 import io
 import itertools
+import typing
+from typing import IO
 
-CHARSET = '-\\|/'
-ENTERPRISE_CHARSET = CHARSET * 4 + '-._.-^' * 2
+CHARSET: str = '-\\|/'
+ENTERPRISE_CHARSET: str = CHARSET * 4 + '-._.-^' * 2
 
 class AbstractSpinner:
     '''The base class for all Spinners
@@ -54,35 +56,35 @@ class AbstractSpinner:
         2. zero or more calls to :py:meth:`update()`
         3. exactly one call to :py:meth:`hide()`
     '''
-    def __init__(self, stream, charset=CHARSET):
+    def __init__(self, stream: IO, charset: str=CHARSET):
         self.stream = stream
         self.charset = itertools.cycle(charset)
 
-    def show(self, prompt):
+    def show(self, prompt: str) -> None:
         '''Show the spinner, with a prompt
 
         :param str prompt: prompt, like "please wait"
         '''
         raise NotImplementedError()
 
-    def hide(self):
+    def hide(self) -> None:
         '''Hide the spinner and the prompt'''
         raise NotImplementedError()
 
-    def update(self):
+    def update(self) -> None:
         '''Show next spinner character'''
         raise NotImplementedError()
 
 
 class DummySpinner(AbstractSpinner):
     '''Dummy spinner, does not do anything'''
-    def show(self, prompt):
+    def show(self, prompt: str) -> None:
         pass
 
-    def hide(self):
+    def hide(self) -> None:
         pass
 
-    def update(self):
+    def update(self) -> None:
         pass
 
 
@@ -90,21 +92,21 @@ class QubesSpinner(AbstractSpinner):
     '''Basic spinner
 
     This spinner uses standard ASCII control characters'''
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.hidelen = 0
         self.cub1 = '\b'
 
-    def show(self, prompt):
+    def show(self, prompt: str) -> None:
         self.hidelen = len(prompt) + 2
         self.stream.write('{} {}'.format(prompt, next(self.charset)))
         self.stream.flush()
 
-    def hide(self):
+    def hide(self) -> None:
         self.stream.write('\r' + ' ' * self.hidelen + '\r')
         self.stream.flush()
 
-    def update(self):
+    def update(self) -> None:
         self.stream.write(self.cub1 + next(self.charset))
         self.stream.flush()
 
@@ -114,7 +116,7 @@ class QubesSpinnerEnterpriseEdition(QubesSpinner):
 
     This is tty- and terminfo-aware spinner. Recommended.
     '''
-    def __init__(self, stream, charset=None):
+    def __init__(self, stream: IO, charset: str | None=None):
         # our Enterprise logic follows
         self.stream_isatty = stream.isatty()
         if charset is None:
@@ -126,18 +128,20 @@ class QubesSpinnerEnterpriseEdition(QubesSpinner):
             try:
                 curses.setupterm()
                 self.has_terminfo = True
-                self.cub1 = curses.tigetstr('cub1').decode()
+                self.cub1 = typing.cast(bytes, curses.tigetstr('cub1')).decode()
             except (curses.error, io.UnsupportedOperation):
                 # we are in very non-Enterprise environment
                 self.has_terminfo = False
         else:
             self.cub1 = ''
 
-    def hide(self):
+    def hide(self) -> None:
         if self.stream_isatty:
             hideseq = '\r' + ' ' * self.hidelen + '\r'
             if self.has_terminfo:
-                hideseq_l = (curses.tigetstr('cr'), curses.tigetstr('clr_eol'))
+                hideseq_l = typing.cast(
+                    tuple[bytes, bytes],
+                    (curses.tigetstr('cr'), curses.tigetstr('clr_eol')))
                 if all(seq is not None for seq in hideseq_l):
                     hideseq = ''.join(seq.decode() for seq in hideseq_l)
         else:

--- a/qubesadmin/storage.py
+++ b/qubesadmin/storage.py
@@ -19,12 +19,20 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 """Storage subsystem."""
+from __future__ import annotations
+from typing import BinaryIO, TYPE_CHECKING, IO
+from collections.abc import Generator
+
 import qubesadmin.exc
+if TYPE_CHECKING:
+    from qubesadmin.app import QubesBase
 
 
 class Volume:
     """Storage volume."""
-    def __init__(self, app, pool=None, vid=None, vm=None, vm_name=None):
+    def __init__(self, app: QubesBase, pool: str | None=None,
+                 vid: str | None=None, vm: str | None=None,
+                 vm_name: str | None=None):
         """Construct a Volume object.
 
         Volume may be identified using pool+vid, or vm+vm_name. Either of
@@ -49,7 +57,8 @@ class Volume:
         self._vm_name = vm_name
         self._info = None
 
-    def _qubesd_call(self, func_name, payload=None, payload_stream=None):
+    def _qubesd_call(self, func_name: str, payload: bytes | None = None,
+                     payload_stream: IO | None = None) -> bytes:
         """Make a call to qubesd regarding this volume
 
         :param str func_name: API function name, like `Info` or `Resize`
@@ -69,6 +78,7 @@ class Volume:
             method = 'admin.pool.volume.' + func_name
             dest = 'dom0'
             arg = self._pool
+            assert self._vid is not None
             if payload is not None:
                 payload = self._vid.encode('ascii') + b' ' + payload
             else:
@@ -77,7 +87,7 @@ class Volume:
             dest, method, arg, payload=payload,
             payload_stream=payload_stream)
 
-    def _fetch_info(self, force=True):
+    def _fetch_info(self, force: bool = True) -> None:
         """Fetch volume properties
 
         Populate self._info dict
@@ -90,27 +100,29 @@ class Volume:
         info = info.decode('ascii')
         self._info = dict([line.split('=', 1) for line in info.splitlines()])
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Volume):
             return self.pool == other.pool and self.vid == other.vid
         return NotImplemented
 
-    def __lt__(self, other):
+    def __lt__(self, other: object) -> bool:
         # pylint: disable=protected-access
         if isinstance(other, Volume):
             if self._vm and other._vm:
+                assert self._vm_name is not None and other._vm_name is not None
                 return (self._vm, self._vm_name) < (other._vm, other._vm_name)
             if self._vid and other._vid:
+                assert self._pool is not None and other._pool is not None
                 return (self._pool, self._vid) < (other._pool, other._vid)
         return NotImplemented
 
     @property
-    def name(self):
+    def name(self) -> str | None:
         """per-VM volume name, if available"""
         return self._vm_name
 
     @property
-    def pool(self):
+    def pool(self) -> str:
         """Storage volume pool name."""
         if self._pool is not None:
             return self._pool
@@ -118,10 +130,11 @@ class Volume:
             self._fetch_info()
         except qubesadmin.exc.QubesDaemonAccessError:
             raise qubesadmin.exc.QubesPropertyAccessError('pool')
+        assert self._info is not None
         return str(self._info['pool'])
 
     @property
-    def vid(self):
+    def vid(self) -> str:
         """Storage volume id, unique within given pool."""
         if self._vid is not None:
             return self._vid
@@ -129,76 +142,83 @@ class Volume:
             self._fetch_info()
         except qubesadmin.exc.QubesDaemonAccessError:
             raise qubesadmin.exc.QubesPropertyAccessError('vid')
+        assert self._info is not None
         return str(self._info['vid'])
 
     @property
-    def size(self):
+    def size(self) -> int:
         """Size of volume, in bytes."""
         try:
             self._fetch_info()
         except qubesadmin.exc.QubesDaemonAccessError:
             raise qubesadmin.exc.QubesPropertyAccessError('size')
+        assert self._info is not None
         return int(self._info['size'])
 
     @property
-    def usage(self):
+    def usage(self) -> int:
         """Used volume space, in bytes."""
         try:
             self._fetch_info()
         except qubesadmin.exc.QubesDaemonAccessError:
             raise qubesadmin.exc.QubesPropertyAccessError('usage')
+        assert self._info is not None
         return int(self._info['usage'])
 
     @property
-    def rw(self):
+    def rw(self) -> bool:
         """True if volume is read-write."""
         try:
             self._fetch_info()
         except qubesadmin.exc.QubesDaemonAccessError:
             raise qubesadmin.exc.QubesPropertyAccessError('rw')
+        assert self._info is not None
         return self._info['rw'] == 'True'
 
     @rw.setter
-    def rw(self, value):
+    def rw(self, value: object) -> None:
         """Set rw property"""
         self._qubesd_call('Set.rw', str(value).encode('ascii'))
         self._info = None
 
     @property
-    def ephemeral(self):
+    def ephemeral(self) -> bool:
         """True if volume is read-write."""
         try:
             self._fetch_info()
         except qubesadmin.exc.QubesDaemonAccessError:
             raise qubesadmin.exc.QubesPropertyAccessError('ephemeral')
+        assert self._info is not None
         return self._info.get('ephemeral', 'False') == 'True'
 
     @ephemeral.setter
-    def ephemeral(self, value):
+    def ephemeral(self, value: object) -> None:
         """Set rw property"""
         self._qubesd_call('Set.ephemeral', str(value).encode('ascii'))
         self._info = None
 
     @property
-    def snap_on_start(self):
+    def snap_on_start(self) -> bool:
         """Create a snapshot from source on VM start."""
         try:
             self._fetch_info()
         except qubesadmin.exc.QubesDaemonAccessError:
             raise qubesadmin.exc.QubesPropertyAccessError('snap_on_start')
+        assert self._info is not None
         return self._info['snap_on_start'] == 'True'
 
     @property
-    def save_on_stop(self):
+    def save_on_stop(self) -> bool:
         """Commit changes to original volume on VM stop."""
         try:
             self._fetch_info()
         except qubesadmin.exc.QubesDaemonAccessError:
             raise qubesadmin.exc.QubesPropertyAccessError('save_on_stop')
+        assert self._info is not None
         return self._info['save_on_stop'] == 'True'
 
     @property
-    def source(self):
+    def source(self) -> str | None:
         """Volume ID of source volume (for :py:attr:`snap_on_start`).
 
         If None, this volume itself will be used.
@@ -207,26 +227,28 @@ class Volume:
             self._fetch_info()
         except qubesadmin.exc.QubesDaemonAccessError:
             raise qubesadmin.exc.QubesPropertyAccessError('source')
+        assert self._info is not None
         if self._info['source']:
             return self._info['source']
         return None
 
     @property
-    def revisions_to_keep(self):
+    def revisions_to_keep(self) -> int:
         """Number of revisions to keep around"""
         try:
             self._fetch_info()
         except qubesadmin.exc.QubesDaemonAccessError:
             raise qubesadmin.exc.QubesPropertyAccessError('revisions_to_keep')
+        assert self._info is not None
         return int(self._info['revisions_to_keep'])
 
     @revisions_to_keep.setter
-    def revisions_to_keep(self, value):
+    def revisions_to_keep(self, value: object) -> None:
         """Set revisions_to_keep property"""
         self._qubesd_call('Set.revisions_to_keep', str(value).encode('ascii'))
         self._info = None
 
-    def is_outdated(self):
+    def is_outdated(self) -> bool:
         """Returns `True` if this snapshot of a source volume (for
         `snap_on_start`=True) is outdated.
         """
@@ -234,9 +256,10 @@ class Volume:
             self._fetch_info()
         except qubesadmin.exc.QubesDaemonAccessError:
             raise qubesadmin.exc.QubesPropertyAccessError('is_outdated')
+        assert self._info is not None
         return self._info.get('is_outdated', False) == 'True'
 
-    def resize(self, size):
+    def resize(self, size: object) -> None:
         """Resize volume.
 
         Currently only extending is supported.
@@ -246,12 +269,12 @@ class Volume:
         self._qubesd_call('Resize', str(size).encode('ascii'))
 
     @property
-    def revisions(self):
+    def revisions(self) -> list[str]:
         """ Returns iterable containing revision identifiers"""
         revisions = self._qubesd_call('ListSnapshots')
         return revisions.decode('ascii').splitlines()
 
-    def revert(self, revision):
+    def revert(self, revision: str) -> None:
         """ Revert volume to previous revision
 
         :param str revision: Revision identifier to revert to
@@ -260,7 +283,7 @@ class Volume:
             raise TypeError('revision must be a str')
         self._qubesd_call('Revert', revision.encode('ascii'))
 
-    def import_data(self, stream):
+    def import_data(self, stream: BinaryIO) -> None:
         """ Import volume data from a given file-like object.
 
         This function overrides existing volume content.
@@ -269,7 +292,7 @@ class Volume:
         """
         self._qubesd_call('Import', payload_stream=stream)
 
-    def import_data_with_size(self, stream, size):
+    def import_data_with_size(self, stream: IO, size: object) -> None:
         """ Import volume data from a given file-like object, informing qubesd
         that data has a specific size.
 
@@ -283,11 +306,11 @@ class Volume:
             'ImportWithSize', payload=size_line.encode(),
             payload_stream=stream)
 
-    def clear_data(self):
+    def clear_data(self) -> None:
         """ Clear existing volume content. """
         self._qubesd_call('Clear')
 
-    def clone(self, source):
+    def clone(self, source: Volume) -> None:
         """ Clone data from sane volume of another VM.
 
         This function override existing volume content.
@@ -309,7 +332,7 @@ class Pool:
     """ A Pool is used to manage different kind of volumes (File
         based/LVM/Btrfs/...).
     """
-    def __init__(self, app, name=None):
+    def __init__(self, app: QubesBase, name: str | None=None):
         """ Initialize storage pool wrapper
 
         :param app: Qubes() object
@@ -319,23 +342,25 @@ class Pool:
         self.name = name
         self._config = None
 
-    def __str__(self):
+    def __str__(self) -> str:
+        assert self.name is not None
         return self.name
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Pool):
             return self.name == other.name
         if isinstance(other, str):
             return self.name == other
         return NotImplemented
 
-    def __lt__(self, other):
+    def __lt__(self, other: object) -> bool:
         if isinstance(other, Pool):
+            assert self.name is not None and other.name is not None
             return self.name < other.name
         return NotImplemented
 
     @property
-    def usage_details(self):
+    def usage_details(self) -> dict[str, int]:
         """ Storage pool usage details (current - not cached) """
         try:
             pool_usage_data = self.app.qubesd_call(
@@ -346,14 +371,14 @@ class Pool:
         assert pool_usage_data.endswith('\n') or pool_usage_data == ''
         pool_usage_data = pool_usage_data[:-1]
 
-        def _int_split(text):  # pylint: disable=missing-docstring
+        def _int_split(text: str) -> tuple[str, int]:  # pylint: disable=missing-docstring
             key, value = text.split("=", 1)
             return key, int(value)
 
         return dict(_int_split(l) for l in pool_usage_data.splitlines())
 
     @property
-    def config(self):
+    def config(self) -> dict[str, str]:
         """ Storage pool config """
         if self._config is None:
             try:
@@ -369,7 +394,7 @@ class Pool:
         return self._config
 
     @property
-    def size(self):
+    def size(self) -> int | None:
         """ Storage pool size, in bytes"""
         try:
             return int(self.usage_details['data_size'])
@@ -378,7 +403,7 @@ class Pool:
             return None
 
     @property
-    def usage(self):
+    def usage(self) -> int | None:
         """ Space used in the pool, in bytes """
         try:
             return int(self.usage_details['data_usage'])
@@ -387,17 +412,17 @@ class Pool:
             return None
 
     @property
-    def driver(self):
+    def driver(self) -> str:
         """ Storage pool driver """
         return self.config['driver']
 
     @property
-    def revisions_to_keep(self):
+    def revisions_to_keep(self) -> int:
         """Number of revisions to keep around"""
         return int(self.config['revisions_to_keep'])
 
     @revisions_to_keep.setter
-    def revisions_to_keep(self, value):
+    def revisions_to_keep(self, value: object) -> None:
         """Set revisions_to_keep property"""
         self.app.qubesd_call(
             'dom0',
@@ -407,13 +432,13 @@ class Pool:
         self._config = None
 
     @property
-    def ephemeral_volatile(self):
+    def ephemeral_volatile(self) -> bool:
         """Whether volatile volumes in this pool should be encrypted with an
            ephemeral key in dom0"""
         return bool(self.config['ephemeral_volatile'])
 
     @ephemeral_volatile.setter
-    def ephemeral_volatile(self, value):
+    def ephemeral_volatile(self, value: object) -> None:
         """Set ephemeral_volatile property"""
         self.app.qubesd_call(
             'dom0',
@@ -423,7 +448,7 @@ class Pool:
         self._config = None
 
     @property
-    def volumes(self):
+    def volumes(self) -> Generator[Volume]:
         """ Volumes managed by this pool """
         try:
             volumes_data = self.app.qubesd_call(

--- a/qubesadmin/storage.py
+++ b/qubesadmin/storage.py
@@ -111,8 +111,8 @@ class Volume:
             if self._vm and other._vm:
                 assert self._vm_name is not None and other._vm_name is not None
                 return (self._vm, self._vm_name) < (other._vm, other._vm_name)
-            if self._vid and other._vid:
-                assert self._pool is not None and other._pool is not None
+            if self._pool and other._pool:
+                assert self._vid is not None and other._vid is not None
                 return (self._pool, self._vid) < (other._pool, other._vid)
         return NotImplemented
 
@@ -279,8 +279,6 @@ class Volume:
 
         :param str revision: Revision identifier to revert to
         """
-        if not isinstance(revision, str):
-            raise TypeError('revision must be a str')
         self._qubesd_call('Revert', revision.encode('ascii'))
 
     def import_data(self, stream: BinaryIO) -> None:
@@ -332,7 +330,7 @@ class Pool:
     """ A Pool is used to manage different kind of volumes (File
         based/LVM/Btrfs/...).
     """
-    def __init__(self, app: QubesBase, name: str | None=None):
+    def __init__(self, app: QubesBase, name: str):
         """ Initialize storage pool wrapper
 
         :param app: Qubes() object
@@ -343,7 +341,6 @@ class Pool:
         self._config = None
 
     def __str__(self) -> str:
-        assert self.name is not None
         return self.name
 
     def __eq__(self, other: object) -> bool:


### PR DESCRIPTION
Major: type-hint `storage.py`
Minor: type-hint `label.py spinner.py log.py`

## Comments (for `storage.py`)

### 1. safe assert
In `__lt__` we have

```python3
            if self._vid and other._vid:
                return (self._pool, self._vid) < (other._pool, other._vid)
```
Technically, `_vid` is supposed to be non-None if `pool` is non-None, not the other way around. Shouldn't it be `if self.pool and other.pool:` ?

### Type error raise

In `revert`:
```python3
        if not isinstance(revision, str):
            raise TypeError('revision must be a str')
```

but typing `def revert(self, revision: str) -> None:` raises no type-checker error, indicating that it's never called with a non-str argument. Is the raise really necessary ?

### None `__str__`

```python3
    def __str__(self):
        return self.name
```

but `self.name` can be `None`, and `__str__` should never be `None`. I added an `assert is not None` for now.

### LT assert

```python3
    def __lt__(self, other: object) -> bool:
        if isinstance(other, Pool):
            return self.name < other.name
```
What guarantees that `self.name` or `other.name` is defined here ?
