### PR TITLE
Fix build on Fedora 45

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PIP ?= pip3
 
 .PHONY: build
 build:
-    # --no-isolation to use distro packages instead of downloading missing ones
+	# --no-isolation to use distro packages instead of downloading missing ones
 	$(PYTHON) -m build --no-isolation
 
 .PHONY: install-misc

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -137,7 +137,7 @@ autodoc_mock_imports = [
 ]
 
 intersphinx_mapping = {
-    'python': ('http://docs.python.org/', None),
+    'python': ('https://docs.python.org/', None),
     'qubes-doc': ('https://doc.qubes-os.org/en/latest/', None),
     'core-admin': ('https://doc.qubes-os.org/projects/core-admin/en/latest/', None),
     'core-qrexec': ('https://doc.qubes-os.org/projects/core-qrexec/en/latest/', None),

--- a/qubesadmin/tools/__init__.py
+++ b/qubesadmin/tools/__init__.py
@@ -361,10 +361,20 @@ class QubesArgumentParser(argparse.ArgumentParser):
         if version is not None:
             self.version = version
         else:
-            _metadata_ = importlib.metadata.metadata('qubesadmin')
-            self.version = '{} ({}) {}'.format(os.path.basename(sys.argv[0]), \
-                _metadata_['summary'], _metadata_['version'])
-            self.version += '\nCopyright (C) {}'.format(_metadata_['author'])
+            _metadata_ = importlib.metadata.metadata("qubesadmin")
+            self.version = "{} ({}) {}".format(
+                os.path.basename(sys.argv[0]),
+                _metadata_["summary"],
+                _metadata_["version"],
+            )
+            if "author" in _metadata_:
+                self.version += "\nCopyright (C) {}".format(
+                    _metadata_["author"]
+                )
+            else:
+                self.version += "\nCopyright (C) {}".format(
+                    _metadata_["Author-email"]
+                )
             self.version += '\nLicense: {}'.format(_metadata_['license'])
         if self.version != '':
             self.add_argument('--version', action='version')


### PR DESCRIPTION

- **Adjust man page generation to updated setuptools**
  Looks like setuptools 82 (or something else in Fedora 45?) uses
  different entry names in the modules metadata. Old one has separate
  'author' (having author name), and 'author_email' (having just email
  address); New setuptools use 'Author-email' field with both combined.
  
  QubesOS/qubes-issues#11018
  
- **Fix indentation in the makefile**
  It needs to be tabs, not spaces.
  