### PR TITLE
tools: fix vm.run(user="root") on template imported from R4.2 (cont)

### DIFF
--- a/qubesadmin/tests/vm/actions.py
+++ b/qubesadmin/tests/vm/actions.py
@@ -93,6 +93,51 @@ class TC_00_Actions(qubesadmin.tests.vm.VMTestCase):
             ('test-vm', 'qubes.VMShell', b'some command& exit\n'),
         ])
 
+    def test_012_run_linux_root(self):
+        self.app.expected_calls[
+            ("test-vm", "admin.vm.feature.CheckWithTemplate", "os", None)
+        ] = b"2\x00QubesFeatureNotFoundError\x00\x00Feature 'os' not set\x00"
+        self.app.expected_calls[
+            (
+                "test-vm",
+                "admin.vm.feature.CheckWithTemplate",
+                "supported-rpc.qubes.VMRootExec",
+                None,
+            )
+        ] = (
+            b"2\x00QubesFeatureNotFoundError\x00\x00"
+            b"Feature 'supported-rpc.qubes.VMRootExec' not set\x00"
+        )
+        self.vm.run("some command", user="root")
+        self.assertEqual(
+            self.app.service_calls,
+            [
+                ("test-vm", "qubes.VMShell", {"user": "root"}),
+                ("test-vm", "qubes.VMShell", b"some command; exit\n"),
+            ],
+        )
+
+    def test_013_run_linux_root_vmrootshell(self):
+        self.app.expected_calls[
+            ("test-vm", "admin.vm.feature.CheckWithTemplate", "os", None)
+        ] = b"2\x00QubesFeatureNotFoundError\x00\x00Feature 'os' not set\x00"
+        self.app.expected_calls[
+            (
+                "test-vm",
+                "admin.vm.feature.CheckWithTemplate",
+                "supported-rpc.qubes.VMRootExec",
+                None,
+            )
+        ] = b"0\x001"
+        self.vm.run("some command", user="root")
+        self.assertEqual(
+            self.app.service_calls,
+            [
+                ("test-vm", "qubes.VMRootShell", {}),
+                ("test-vm", "qubes.VMRootShell", b"some command; exit\n"),
+            ],
+        )
+
     def test_015_run_with_args_shell(self):
         self.app.expected_calls[
             ('test-vm', 'admin.vm.feature.CheckWithTemplate', 'vmexec',

--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -364,13 +364,20 @@ class QubesVM(qubesadmin.base.PropertyHolder):
         # pylint: disable=redefined-builtin
         try:
             service = "qubes.VMShell"
-            if kwargs.get("user", None) == "root":
+            # intentionally check for qubes.VMRootExec, as this is when
+            # qubes.VMRootShell got force-user='root' in its config
+            if kwargs.get(
+                "user", None
+            ) == "root" and self.features.check_with_template(
+                "supported-rpc.qubes.VMRootExec", False
+            ):
+
                 kwargs.pop("user")
                 service = "qubes.VMRootShell"
             return self.run_service_for_stdio(
                 service,
                 input=self.prepare_input_for_vmshell(command, input),
-                **kwargs
+                **kwargs,
             )
         except subprocess.CalledProcessError as e:
             e.cmd = command


### PR DESCRIPTION
Template imported from R4.2 already has qubes.VMRootShell service, but
it isn't really running as root by default. It's only R4.3+ when both
qubes.VMRootShell and qubes.VMRootExec got also force-user=root setting.
Since the check for VMRootExec is already needed anyway, use the same to
check if using qubes.VMRootShell makes sense, as both changes were
introduced at the same time in core-agent-linux:

    1c538af2 Use rpc-config for running qubes.VMRoot* services as root
    563a9cfa Add qubes.VMRootExec service

This is more flexible method than hardcoding version check.

And add a test for this case.

Fixes: f38c1d4 "use qubes.VMRootExec/qubes.VMRootShell services when root needed"
Fixes QubesOS/qubes-issues#10590