### PR TITLE
tools/qvm-run: use prefix_data feature instead of copy_stdin subprocess

### DIFF
--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -688,6 +688,7 @@ class QubesBase(qubesadmin.base.PropertyHolder):
         localcmd: str | None=None,
         wait: bool=True,
         autostart: bool=True,
+        prefix_data: bytes | None=None,
         **kwargs,
     ) -> Popen:
         """Run qrexec service in a given destination
@@ -930,6 +931,7 @@ class QubesLocal(QubesBase):
         localcmd: str | None=None,
         wait: bool=True,
         autostart: bool=True,
+        prefix_data: bytes | None=None,
         **kwargs,
     ) -> Popen:
         """Run qrexec service in a given destination
@@ -949,6 +951,8 @@ class QubesLocal(QubesBase):
             raise ValueError("Empty destination name allowed only from a VM")
         if not wait and localcmd:
             raise ValueError("wait=False incompatible with localcmd")
+        if prefix_data and b"\0" in prefix_data:
+            raise ValueError("prefix_data cannot contain NUL character")
         if autostart:
             try:
                 self.qubesd_call(dest, "admin.vm.Start")
@@ -973,6 +977,10 @@ class QubesLocal(QubesBase):
                 raise NotImplementedError(
                     "wait=False not implemented in dom0->dom0 calls"
                 )
+            if prefix_data and kwargs.get("stdin", None) != subprocess.PIPE:
+                raise NotImplementedError(
+                    "prefix_data for dom0->dom0 calls requires stdin=PIPE"
+                )
             if user is None:
                 user = grp.getgrnam("qubes").gr_mem[0]
 
@@ -992,6 +1000,8 @@ class QubesLocal(QubesBase):
                 **kwargs,
                 env=env,
             )
+            if prefix_data:
+                p.stdin.write(prefix_data)
             return p
         qrexec_opts = ["-d", dest]
         if filter_esc:
@@ -1008,6 +1018,8 @@ class QubesLocal(QubesBase):
             user = "DEFAULT"
         if not wait:
             qrexec_opts.extend(["-e"])
+        if prefix_data:
+            qrexec_opts.extend(["-p", prefix_data])
         if "connect_timeout" in kwargs:
             qrexec_opts.extend(["-w", str(kwargs.pop("connect_timeout"))])
         kwargs.setdefault("stdin", subprocess.PIPE)
@@ -1087,6 +1099,7 @@ class QubesRemote(QubesBase):
         localcmd: str | None=None,
         wait: bool=True,
         autostart: bool=True,
+        prefix_data: bytes | None=None,
         **kwargs,
     ) -> Popen:
         """Run qrexec service in a given destination
@@ -1109,6 +1122,8 @@ class QubesRemote(QubesBase):
             raise ValueError("non-default user not possible for calls from VM")
         if not wait and localcmd:
             raise ValueError("wait=False incompatible with localcmd")
+        if prefix_data and b"\0" in prefix_data:
+            raise ValueError("prefix_data cannot contain NUL character")
         qrexec_opts = []
         if filter_esc:
             qrexec_opts.extend(["-t"])
@@ -1122,6 +1137,8 @@ class QubesRemote(QubesBase):
             raise qubesadmin.exc.QubesVMNotRunningError(
                 "%s is not running", dest
             )
+        if prefix_data:
+            qrexec_opts.extend(["-p", prefix_data])
         if not wait:
             # qrexec-client-vm can only request service calls, which are
             # started using MSG_EXEC_CMDLINE qrexec protocol message; this

--- a/qubesadmin/base.py
+++ b/qubesadmin/base.py
@@ -101,6 +101,8 @@ class PropertyHolder:
                         "%s has empty 'default_dispvm' property, but it is "
                         "required when target is @dispvm", self.app.local_name
                     )
+                dest = dest.name
+
         # have the actual implementation at Qubes() instance
         return self.app.qubesd_call(dest, method, arg, payload,
             payload_stream)

--- a/qubesadmin/tests/__init__.py
+++ b/qubesadmin/tests/__init__.py
@@ -62,23 +62,34 @@ class TestVMCollection(dict):
 
 
 class TestProcess:
-    def __init__(self, input_callback=None, stdout=None, stderr=None,
-            stdout_data=None):
+    def __init__(
+        self,
+        input_callback=None,
+        stdin=None,
+        stdout=None,
+        stderr=None,
+        stdout_data=None,
+    ):
         self.input_callback = input_callback
         self.got_any_input = False
-        self.stdin = io.BytesIO()
-        # don't let anyone close it, before we get the value
-        self.stdin_close = self.stdin.close
-        self.stdin.close = self.store_input
-        self.stdin.flush = self.store_input
-        if stdout == subprocess.PIPE or stdout == subprocess.DEVNULL \
-                or stdout is None:
+        if stdin == subprocess.PIPE:
+            self.stdin = io.BytesIO()
+            # don't let anyone close it, before we get the value
+            self.stdin_close = self.stdin.close
+            self.stdin.close = self.store_input
+            self.stdin.flush = self.store_input
+        else:
+            self.stdin = None
+        if stdout == subprocess.PIPE:
             self.stdout = io.BytesIO()
+        elif stdout == subprocess.DEVNULL:
+            self.stdout = None
         else:
             self.stdout = stdout
-        if stderr == subprocess.PIPE or stderr == subprocess.DEVNULL \
-                or stderr is None:
+        if stderr == subprocess.PIPE:
             self.stderr = io.BytesIO()
+        elif stderr == subprocess.DEVNULL:
+            self.stderr = None
         else:
             self.stderr = stderr
         if stdout_data:
@@ -102,12 +113,22 @@ class TestProcess:
         # pylint: disable=redefined-builtin,unused-argument
         if input is not None:
             self.stdin.write(input)
-        self.stdin.close()
-        self.stdin_close()
-        return self.stdout.read(), self.stderr.read()
+        if self.stdin:
+            self.stdin.close()
+            self.stdin_close()
+        if self.stdout:
+            stdout = self.stdout.read()
+        else:
+            stdout = None
+        if self.stderr:
+            stderr = self.stderr.read()
+        else:
+            stderr = None
+        return stdout, stderr
 
     def wait(self):
-        self.stdin_close()
+        if self.stdin:
+            self.stdin_close()
         return 0
 
     def poll(self):
@@ -188,6 +209,9 @@ class QubesTest(qubesadmin.app.QubesBase):
         # pylint: disable=arguments-differ
         assert all(c in QREXEC_ALLOWED_CHARS for c in service), \
             f"forbidden char in service '{service}"
+        kwargs.setdefault("stdin", subprocess.PIPE)
+        kwargs.setdefault("stdout", subprocess.PIPE)
+        kwargs.setdefault("stderr", subprocess.PIPE)
         self.service_calls.append((dest, service, kwargs))
         call_key = (dest, service)
         # TODO: consider it as a future extension, as a replacement for
@@ -200,8 +224,9 @@ class QubesTest(qubesadmin.app.QubesBase):
             kwargs['stdout_data'] = self.expected_service_calls[call_key]
         return TestProcess(lambda input: self.service_calls.append((dest,
             service, input)),
-            stdout=kwargs.get('stdout', None),
-            stderr=kwargs.get('stderr', None),
+            stdin=kwargs.get('stdin'),
+            stdout=kwargs.get('stdout'),
+            stderr=kwargs.get('stderr'),
             stdout_data=kwargs.get('stdout_data', None),
         )
 

--- a/qubesadmin/tests/app.py
+++ b/qubesadmin/tests/app.py
@@ -188,7 +188,6 @@ class TC_00_VMCollection(qubesadmin.tests.QubesTestCase):
         self.assertAllCalled()
 
 
-
 class TC_10_QubesBase(qubesadmin.tests.QubesTestCase):
     def setUp(self):
         super().setUp()
@@ -1094,6 +1093,32 @@ class TC_20_QubesLocal(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.app.run_service('', 'service.name')
 
+    @mock.patch('os.isatty', lambda fd: fd == 2)
+    def test_014_run_service_prefix_data(self):
+        self.listen_and_send(b'0\0')
+        with mock.patch("subprocess.Popen") as mock_proc:
+            self.app.run_service(
+                "some-vm", "service.name", prefix_data=b"prefix data"
+            )
+            mock_proc.assert_called_once_with(
+                [
+                    qubesadmin.config.QREXEC_CLIENT,
+                    "-d",
+                    "some-vm",
+                    "-T",
+                    "-p",
+                    b"prefix data",
+                    "DEFAULT:QUBESRPC service.name+ dom0",
+                ],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertEqual(
+            self.get_request(), b"admin.vm.Start+ dom0 name some-vm\0"
+        )
+
 
 class TC_30_QubesRemote(unittest.TestCase):
     def setUp(self):
@@ -1276,3 +1301,15 @@ class TC_30_QubesRemote(unittest.TestCase):
             'some-vm', 'admin.vm.CurrentState'],
             stdin=subprocess.PIPE, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
+
+    @mock.patch('os.isatty', lambda fd: fd == 2)
+    def test_016_run_service_prefix_data(self):
+        self.app.run_service(
+            "some-vm", "service.name", prefix_data=b"prefix data"
+        )
+        self.proc_mock.assert_called_once_with(
+            [qubesadmin.config.QREXEC_CLIENT_VM,
+              "-T", "-p", b"prefix data", "some-vm", "service.name"],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )

--- a/qubesadmin/tests/backup/dispvm.py
+++ b/qubesadmin/tests/backup/dispvm.py
@@ -27,6 +27,7 @@ import unittest.mock
 from unittest.mock import call
 
 import subprocess
+from subprocess import PIPE
 
 import qubesadmin.tests
 from qubesadmin.tools import qvm_backup_restore
@@ -195,7 +196,7 @@ class TC_00_RestoreInDispVM(qubesadmin.tests.QubesTestCase):
         self.assertEqual(obj.storage_access_id, 'someid')
         self.assertEqual(self.app.service_calls, [
             ('backup-storage', 'qubes.RegisterBackupLocation',
-             {'stdin':subprocess.PIPE, 'stdout':subprocess.PIPE}),
+             {'stdin': PIPE, 'stdout': PIPE, 'stderr': PIPE}),
             ('backup-storage', 'qubes.RegisterBackupLocation',
              b'/backup/path\n'),
         ])

--- a/qubesadmin/tests/tools/qvm_run.py
+++ b/qubesadmin/tests/tools/qvm_run.py
@@ -61,6 +61,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -97,6 +98,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -131,6 +133,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -168,6 +171,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -231,6 +235,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -241,6 +246,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm2",
                     "qubes.WaitForSession",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                     },
@@ -250,6 +256,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm2",
                     "qubes.VMShell",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -298,6 +305,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "qubes.VMShell",
                     {
                         "filter_esc": True,
+                        "stdin": subprocess.PIPE,
                         "stdout": None,
                         "stderr": None,
                         "user": None,
@@ -343,6 +351,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test.service",
                     {
                         "filter_esc": True,
+                        "stdin": subprocess.PIPE,
                         "stdout": None,
                         "stderr": None,
                         "user": None,
@@ -393,6 +402,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "qubes.VMShell",
                     {
                         "filter_esc": True,
+                        "stdin": subprocess.PIPE,
                         "stdout": None,
                         "stderr": None,
                         "user": None,
@@ -441,6 +451,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "qubes.VMShell",
                     {
                         "filter_esc": self.default_filter_esc(),
+                        "stdin": subprocess.PIPE,
                         "stdout": None,
                         "stderr": None,
                         "user": None,
@@ -492,6 +503,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "qubes.VMShell",
                     {
                         "filter_esc": False,
+                        "stdin": subprocess.PIPE,
                         "stdout": None,
                         "stderr": None,
                         "user": None,
@@ -584,6 +596,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.WaitForSession",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                     },
@@ -593,6 +606,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -631,6 +645,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.WaitForSession",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                     },
@@ -640,6 +655,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "service.name",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -671,6 +687,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "@dispvm",
                     "test.service",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -699,6 +716,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "@dispvm:test-vm",
                     "test.service",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -740,6 +758,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "disp123",
                     "test.service",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -776,6 +795,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "disp123",
                     "test.service",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -824,6 +844,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -884,6 +905,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "disp123",
                     "qubes.VMShell+WaitForSession",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -924,6 +946,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "disp123",
                     "qubes.VMShell",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -966,6 +989,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "disp123",
                     "qubes.VMShell",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -998,6 +1022,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -1035,6 +1060,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -1066,6 +1092,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMExec+command+arg",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -1100,6 +1127,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -1131,6 +1159,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMExec+command",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -1162,6 +1191,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "@dispvm:test-vm",
                     "qubes.VMExec+command",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -1194,6 +1224,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMExec+command+arg",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -1226,6 +1257,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMExec+command+----+arg",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -1258,6 +1290,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMExec+command+----+arg",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -1289,6 +1322,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "@dispvm:test-vm",
                     "qubes.VMExec+command+arg",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -1320,6 +1354,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "@dispvm:test-vm",
                     "qubes.VMExec+command+----",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -1351,6 +1386,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "@dispvm:test-vm",
                     "qubes.VMExec+----",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -1380,6 +1416,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "@dispvm",
                     "qubes.VMExec+test--vm+command+arg",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -1409,6 +1446,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "@dispvm",
                     "qubes.VMExec+test--vm+command+----",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -1435,6 +1473,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "@dispvm",
                     "qubes.VMExec+test--vm+command+----",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -1474,6 +1513,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMRootShell",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -1513,6 +1553,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": "root",
@@ -1553,6 +1594,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMRootExec+command+arg",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
@@ -1593,6 +1635,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMExec+command+arg",
                     {
+                        "stdin": subprocess.PIPE,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": "root",

--- a/qubesadmin/tests/tools/qvm_run.py
+++ b/qubesadmin/tests/tools/qvm_run.py
@@ -61,13 +61,13 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
+                        "prefix_data": b"command; exit\n",
                     },
                 ),
-                ("test-vm", "qubes.VMShell", b"command; exit\n"),
             ],
         )
         self.assertAllCalled()
@@ -98,13 +98,13 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
+                        "prefix_data": b"command; exit\n",
                     },
                 ),
-                ("test-vm", "qubes.VMShell", b"command; exit\n"),
             ],
         )
         self.assertAllCalled()
@@ -133,13 +133,13 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
+                        "prefix_data": b"command; exit\n",
                     },
                 ),
-                ("test-vm", "qubes.VMShell", b"command; exit\n"),
             ],
         )
         self.assertAllCalled()
@@ -171,13 +171,13 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
+                        "prefix_data": b"command; exit\n",
                     },
                 ),
-                ("test-vm", "qubes.VMShell", b"command; exit\n"),
             ],
         )
         self.assertAllCalled()
@@ -235,13 +235,13 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
+                        "prefix_data": b"command; exit\n",
                     },
                 ),
-                ("test-vm", "qubes.VMShell", b"command; exit\n"),
                 (
                     "test-vm2",
                     "qubes.WaitForSession",
@@ -256,13 +256,13 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm2",
                     "qubes.VMShell",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
+                        "prefix_data": b"command; exit\n",
                     },
                 ),
-                ("test-vm2", "qubes.VMShell", b"command; exit\n"),
             ],
         )
         self.assertAllCalled()
@@ -305,15 +305,15 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "qubes.VMShell",
                     {
                         "filter_esc": True,
-                        "stdin": subprocess.PIPE,
+                        "stdin": None,
                         "stdout": None,
                         "stderr": None,
                         "user": None,
+                        "prefix_data": b"command; exit\n",
                     },
                 ),
                 # TODO: find a way to compare b'some-data\n' sent from another
                 # proces
-                ("test-vm", "qubes.VMShell", b"command; exit\n"),
             ],
         )
         self.assertAllCalled()
@@ -351,7 +351,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test.service",
                     {
                         "filter_esc": True,
-                        "stdin": subprocess.PIPE,
+                        "stdin": None,
                         "stdout": None,
                         "stderr": None,
                         "user": None,
@@ -359,7 +359,6 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                 ),
                 # TODO: find a way to compare b'some-data\n' sent from another
                 # proces
-                ("test-vm", "test.service", b""),
             ],
         )
         self.assertAllCalled()
@@ -376,22 +375,17 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
         #     ('test-vm', 'admin.vm.List', None, None)] = \
         #     b'0\x00test-vm class=AppVM state=Running\n'
         stdout = io.StringIO()
-        with subprocess.Popen(
-            ["echo", "some-data"], stdout=subprocess.PIPE
-        ) as echo:
-            with unittest.mock.patch("sys.stdin", echo.stdout):
-                with unittest.mock.patch("sys.stdout", stdout):
-                    ret = qubesadmin.tools.qvm_run.main(
-                        [
-                            "--no-gui",
-                            "--filter-esc",
-                            "--pass-io",
-                            "test-vm",
-                            "command",
-                        ],
-                        app=self.app,
-                    )
-            echo.stdout.close()
+        with unittest.mock.patch("sys.stdout", stdout):
+            ret = qubesadmin.tools.qvm_run.main(
+                [
+                    "--no-gui",
+                    "--filter-esc",
+                    "--pass-io",
+                    "test-vm",
+                    "command",
+                ],
+                app=self.app,
+            )
 
         self.assertEqual(ret, 0)
         self.assertEqual(
@@ -402,13 +396,13 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "qubes.VMShell",
                     {
                         "filter_esc": True,
-                        "stdin": subprocess.PIPE,
+                        "stdin": None,
                         "stdout": None,
                         "stderr": None,
                         "user": None,
+                        "prefix_data": b"command; exit\n",
                     },
                 ),
-                ("test-vm", "qubes.VMShell", b"command; exit\nsome-data\n"),
             ],
         )
         self.assertEqual(stdout.getvalue(), "\033[0;31m\033[0m")
@@ -424,23 +418,17 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
         #     ('test-vm', 'admin.vm.List', None, None)] = \
         #     b'0\x00test-vm class=AppVM state=Running\n'
         stdout = io.StringIO()
-        with subprocess.Popen(
-            ["echo", "some-data"], stdout=subprocess.PIPE
-        ) as echo:
-            with unittest.mock.patch("sys.stdin", echo.stdout):
-                with unittest.mock.patch("sys.stdout", stdout):
-                    ret = qubesadmin.tools.qvm_run.main(
-                        [
-                            "--no-gui",
-                            "--pass-io",
-                            "--no-color-output",
-                            "test-vm",
-                            "command",
-                        ],
-                        app=self.app,
-                    )
-
-            echo.stdout.close()
+        with unittest.mock.patch("sys.stdout", stdout):
+            ret = qubesadmin.tools.qvm_run.main(
+                [
+                    "--no-gui",
+                    "--pass-io",
+                    "--no-color-output",
+                    "test-vm",
+                    "command",
+                ],
+                app=self.app,
+            )
 
         self.assertEqual(ret, 0)
         self.assertEqual(
@@ -451,13 +439,13 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "qubes.VMShell",
                     {
                         "filter_esc": self.default_filter_esc(),
-                        "stdin": subprocess.PIPE,
+                        "stdin": None,
                         "stdout": None,
                         "stderr": None,
                         "user": None,
+                        "prefix_data": b"command; exit\n",
                     },
                 ),
-                ("test-vm", "qubes.VMShell", b"command; exit\nsome-data\n"),
             ],
         )
         self.assertEqual(stdout.getvalue(), "")
@@ -476,23 +464,17 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
         #     ('test-vm', 'admin.vm.List', None, None)] = \
         #     b'0\x00test-vm class=AppVM state=Running\n'
         stdout = io.StringIO()
-        with subprocess.Popen(
-            ["echo", "some-data"], stdout=subprocess.PIPE
-        ) as echo:
-            with unittest.mock.patch("sys.stdin", echo.stdout):
-                with unittest.mock.patch("sys.stdout", stdout):
-                    ret = qubesadmin.tools.qvm_run.main(
-                        [
-                            "--no-gui",
-                            "--pass-io",
-                            "--no-filter-esc",
-                            "test-vm",
-                            "command",
-                        ],
-                        app=self.app,
-                    )
-
-            echo.stdout.close()
+        with unittest.mock.patch("sys.stdout", stdout):
+            ret = qubesadmin.tools.qvm_run.main(
+                [
+                    "--no-gui",
+                    "--pass-io",
+                    "--no-filter-esc",
+                    "test-vm",
+                    "command",
+                ],
+                app=self.app,
+            )
 
         self.assertEqual(ret, 0)
         self.assertEqual(
@@ -503,13 +485,12 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "qubes.VMShell",
                     {
                         "filter_esc": False,
-                        "stdin": subprocess.PIPE,
-                        "stdout": None,
+                        "stdin": None,
                         "stderr": None,
                         "user": None,
+                        "prefix_data": b"command; exit\n",
                     },
                 ),
-                ("test-vm", "qubes.VMShell", b"command; exit\nsome-data\n"),
             ],
         )
         self.assertEqual(stdout.getvalue(), "")
@@ -551,9 +532,10 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                         "stdin": subprocess.PIPE,
                         "stderr": None,
                         "user": None,
+                        "prefix_data": b"command; exit\n",
                     },
                 ),
-                ("test-vm", "qubes.VMShell", b"command; exit\n"),
+                ("test-vm", "qubes.VMShell", b""),
             ],
         )
         mock_popen.assert_called_once_with(
@@ -606,13 +588,13 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
+                        "prefix_data": b"command; exit\n",
                     },
                 ),
-                ("test-vm", "qubes.VMShell", b"command; exit\n"),
             ],
         )
         self.assertAllCalled()
@@ -655,13 +637,12 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "service.name",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                     },
                 ),
-                ("test-vm", "service.name", b""),
             ],
         )
         self.assertAllCalled()
@@ -687,13 +668,12 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "@dispvm",
                     "test.service",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                     },
                 ),
-                ("@dispvm", "test.service", b""),
             ],
         )
         self.assertAllCalled()
@@ -716,13 +696,12 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "@dispvm:test-vm",
                     "test.service",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                     },
                 ),
-                ("@dispvm:test-vm", "test.service", b""),
             ],
         )
         self.assertAllCalled()
@@ -758,14 +737,13 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "disp123",
                     "test.service",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                         "connect_timeout": 30,
                     },
                 ),
-                ("disp123", "test.service", b""),
             ],
         )
         self.assertAllCalled()
@@ -795,14 +773,13 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "disp123",
                     "test.service",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                         "connect_timeout": 30,
                     },
                 ),
-                ("disp123", "test.service", b""),
             ],
         )
         self.assertAllCalled()
@@ -844,13 +821,13 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
+                        "prefix_data": b"command; exit\n",
                     },
                 ),
-                ("test-vm", "qubes.VMShell", b"command; exit\n"),
             ],
         )
         self.assertAllCalled()
@@ -892,7 +869,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             ("disp123", "admin.vm.property.Get", "qrexec_timeout", None)
         ] = b"0\x00default=yes type=int 30"
         self.app.expected_calls[
-            ("disp123", "admin.vm.feature.CheckWithTemplate", "os", None)
+            ("default-dvm", "admin.vm.feature.CheckWithTemplate", "os", None)
         ] = b"2\x00QubesFeatureNotFoundError\x00\x00Feature 'os' not set\x00"
         ret = qubesadmin.tools.qvm_run.main(
             ["--dispvm", "--", "test.command"], app=self.app
@@ -905,17 +882,13 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "disp123",
                     "qubes.VMShell+WaitForSession",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                         "connect_timeout": 30,
+                        "prefix_data": b"test.command; exit\n",
                     },
-                ),
-                (
-                    "disp123",
-                    "qubes.VMShell+WaitForSession",
-                    b"test.command; exit\n",
                 ),
             ],
         )
@@ -930,10 +903,13 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             b"0\x00"
         )
         self.app.expected_calls[
+            ("testvm", "admin.vm.property.Get", "default_dispvm", None)
+        ] = b"0\x00default=True type=vm default-dvm"
+        self.app.expected_calls[
             ("disp123", "admin.vm.property.Get", "qrexec_timeout", None)
         ] = b"0\x00default=yes type=int 30"
         self.app.expected_calls[
-            ("disp123", "admin.vm.feature.CheckWithTemplate", "os", None)
+            ("default-dvm", "admin.vm.feature.CheckWithTemplate", "os", None)
         ] = b"2\x00QubesFeatureNotFoundError\x00\x00Feature 'os' not set\x00"
         ret = qubesadmin.tools.qvm_run.main(
             ["--no-gui", "--dispvm", "--", "test.command"], app=self.app
@@ -946,14 +922,14 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "disp123",
                     "qubes.VMShell",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                         "connect_timeout": 30,
+                        "prefix_data": b"test.command; exit\n",
                     },
                 ),
-                ("disp123", "qubes.VMShell", b"test.command; exit\n"),
             ],
         )
         self.assertAllCalled()
@@ -976,7 +952,7 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
             ("disp123", "admin.vm.property.Get", "qrexec_timeout", None)
         ] = b"0\x00default=yes type=int 30"
         self.app.expected_calls[
-            ("disp123", "admin.vm.feature.CheckWithTemplate", "os", None)
+            ("default-dvm", "admin.vm.feature.CheckWithTemplate", "os", None)
         ] = b"2\x00QubesFeatureNotFoundError\x00\x00Feature 'os' not set\x00"
         ret = qubesadmin.tools.qvm_run.main(
             ["--dispvm", "--", "test.command"], app=self.app
@@ -989,14 +965,14 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "disp123",
                     "qubes.VMShell",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                         "connect_timeout": 30,
+                        "prefix_data": b"test.command; exit\n",
                     },
                 ),
-                ("disp123", "qubes.VMShell", b"test.command; exit\n"),
             ],
         )
         self.assertAllCalled()
@@ -1022,13 +998,13 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
+                        "prefix_data": b"command& exit\n",
                     },
                 ),
-                ("test-vm", "qubes.VMShell", b"command& exit\n"),
             ],
         )
         self.assertAllCalled()
@@ -1060,13 +1036,13 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
+                        "prefix_data": b"command arg; exit\n",
                     },
                 ),
-                ("test-vm", "qubes.VMShell", b"command arg; exit\n"),
             ],
         )
         self.assertAllCalled()
@@ -1092,13 +1068,12 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMExec+command+arg",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                     },
                 ),
-                ("test-vm", "qubes.VMExec+command+arg", b""),
             ],
         )
         self.assertAllCalled()
@@ -1127,13 +1102,13 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
+                        "prefix_data": b"command; exit\n",
                     },
                 ),
-                ("test-vm", "qubes.VMShell", b"command; exit\n"),
             ],
         )
         self.assertAllCalled()
@@ -1159,13 +1134,12 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMExec+command",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                     },
                 ),
-                ("test-vm", "qubes.VMExec+command", b""),
             ],
         )
         self.assertAllCalled()
@@ -1191,13 +1165,12 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "@dispvm:test-vm",
                     "qubes.VMExec+command",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                     },
                 ),
-                ("@dispvm:test-vm", "qubes.VMExec+command", b""),
             ],
         )
         self.assertAllCalled()
@@ -1224,13 +1197,12 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMExec+command+arg",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                     },
                 ),
-                ("test-vm", "qubes.VMExec+command+arg", b""),
             ],
         )
         self.assertAllCalled()
@@ -1257,13 +1229,12 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMExec+command+----+arg",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                     },
                 ),
-                ("test-vm", "qubes.VMExec+command+----+arg", b""),
             ],
         )
         self.assertAllCalled()
@@ -1290,13 +1261,12 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMExec+command+----+arg",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                     },
                 ),
-                ("test-vm", "qubes.VMExec+command+----+arg", b""),
             ],
         )
         self.assertAllCalled()
@@ -1322,13 +1292,12 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "@dispvm:test-vm",
                     "qubes.VMExec+command+arg",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                     },
                 ),
-                ("@dispvm:test-vm", "qubes.VMExec+command+arg", b""),
             ],
         )
         self.assertAllCalled()
@@ -1354,13 +1323,12 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "@dispvm:test-vm",
                     "qubes.VMExec+command+----",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                     },
                 ),
-                ("@dispvm:test-vm", "qubes.VMExec+command+----", b""),
             ],
         )
         self.assertAllCalled()
@@ -1386,13 +1354,12 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "@dispvm:test-vm",
                     "qubes.VMExec+----",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                     },
                 ),
-                ("@dispvm:test-vm", "qubes.VMExec+----", b""),
             ],
         )
         self.assertAllCalled()
@@ -1416,13 +1383,12 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "@dispvm",
                     "qubes.VMExec+test--vm+command+arg",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                     },
                 ),
-                ("@dispvm", "qubes.VMExec+test--vm+command+arg", b""),
             ],
         )
         self.assertAllCalled()
@@ -1446,13 +1412,12 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "@dispvm",
                     "qubes.VMExec+test--vm+command+----",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                     },
                 ),
-                ("@dispvm", "qubes.VMExec+test--vm+command+----", b""),
             ],
         )
         self.assertAllCalled()
@@ -1473,13 +1438,12 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "@dispvm",
                     "qubes.VMExec+test--vm+command+----",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                     },
                 ),
-                ("@dispvm", "qubes.VMExec+test--vm+command+----", b""),
             ],
         )
         self.assertAllCalled()
@@ -1513,13 +1477,13 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMRootShell",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
+                        "prefix_data": b"shell command; exit\n",
                     },
                 ),
-                ("test-vm", "qubes.VMRootShell", b"shell command; exit\n"),
             ],
         )
         self.assertAllCalled()
@@ -1553,13 +1517,13 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMShell",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": "root",
+                        "prefix_data": b"shell command; exit\n",
                     },
                 ),
-                ("test-vm", "qubes.VMShell", b"shell command; exit\n"),
             ],
         )
         self.assertAllCalled()
@@ -1594,13 +1558,12 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMRootExec+command+arg",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": None,
                     },
                 ),
-                ("test-vm", "qubes.VMRootExec+command+arg", b""),
             ],
         )
         self.assertAllCalled()
@@ -1635,13 +1598,12 @@ class TC_00_qvm_run(qubesadmin.tests.QubesTestCase):
                     "test-vm",
                     "qubes.VMExec+command+arg",
                     {
-                        "stdin": subprocess.PIPE,
+                        "stdin": subprocess.DEVNULL,
                         "stdout": subprocess.DEVNULL,
                         "stderr": subprocess.DEVNULL,
                         "user": "root",
                     },
                 ),
-                ("test-vm", "qubes.VMExec+command+arg", b""),
             ],
         )
         self.assertAllCalled()

--- a/qubesadmin/tests/tools/qvm_template.py
+++ b/qubesadmin/tests/tools/qvm_template.py
@@ -1475,7 +1475,7 @@ qubes-template-fedora-32|1|4.2|20200201|qubes-templates-itl-testing|2048576|2020
         ])
         self.assertEqual(self.app.service_calls, [
             ('test-vm', 'qubes.TemplateSearch',
-                {'filter_esc': True, 'stdout': subprocess.PIPE}),
+                {'filter_esc': True, 'stdin': subprocess.PIPE, 'stdout': subprocess.PIPE, 'stderr': subprocess.PIPE}),
             ('test-vm', 'qubes.TemplateSearch', b'str1\nstr2')
         ])
         self.assertEqual(mock_payload.mock_calls, [
@@ -1513,7 +1513,7 @@ b'''qubes-template-debian-12-minimal|0|4.3.0|202405272135|qubes-templates-itl|22
         ])
         self.assertEqual(self.app.service_calls, [
             ('test-vm', 'qubes.TemplateSearch',
-                {'filter_esc': True, 'stdout': subprocess.PIPE}),
+                {'filter_esc': True, 'stdin': subprocess.PIPE, 'stdout': subprocess.PIPE, 'stderr': subprocess.PIPE}),
             ('test-vm', 'qubes.TemplateSearch', b'str1\nstr2')
         ])
         self.assertEqual(mock_payload.mock_calls, [
@@ -1564,7 +1564,7 @@ qubes-template-fedora-32|1|4.2|20200201|qubes-templates-itl-testing|2048576|2020
         ])
         self.assertEqual(self.app.service_calls, [
             ('test-vm', 'qubes.TemplateSearch',
-                {'filter_esc': True, 'stdout': subprocess.PIPE}),
+                {'filter_esc': True, 'stdin': subprocess.PIPE, 'stdout': subprocess.PIPE, 'stderr': subprocess.PIPE}),
             ('test-vm', 'qubes.TemplateSearch', b'str1\nstr2')
         ])
         self.assertEqual(mock_payload.mock_calls, [
@@ -1602,7 +1602,7 @@ qubes-template-fedora-32|0|4.1|20200101|qubes-templates-itl|1048576|2020-01-23 0
         ])
         self.assertEqual(self.app.service_calls, [
             ('test-vm', 'qubes.TemplateSearch',
-                {'filter_esc': True, 'stdout': subprocess.PIPE}),
+                {'filter_esc': True, 'stdin': subprocess.PIPE, 'stdout': subprocess.PIPE, 'stderr': subprocess.PIPE}),
             ('test-vm', 'qubes.TemplateSearch', b'str1\nstr2')
         ])
         self.assertEqual(mock_payload.mock_calls, [
@@ -1640,7 +1640,7 @@ qubes-template-fedora-32|0|4.1|20200101|qubes-templates-itl|1048576|2020-01-23 0
         ])
         self.assertEqual(self.app.service_calls, [
             ('test-vm', 'qubes.TemplateSearch',
-                {'filter_esc': True, 'stdout': subprocess.PIPE}),
+                {'filter_esc': True, 'stdin': subprocess.PIPE, 'stdout': subprocess.PIPE, 'stderr': subprocess.PIPE}),
             ('test-vm', 'qubes.TemplateSearch', b'str1\nstr2')
         ])
         self.assertEqual(mock_payload.mock_calls, [
@@ -1662,7 +1662,7 @@ qubes-template-fedora-32|0|4.1|20200101|qubes-templates-itl|1048576|2020-01-23 0
                     'qubes-template-fedora-32')
         self.assertEqual(self.app.service_calls, [
             ('test-vm', 'qubes.TemplateSearch',
-                {'filter_esc': True, 'stdout': subprocess.PIPE}),
+                {'filter_esc': True, 'stdin': subprocess.PIPE, 'stdout': subprocess.PIPE, 'stderr': subprocess.PIPE}),
             ('test-vm', 'qubes.TemplateSearch', b'str1\nstr2')
         ])
         self.assertEqual(mock_payload.mock_calls, [
@@ -1687,7 +1687,7 @@ qubes-template-fedora-32|0|4.1|20200101|qubes-templates-itl|1048576|2020-01-23 0
                 'qubes-template-fedora-32')
         self.assertEqual(self.app.service_calls, [
             ('test-vm', 'qubes.TemplateSearch',
-                {'filter_esc': True, 'stdout': subprocess.PIPE}),
+                {'filter_esc': True, 'stdin': subprocess.PIPE, 'stdout': subprocess.PIPE, 'stderr': subprocess.PIPE}),
             ('test-vm', 'qubes.TemplateSearch', b'str1\nstr2')
         ])
         self.assertEqual(mock_payload.mock_calls, [
@@ -1712,7 +1712,7 @@ qubes-template-fedora-32|0|4.1|20200101|qubes-templates-itl|1048576|2020-01-23 0
                 'qubes-template-fedora-32')
         self.assertEqual(self.app.service_calls, [
             ('test-vm', 'qubes.TemplateSearch',
-                {'filter_esc': True, 'stdout': subprocess.PIPE}),
+                {'filter_esc': True, 'stdin': subprocess.PIPE, 'stdout': subprocess.PIPE, 'stderr': subprocess.PIPE}),
             ('test-vm', 'qubes.TemplateSearch', b'str1\nstr2')
         ])
         self.assertEqual(mock_payload.mock_calls, [
@@ -1737,7 +1737,7 @@ qubes-template-fedora-32|0|4.1|20200101|qubes-templates-itl|1048576|2020-01-23 0
                 'qubes-template-fedora-32')
         self.assertEqual(self.app.service_calls, [
             ('test-vm', 'qubes.TemplateSearch',
-                {'filter_esc': True, 'stdout': subprocess.PIPE}),
+                {'filter_esc': True, 'stdin': subprocess.PIPE, 'stdout': subprocess.PIPE, 'stderr': subprocess.PIPE}),
             ('test-vm', 'qubes.TemplateSearch', b'str1\nstr2')
         ])
         self.assertEqual(mock_payload.mock_calls, [
@@ -1762,7 +1762,7 @@ qubes-template-fedora-32|0|4.1|20200101|qubes-templates-itl|1048576|2020-01-23 0
                 'qubes-template-fedora-32')
         self.assertEqual(self.app.service_calls, [
             ('test-vm', 'qubes.TemplateSearch',
-                {'filter_esc': True, 'stdout': subprocess.PIPE}),
+                {'filter_esc': True, 'stdin': subprocess.PIPE, 'stdout': subprocess.PIPE, 'stderr': subprocess.PIPE}),
             ('test-vm', 'qubes.TemplateSearch', b'str1\nstr2')
         ])
         self.assertEqual(mock_payload.mock_calls, [
@@ -1787,7 +1787,7 @@ qubes-template-fedora-32|0|4.1|20200101|qubes-templates-itl|1048576|2020-01-23 0
                 'qubes-template-fedora-32')
         self.assertEqual(self.app.service_calls, [
             ('test-vm', 'qubes.TemplateSearch',
-                {'filter_esc': True, 'stdout': subprocess.PIPE}),
+                {'filter_esc': True, 'stdin': subprocess.PIPE, 'stdout': subprocess.PIPE, 'stderr': subprocess.PIPE}),
             ('test-vm', 'qubes.TemplateSearch', b'str1\nstr2')
         ])
         self.assertEqual(mock_payload.mock_calls, [
@@ -1812,7 +1812,7 @@ qubes-template-fedora-32|0|4.1|20200101|qubes-templates-itl|1048576|2020-01-23 0
                 'qubes-template-fedora-32')
         self.assertEqual(self.app.service_calls, [
             ('test-vm', 'qubes.TemplateSearch',
-                {'filter_esc': True, 'stdout': subprocess.PIPE}),
+                {'filter_esc': True, 'stdin': subprocess.PIPE, 'stdout': subprocess.PIPE, 'stderr': subprocess.PIPE}),
             ('test-vm', 'qubes.TemplateSearch', b'str1\nstr2')
         ])
         self.assertEqual(mock_payload.mock_calls, [
@@ -1837,7 +1837,7 @@ qubes-template-fedora-32|0|4.1|20200101|qubes-templates-itl|1048576|2020-01-23 0
                 'qubes-template-fedora-32')
         self.assertEqual(self.app.service_calls, [
             ('test-vm', 'qubes.TemplateSearch',
-                {'filter_esc': True, 'stdout': subprocess.PIPE}),
+                {'filter_esc': True, 'stdin': subprocess.PIPE, 'stdout': subprocess.PIPE, 'stderr': subprocess.PIPE}),
             ('test-vm', 'qubes.TemplateSearch', b'str1\nstr2')
         ])
         self.assertEqual(mock_payload.mock_calls, [
@@ -1862,7 +1862,7 @@ qubes-template-fedora-32|0|4.1|20200101|qubes-templates-itl|1048576|2020-01-23 0
                 'qubes-template-fedora-32')
         self.assertEqual(self.app.service_calls, [
             ('test-vm', 'qubes.TemplateSearch',
-                {'filter_esc': True, 'stdout': subprocess.PIPE}),
+                {'filter_esc': True, 'stdin': subprocess.PIPE, 'stdout': subprocess.PIPE, 'stderr': subprocess.PIPE}),
             ('test-vm', 'qubes.TemplateSearch', b'str1\nstr2')
         ])
         self.assertEqual(mock_payload.mock_calls, [

--- a/qubesadmin/tests/tools/qvm_template_postprocess.py
+++ b/qubesadmin/tests/tools/qvm_template_postprocess.py
@@ -428,7 +428,11 @@ class TC_00_qvm_template_postprocess(qubesadmin.tests.QubesTestCase):
             mock_domain_shutdown.assert_called_once_with([self.app.domains[
                 'test-vm']])
         self.assertEqual(self.app.service_calls, [
-            ('test-vm', 'qubes.PostInstall', {}),
+            ('test-vm', 'qubes.PostInstall', {
+                'stdin': subprocess.PIPE,
+                'stdout': subprocess.PIPE,
+                'stderr': subprocess.PIPE
+            }),
             ('test-vm', 'qubes.PostInstall', b''),
         ])
         self.assertAllCalled()
@@ -483,7 +487,11 @@ class TC_00_qvm_template_postprocess(qubesadmin.tests.QubesTestCase):
             mock_domain_shutdown.assert_called_once_with([self.app.domains[
                 'test-vm']])
         self.assertEqual(self.app.service_calls, [
-            ('test-vm', 'qubes.PostInstall', {}),
+            ('test-vm', 'qubes.PostInstall', {
+                'stdin': subprocess.PIPE,
+                'stdout': subprocess.PIPE,
+                'stderr': subprocess.PIPE
+            }),
             ('test-vm', 'qubes.PostInstall', b''),
         ])
         self.assertAllCalled()

--- a/qubesadmin/tests/vm/actions.py
+++ b/qubesadmin/tests/vm/actions.py
@@ -20,6 +20,8 @@
 
 # pylint: disable=missing-docstring
 
+from subprocess import PIPE
+
 import qubesadmin.tests.vm
 
 
@@ -79,7 +81,9 @@ class TC_00_Actions(qubesadmin.tests.vm.VMTestCase):
             b'2\x00QubesFeatureNotFoundError\x00\x00Feature \'os\' not set\x00'
         self.vm.run('some command')
         self.assertEqual(self.app.service_calls, [
-            ('test-vm', 'qubes.VMShell', {}),
+            ('test-vm', 'qubes.VMShell', {
+                'stdin': PIPE, 'stdout': PIPE, 'stderr': PIPE
+            }),
             ('test-vm', 'qubes.VMShell', b'some command; exit\n'),
         ])
 
@@ -89,7 +93,9 @@ class TC_00_Actions(qubesadmin.tests.vm.VMTestCase):
             b'0\x00Windows'
         self.vm.run('some command')
         self.assertEqual(self.app.service_calls, [
-            ('test-vm', 'qubes.VMShell', {}),
+            ('test-vm', 'qubes.VMShell', {
+                'stdin': PIPE, 'stdout': PIPE, 'stderr': PIPE
+            }),
             ('test-vm', 'qubes.VMShell', b'some command& exit\n'),
         ])
 
@@ -112,7 +118,12 @@ class TC_00_Actions(qubesadmin.tests.vm.VMTestCase):
         self.assertEqual(
             self.app.service_calls,
             [
-                ("test-vm", "qubes.VMShell", {"user": "root"}),
+                ("test-vm", "qubes.VMShell", {
+                    "user": "root",
+                    "stdin": PIPE,
+                    "stdout": PIPE,
+                    "stderr": PIPE
+                }),
                 ("test-vm", "qubes.VMShell", b"some command; exit\n"),
             ],
         )
@@ -133,7 +144,9 @@ class TC_00_Actions(qubesadmin.tests.vm.VMTestCase):
         self.assertEqual(
             self.app.service_calls,
             [
-                ("test-vm", "qubes.VMRootShell", {}),
+                ("test-vm", "qubes.VMRootShell", {
+                    "stdin": PIPE, "stdout": PIPE, "stderr": PIPE
+                }),
                 ("test-vm", "qubes.VMRootShell", b"some command; exit\n"),
             ],
         )
@@ -150,7 +163,9 @@ class TC_00_Actions(qubesadmin.tests.vm.VMTestCase):
         self.vm.run_with_args('some', 'argument with spaces',
             'and $pecial; chars')
         self.assertEqual(self.app.service_calls, [
-            ('test-vm', 'qubes.VMShell', {}),
+            ('test-vm', 'qubes.VMShell', {
+                "stdin": PIPE, "stdout": PIPE, "stderr": PIPE
+            }),
             ('test-vm', 'qubes.VMShell',
                 b'some \'argument with spaces\' \'and $pecial; chars\'; '
                 b'exit\n'),
@@ -167,7 +182,7 @@ class TC_00_Actions(qubesadmin.tests.vm.VMTestCase):
             ('test-vm',
              'qubes.VMExec+some+argument-20with-20spaces+and-20-24'
              'pecial-3B-20chars',
-             {}),
+             {"stdin": PIPE, "stdout": PIPE, "stderr": PIPE}),
             ('test-vm',
              'qubes.VMExec+some+argument-20with-20spaces+and-20-24'
              'pecial-3B-20chars',

--- a/qubesadmin/tests/vm/dispvm.py
+++ b/qubesadmin/tests/vm/dispvm.py
@@ -20,6 +20,8 @@
 
 # pylint: disable=missing-docstring
 
+import subprocess
+
 import qubesadmin.tests
 import qubesadmin.vm
 
@@ -37,7 +39,12 @@ class TC_00_Dispvm(qubesadmin.tests.QubesTestCase):
         vm.run_service_for_stdio('test.service')
         vm.cleanup()
         self.assertEqual(self.app.service_calls, [
-            ('disp123', 'test.service', {'connect_timeout': 30}),
+            ('disp123', 'test.service', {
+                'connect_timeout': 30,
+                "stdin": subprocess.PIPE,
+                "stdout": subprocess.PIPE,
+                "stderr": subprocess.PIPE,
+            }),
             ('disp123', 'test.service', b''),
         ])
         self.assertAllCalled()
@@ -56,7 +63,12 @@ class TC_00_Dispvm(qubesadmin.tests.QubesTestCase):
         vm.run_service_for_stdio('test.service')
         vm.cleanup()
         self.assertEqual(self.app.service_calls, [
-            ('disp123', 'test.service', {'connect_timeout': 30}),
+            ('disp123', 'test.service', {
+                'connect_timeout': 30,
+                "stdin": subprocess.PIPE,
+                "stdout": subprocess.PIPE,
+                "stderr": subprocess.PIPE,
+            }),
             ('disp123', 'test.service', b''),
         ])
         self.assertAllCalled()
@@ -73,7 +85,11 @@ class TC_00_Dispvm(qubesadmin.tests.QubesTestCase):
         vm.run_service_for_stdio('test.service')
         vm.cleanup()
         self.assertEqual(self.app.service_calls, [
-            ('@dispvm', 'test.service', {}),
+            ('@dispvm', 'test.service', {
+                "stdin": subprocess.PIPE,
+                "stdout": subprocess.PIPE,
+                "stderr": subprocess.PIPE,
+            }),
             ('@dispvm', 'test.service', b''),
         ])
         self.assertAllCalled()
@@ -83,7 +99,11 @@ class TC_00_Dispvm(qubesadmin.tests.QubesTestCase):
         vm.run_service_for_stdio('test.service')
         vm.cleanup()
         self.assertEqual(self.app.service_calls, [
-            ('@dispvm:test-vm', 'test.service', {}),
+            ('@dispvm:test-vm', 'test.service', {
+                "stdin": subprocess.PIPE,
+                "stdout": subprocess.PIPE,
+                "stderr": subprocess.PIPE,
+            }),
             ('@dispvm:test-vm', 'test.service', b''),
         ])
         self.assertAllCalled()

--- a/qubesadmin/tools/qvm_run.py
+++ b/qubesadmin/tools/qvm_run.py
@@ -28,10 +28,6 @@ import signal
 import subprocess
 import sys
 
-import multiprocessing
-
-import select
-
 import qubesadmin.tools
 import qubesadmin.exc
 import qubesadmin.utils
@@ -201,24 +197,6 @@ parser.add_argument(
 )
 
 
-def copy_stdin(stream):
-    """Copy stdin to *stream*"""
-    # multiprocessing.Process have sys.stdin connected to /dev/null, use fd 0
-    #  directly
-    while True:
-        try:
-            # select so this code works even if fd 0 is non-blocking
-            select.select([0], [], [])
-            data = os.read(0, 65536)
-            if data is None or data == b"":
-                break
-            stream.write(data)
-            stream.flush()
-        except KeyboardInterrupt:
-            break
-    stream.close()
-
-
 def print_no_color(msg, file, color):
     """Print a *msg* to *file* without coloring it.
     Namely reset to base color first, print a message, then restore color.
@@ -233,6 +211,7 @@ def run_command_single(args, vm):
     """Handle a single VM to run the command in"""
     run_kwargs = {}
     if not args.passio:
+        run_kwargs["stdin"] = subprocess.DEVNULL
         run_kwargs["stdout"] = subprocess.DEVNULL
         run_kwargs["stderr"] = subprocess.DEVNULL
     elif args.localcmd:
@@ -240,7 +219,9 @@ def run_command_single(args, vm):
         run_kwargs["stdout"] = subprocess.PIPE
         run_kwargs["stderr"] = None
     else:
-        # connect process output to stdout/err directly if --pass-io is given
+        # connect process output to stdin/stdout/err directly if --pass-io is
+        # given
+        run_kwargs["stdin"] = None
         run_kwargs["stdout"] = None
         run_kwargs["stderr"] = None
         if args.filter_esc:
@@ -269,7 +250,6 @@ def run_command_single(args, vm):
 
     use_exec = len(args.cmd_args) > 0 or args.no_shell
 
-    copy_proc = None
     local_proc = None
     shell_cmd = None
     if args.service:
@@ -307,25 +287,19 @@ def run_command_single(args, vm):
             args.user = None
         shell_cmd = args.cmd
 
-    proc = vm.run_service(service, user=args.user, **run_kwargs)
     if shell_cmd:
-        proc.stdin.write(vm.prepare_input_for_vmshell(shell_cmd))
-        proc.stdin.flush()
+        run_kwargs["prefix_data"] = vm.prepare_input_for_vmshell(shell_cmd)
+    proc = vm.run_service(service, user=args.user, **run_kwargs)
     if args.localcmd:
         # pylint: disable=consider-using-with
         local_proc = subprocess.Popen(
             args.localcmd, shell=True, stdout=proc.stdin, stdin=proc.stdout
         )
-        # stdin is closed below
+        proc.stdin.close()
         proc.stdout.close()
-    elif args.passio:
-        copy_proc = multiprocessing.Process(
-            target=copy_stdin, args=(proc.stdin,)
-        )
-        copy_proc.start()
-        # keep the copying process running
-    proc.stdin.close()
-    return proc, copy_proc, local_proc
+    else:
+        assert proc.stdin is None, repr(proc.stdin)
+    return proc, local_proc
 
 
 def has_gui(qube) -> bool:
@@ -415,7 +389,6 @@ def main(args=None, app=None):
     if args.color_stderr:
         sys.stderr.write("\033[0;{}m".format(args.color_stderr))
         sys.stderr.flush()
-    copy_proc = None
     try:
         procs = []
         for vm in domains:
@@ -470,7 +443,7 @@ def main(args=None, app=None):
                         with contextlib.suppress(ProcessLookupError):
                             wait_session.send_signal(signal.SIGINT)
                         break
-                proc, copy_proc, local_proc = run_command_single(args, vm)
+                proc, local_proc = run_command_single(args, vm)
                 procs.append((vm, proc))
                 if local_proc:
                     procs.append((vm, local_proc))
@@ -507,8 +480,6 @@ def main(args=None, app=None):
         if args.color_stderr:
             sys.stderr.write("\033[0m")
             sys.stderr.flush()
-        if copy_proc is not None:
-            copy_proc.terminate()
 
     return retcode
 


### PR DESCRIPTION
Do not rely on multiprocessing.Process() in qvm-run. See commit messages for more details.

This needs https://github.com/QubesOS/qubes-core-qrexec/pull/230

Fixes QubesOS/qubes-issues#10855