### PR TITLE
Add dependencies for 'column' tool

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -33,6 +33,7 @@ Depends:
  qubes-rpm-oxide (>= 0.2.3),
  python3-xlib,
  qubes-core-qrexec (>= 4.4.2),
+ bsdextrautils,
  ${python:Depends},
  ${python3:Depends},
  ${misc:Depends},

--- a/rpm_spec/qubes-core-admin-client.spec.in
+++ b/rpm_spec/qubes-core-admin-client.spec.in
@@ -29,6 +29,8 @@ Requires:   zstd
 Requires:   qubes-rpm-oxide >= 0.2.3
 Requires:   xrandr
 Requires:   qubes-core-qrexec >= 4.4.2
+# for column
+Requires:   util-linux
 
 BuildArch:  noarch
 


### PR DESCRIPTION
Needed for qvm-ls. It's in util-linux on Fedora and bsdextrautils in
Debian.

Fixes QubesOS/qubes-issues#10967
