### PR TITLE
Fix warnings during Sphinx build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -131,6 +131,9 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 
+autodoc_mock_imports = [
+    'rpm',
+]
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -172,7 +172,7 @@ html_theme = 'nature'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/doc/manpages/qvm-firewall.rst
+++ b/doc/manpages/qvm-firewall.rst
@@ -49,7 +49,7 @@ Available actions:
 
 * add - add specified rule. See `Rule syntax` section below.
 
-* del - delete specified rule. The rule to remove can be selected either by rule number using :option:`--rule-no`
+* del - delete specified rule. The rule to remove can be selected either by rule number using ``--rule-no``
   or by specifying the rule itself using the same syntax used for adding it.
 
 * list - list all the rules for a given VM.

--- a/doc/manpages/qvm-ls.rst
+++ b/doc/manpages/qvm-ls.rst
@@ -1,7 +1,7 @@
 .. program:: qvm-ls
 
 :program:`qvm-ls` -- List qubes and various information about them
-================================================================
+==================================================================
 
 Synopsis
 --------

--- a/qubesadmin/storage.py
+++ b/qubesadmin/storage.py
@@ -250,7 +250,7 @@ class Volume:
 
     def is_outdated(self) -> bool:
         """Returns `True` if this snapshot of a source volume (for
-        `snap_on_start`=True) is outdated.
+        `snap_on_start` = True) is outdated.
         """
         try:
             self._fetch_info()

--- a/qubesadmin/tools/dochelpers.py
+++ b/qubesadmin/tools/dochelpers.py
@@ -231,9 +231,14 @@ class ManpageCheckVisitor(docutils.nodes.SparseNodeVisitor):
     def __init__(self, app, command, document):
         docutils.nodes.SparseNodeVisitor.__init__(self, document)
         try:
-            parser = qubesadmin.tools.get_parser_for_command(command)
+            if command == "qvm-start-gui":
+                parser = qubesadmin.tools.get_parser_for_command(
+                    "qvm-start-daemon"
+                )
+            else:
+                parser = qubesadmin.tools.get_parser_for_command(command)
         except ImportError:
-            msg = 'cannot import module for command'
+            msg = f"cannot import module for command '{command}'"
             if log:
                 log.warning(msg)
 
@@ -288,7 +293,7 @@ def check_man_args(app, doctree, docname):
         options.
     """
     dirname, command = os.path.split(docname)
-    if os.path.basename(dirname) != 'manpages':
+    if os.path.basename(dirname) != "manpages" or command == "index":
         return
 
     msg = 'Checking arguments for {!r}'.format(command)

--- a/qubesadmin/tools/qvm_template.py
+++ b/qubesadmin/tools/qvm_template.py
@@ -959,7 +959,7 @@ def download(
         ``args``.  Optional
     :param version_selector: Specify algorithm to select the candidate version
         of a package.  Defaults to ``VersionSelector.LATEST``
-    :return package headers of downloaded templates
+    :return: package headers of downloaded templates
     """
     if dl_list is None:
         dl_list = get_dl_list(args, app, version_selector=version_selector)


### PR DESCRIPTION
* Fix Sphinx and rST formatting issues
* Checking manpage commands ignore index.rst files, provide the command name if a warning is raised and convert `qvm-start-gui` to the appropriate `qvm-start-daemon`

Related issue: https://github.com/QubesOS/qubes-issues/issues/10970