### PR TITLE
Add standalone disposable template to mock_app

### DIFF
--- a/qubesadmin/tests/mock_app.py
+++ b/qubesadmin/tests/mock_app.py
@@ -1073,6 +1073,16 @@ class MockQubesComplete(MockQubes):
             running=True,
         )
 
+        self._qubes["test-std-dvm"] = MockQube(
+            name="test-std-dvm",
+            qapp=self,
+            klass="StandaloneVM",
+            template_for_dispvms=True,
+            template="fedora-36",
+            features={"appmenus-dispvm": "1"},
+            running=True,
+        )
+
         self._qubes["test-vm"] = MockQube(
             name="test-vm",
             qapp=self,


### PR DESCRIPTION
Helps test applications that tries to query different property set from the more common disposable template klass, AppVM. StandaloneVMs don't have "template" attribute for example.

For: https://github.com/QubesOS/qubes-desktop-linux-manager/pull/323