### PR TITLE
qvm_device: copy assign options to suggested attach command

### DIFF
--- a/qubesadmin/tests/tools/qvm_device.py
+++ b/qubesadmin/tests/tools/qvm_device.py
@@ -379,6 +379,36 @@ class TC_00_qvm_device(qubesadmin.tests.QubesTestCase):
                 app=self.app)
             self.assertIn('Assigned.', buf.getvalue())
             self.assertIn('now restart domain', buf.getvalue())
+            self.assertIn('-o read-only=yes', buf.getvalue())
+        self.assertAllCalled()
+
+    def test_032b_assign_option_in_hint(self):
+        """ Test that -o options are copied to the suggested attach command """
+        self.app.domains['test-vm2'].is_running = lambda: True
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.device.testclass.Assign',
+            'test-vm1+dev1+dead+beef+babe+u012345',
+            b"device_id='dead:beef:babe:u012345' port_id='dev1' "
+            b"devclass='testclass' backend_domain='test-vm1' "
+            b"mode='auto-attach' frontend_domain='test-vm2' "
+            b"_frontend-dev='xvdl'"
+        )] = b'0\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.device.testclass.Attached', None, None
+        )] = b'0\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.GetAll', None, None
+        )] = b'2\0QubesDaemonNoResponseError\0\0err\0'
+        self.app.expected_calls[(
+            'test-vm2', 'admin.vm.property.Get', 'devices_denied', None
+        )] = b'0\0default=False type=str '
+        with qubesadmin.tests.tools.StdoutBuffer() as buf:
+            qubesadmin.tools.qvm_device.main(
+                ['testclass', 'assign', '-o', 'frontend-dev=xvdl',
+                 'test-vm2', 'test-vm1:dev1'],
+                app=self.app)
+            self.assertIn('Assigned.', buf.getvalue())
+            self.assertIn('-o frontend-dev=xvdl', buf.getvalue())
         self.assertAllCalled()
 
     def test_033_assign_invalid(self):

--- a/qubesadmin/tools/qvm_device.py
+++ b/qubesadmin/tools/qvm_device.py
@@ -356,11 +356,18 @@ def assign_device(args):
         _print_attach_hint(assignment, vm)
 
 
+def _build_options_str(options):
+    """Build CLI option flags string from assignment options dict."""
+    parts = [f"-o {key}={value}" for key, value in options.items()]
+    return (" " + " ".join(parts)) if parts else ""
+
+
 def _print_attach_hint(assignment, vm):
     # pylint: disable=missing-function-docstring
     attached = vm.devices[assignment.devclass].get_attached_devices()
+    options_str = _build_options_str(assignment.options)
     ports = [
-        f"\tqvm-{assignment.devclass} attach {vm} "
+        f"\tqvm-{assignment.devclass} attach{options_str} {vm} "
         f"{assignment.backend_domain}:{dev.port_id}"
         for dev in assignment.devices
         if dev not in attached and not isinstance(dev, UnknownDevice)


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#10203

## Problem

When using `qvm-<block,usb,pci> assign` with options like `--ro` or
`-o frontend-dev=xvdl`, the suggested attach command printed after a
successful assign omits those options:

```
Assigned. To attach you can now restart domain or run:
	qvm-block attach sys-borg-server sys-usb2:sda2
```

Running the suggested command without the original options would attach
the device with different settings than intended.

## Fix

Introduce `_build_options_str()` that converts the assignment's options
dict back to CLI flags (`--ro` for `read-only=yes`, `-o key=value` for
everything else), and append it to the suggested attach command:

```
Assigned. To attach you can now restart domain or run:
	qvm-block attach --ro -o frontend-dev=xvdl sys-borg-server sys-usb2:sda2
```

## Tests

- Updated `test_032_assign_ask_and_options` to assert `--ro` appears in
  the hint output.
- Added `test_032b_assign_option_in_hint` to cover `-o key=value` options.