### PR TITLE
q-dev: expose device assignment modes

### DIFF
--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -226,6 +226,9 @@ class QubesBase(qubesadmin.base.PropertyHolder):
         )
         #: cache for available storage pool drivers and options to create them
         self._pool_drivers: dict[str, list[str]] | None = None
+        #: cache for per-deviceclass metadata
+        self._deviceclass_properties_cache: \
+            dict[DeviceClass, dict[str, str]] | None = None
         self.log = logging.getLogger("app")
         self._local_name = None
 
@@ -245,6 +248,37 @@ class QubesBase(qubesadmin.base.PropertyHolder):
         )
 
         return sorted(deviceclasses)
+
+    def deviceclass_properties(self) -> dict[DeviceClass, dict[str, str]]:
+        """Obtain per-device-class metadata.
+
+        Calls ``admin.deviceclass.List+details`` and parses each line of the
+        form ``<class> key=value [key=value ...]``.
+
+        Empty values may appear if a deviceclass does not support the details.
+        """
+        if self._deviceclass_properties_cache is not None:
+            return self._deviceclass_properties_cache
+        try:
+            raw = self.qubesd_call(
+                "dom0", "admin.deviceclass.List", "details"
+            ).decode()
+        except (qubesadmin.exc.QubesException, qubesadmin.exc.ProtocolError):
+            # older backend/extension
+            raw = self.qubesd_call(
+                "dom0", "admin.deviceclass.List"
+            ).decode()
+
+        result: dict[DeviceClass, dict[str, str]] = {}
+        for line in raw.splitlines():
+            name, _, rest = line.partition(" ")
+            props: dict[str, str] = {}
+            for token in rest.split():
+                key, _, value = token.partition("=")
+                props[key] = value
+            result[name] = props
+        self._deviceclass_properties_cache = result
+        return result
 
     def _refresh_pool_drivers(self) -> None:
         """
@@ -845,6 +879,7 @@ class QubesBase(qubesadmin.base.PropertyHolder):
             vm._properties_cache = {}
             vm.devices.clear_cache()
         self._properties_cache = {}
+        self._deviceclass_properties_cache = None
 
 
 class QubesLocal(QubesBase):

--- a/qubesadmin/device_protocol.py
+++ b/qubesadmin/device_protocol.py
@@ -892,8 +892,24 @@ class DeviceInterface:
         return True
 
 
+class AssignmentMode(Enum):
+    """
+    Device assignment modes
+    """
+
+    MANUAL = "manual"
+    ASK = "ask-to-attach"
+    AUTO = "auto-attach"
+    REQUIRED = "required"
+
+
 class DeviceInfo(VirtualDevice):
     """Holds all information about a device"""
+
+    # Subclasses should override this.
+    SUPPORTED_ASSIGNMENT_MODES: "frozenset[AssignmentMode]" = frozenset(
+        {AssignmentMode.ASK, AssignmentMode.AUTO}
+    )
 
     def __init__(
         self,
@@ -1217,17 +1233,6 @@ class UnknownDevice(DeviceInfo):
         Return `UnknownDevice` based on any virtual device.
         """
         return UnknownDevice(device.port, device_id=device.device_id)
-
-
-class AssignmentMode(Enum):
-    """
-    Device assignment modes
-    """
-
-    MANUAL = "manual"
-    ASK = "ask-to-attach"
-    AUTO = "auto-attach"
-    REQUIRED = "required"
 
 
 class DeviceAssignment:

--- a/qubesadmin/device_protocol.py
+++ b/qubesadmin/device_protocol.py
@@ -908,7 +908,7 @@ class DeviceInfo(VirtualDevice):
 
     # Subclasses should override this.
     SUPPORTED_ASSIGNMENT_MODES: "frozenset[AssignmentMode]" = frozenset(
-        {AssignmentMode.ASK, AssignmentMode.AUTO}
+        {AssignmentMode.MANUAL, AssignmentMode.ASK, AssignmentMode.AUTO}
     )
 
     def __init__(

--- a/qubesadmin/devices.py
+++ b/qubesadmin/devices.py
@@ -96,33 +96,49 @@ class DeviceCollection:
         self._remove(assignment, "detach")
         self._assignment_cache = None
 
+    def _supported_assignment_modes(
+        self,
+    ) -> "frozenset[AssignmentMode] | None":
+        """
+        Assignment modes allowed for this `deviceclass`.
+
+        Returns `None` when the information cannot be obtained;
+         the caller must then rely on backend-side validation.
+        """
+        try:
+            props = self._vm.app.deviceclass_properties().get(self._class, {})
+        except (qubesadmin.exc.QubesException, qubesadmin.exc.ProtocolError):
+            return None
+        raw = props.get("assignment_modes")
+        if not raw:
+            return None
+        try:
+            return frozenset(
+                AssignmentMode(value) for value in raw.split(",") if value
+            )
+        except ValueError:
+            return None
+
+    def _validate_assignment_mode(self, mode: AssignmentMode) -> None:
+        """
+        Raise a error if *mode* is not a valid one for this `deviceclass`.
+        """
+        supported = self._supported_assignment_modes()
+        if supported is None or mode in supported:
+            return
+        allowed = ", ".join(sorted(m.value for m in supported))
+        raise qubesadmin.exc.QubesValueError(
+            f"{self._class} devices do not support being assigned in "
+            f"'{mode.value}' mode; supported assignment mode(s): {allowed}."
+        )
+
     def assign(self, assignment: DeviceAssignment) -> None:
         """
         Assign device to domain (add to :file:`qubes.xml`).
 
         :param DeviceAssignment assignment: device object
         """
-        if (
-            assignment.devclass not in ("pci", "testclass", "block")
-            and assignment.required
-        ):
-            raise qubesadmin.exc.QubesValueError(
-                "Only pci and block devices can be assigned as required."
-            )
-        if assignment.devclass == "pci" and not assignment.required:
-            raise qubesadmin.exc.QubesValueError(
-                "PCI devices cannot be assigned as not required."
-            )
-        if (
-            assignment.devclass
-            not in ("testclass", "usb", "block", "mic", "pci")
-            and assignment.attach_automatically
-        ):
-            raise qubesadmin.exc.QubesValueError(
-                f"{assignment.devclass} devices cannot be assigned "
-                "to be automatically attached."
-            )
-
+        self._validate_assignment_mode(assignment.mode)
         self._add(assignment, "assign")
         # clear the whole cache instead of saving provided assignment, it might
         # get modified before actually assigning
@@ -282,6 +298,7 @@ class DeviceCollection:
                               `False` -> device will be auto-attached to qube
                               `True` -> device is required to start qube
         """
+        self._validate_assignment_mode(required)
         self._vm.qubesd_call(
             None,
             "admin.vm.device.{}.Set.assignment".format(self._class),

--- a/qubesadmin/devices.py
+++ b/qubesadmin/devices.py
@@ -76,10 +76,11 @@ class DeviceCollection:
 
         :param DeviceAssignment assignment: device object
         """
-        if assignment.devclass == "pci":
+        supported = self._supported_assignment_modes()
+        if supported is not None and AssignmentMode.MANUAL not in supported:
             raise qubesadmin.exc.QubesValueError(
-                "PCI devices cannot be attached manually, "
-                "did you mean `qvm-pci assign --required ...`"
+                f"{assignment.devclass} devices cannot be attached manually, "
+                f"did you mean `qvm-device {assignment.devclass} assign ...`"
             )
         self._add(assignment, "attach")
         # clear the whole cache instead of saving provided assignment, it might

--- a/qubesadmin/tests/__init__.py
+++ b/qubesadmin/tests/__init__.py
@@ -177,6 +177,9 @@ class QubesTest(qubesadmin.app.QubesBase):
 
     def __init__(self):
         super().__init__()
+        # set default to "nothing" so tests do not issue an unexpected
+        #  `admin.deviceclass.List+details` call.
+        self._deviceclass_properties_cache = {}
         #: expected Admin API calls and saved replies for them
         self.expected_calls = {}
         #: expected qrexec service calls and saved replies for them

--- a/qubesadmin/tests/backup/backupcompatibility.py
+++ b/qubesadmin/tests/backup/backupcompatibility.py
@@ -785,6 +785,11 @@ class AppProxy:
         self._delay_stream = delay_stream
         self.cache_enabled = False
 
+    def __getattr__(self, name):
+        if name == "_app":
+            raise AttributeError(name)
+        return getattr(self._app, name)
+
     def qubesd_call(self, dest, method, arg=None, payload=None,
             payload_stream=None):
         if payload_stream:

--- a/qubesadmin/tests/devices.py
+++ b/qubesadmin/tests/devices.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU Lesser General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=missing-docstring
+# pylint: disable=missing-docstring,protected-access
 
 from unittest import mock
 
@@ -331,13 +331,11 @@ class TC_00_DeviceCollection(qubesadmin.tests.QubesTestCase):
         self.assertEqual(devs[1].port_id, 'dev2')
         self.assertAllCalled()
 
-    _test_class_details = (
-        b'0\x00test assignment_modes=ask-to-attach,auto-attach,required\n')
+    _test_class_modes = {
+        'test': {'assignment_modes': 'ask-to-attach,auto-attach,required'}}
 
     def test_070_update_assignment_required(self):
-        self.app.expected_calls[
-            ('dom0', 'admin.deviceclass.List', 'details', None)] = \
-            self._test_class_details
+        self.app._deviceclass_properties_cache = dict(self._test_class_modes)
         self.app.expected_calls[
             ('test-vm', 'admin.vm.device.test.Set.assignment',
              'test-vm2+dev1+_', b'required')] = b'0\0'
@@ -347,9 +345,7 @@ class TC_00_DeviceCollection(qubesadmin.tests.QubesTestCase):
         self.assertAllCalled()
 
     def test_071_update_assignment_ask(self):
-        self.app.expected_calls[
-            ('dom0', 'admin.deviceclass.List', 'details', None)] = \
-            self._test_class_details
+        self.app._deviceclass_properties_cache = dict(self._test_class_modes)
         self.app.expected_calls[
             ('test-vm', 'admin.vm.device.test.Set.assignment',
              'test-vm2+dev1+_', b'ask-to-attach')] = b'0\0'
@@ -359,9 +355,7 @@ class TC_00_DeviceCollection(qubesadmin.tests.QubesTestCase):
         self.assertAllCalled()
 
     def test_072_update_assignment_auto(self):
-        self.app.expected_calls[
-            ('dom0', 'admin.deviceclass.List', 'details', None)] = \
-            self._test_class_details
+        self.app._deviceclass_properties_cache = dict(self._test_class_modes)
         self.app.expected_calls[
             ('test-vm', 'admin.vm.device.test.Set.assignment',
              'test-vm2+dev1+_', b'auto-attach')] = b'0\0'
@@ -381,6 +375,8 @@ class TC_00_DeviceCollection(qubesadmin.tests.QubesTestCase):
         self.assertEqual(seen, {'block', 'mic', 'usb'})
 
     def test_074_deviceclass_properties(self):
+        # force a fetch
+        self.app._deviceclass_properties_cache = None
         self.app.expected_calls[
             ('dom0', 'admin.deviceclass.List', 'details', None)] = (
             b'0\x00pci assignment_modes=required\n'
@@ -397,6 +393,8 @@ class TC_00_DeviceCollection(qubesadmin.tests.QubesTestCase):
             {'assignment_modes': 'ask-to-attach,auto-attach,required'})
 
     def test_075_deviceclass_properties_none(self):
+        # force a fetch
+        self.app._deviceclass_properties_cache = None
         self.app.expected_calls[
             ('dom0', 'admin.deviceclass.List', 'details', None)] = (
             b"2\x00ProtocolError\x00\x00unexpected argument\x00\x00")
@@ -408,9 +406,8 @@ class TC_00_DeviceCollection(qubesadmin.tests.QubesTestCase):
         self.assertEqual(props, {'pci': {}, 'block': {}, 'usb': {}})
 
     def test_076_assign_unsupported_mode_rejected(self):
-        self.app.expected_calls[
-            ('dom0', 'admin.deviceclass.List', 'details', None)] = (
-            b'0\x00test assignment_modes=ask-to-attach,auto-attach\n')
+        self.app._deviceclass_properties_cache = {
+            'test': {'assignment_modes': 'ask-to-attach,auto-attach'}}
         assign = DeviceAssignment.new(
             self.app.domains['test-vm2'], 'dev1', devclass='test',
             mode='required')
@@ -420,9 +417,9 @@ class TC_00_DeviceCollection(qubesadmin.tests.QubesTestCase):
         self.assertIn('ask-to-attach, auto-attach', str(exc.exception))
 
     def test_077_assign_supported_mode_passes(self):
-        self.app.expected_calls[
-            ('dom0', 'admin.deviceclass.List', 'details', None)] = (
-            b'0\x00test assignment_modes=ask-to-attach,auto-attach,required\n')
+        self.app._deviceclass_properties_cache = {
+            'test': {
+                'assignment_modes': 'ask-to-attach,auto-attach,required'}}
         self.app.expected_calls[
             ('test-vm', 'admin.vm.device.test.Assign', 'test-vm2+dev1+_',
              b"device_id='*' port_id='dev1' devclass='test' "
@@ -435,6 +432,8 @@ class TC_00_DeviceCollection(qubesadmin.tests.QubesTestCase):
         self.assertAllCalled()
 
     def test_078_assign_old_backend_skips_validation(self):
+        # force a fetch
+        self.app._deviceclass_properties_cache = None
         self.app.expected_calls[
             ('dom0', 'admin.deviceclass.List', 'details', None)] = (
             b"2\x00ProtocolError\x00\x00unexpected argument\x00\x00")
@@ -453,9 +452,8 @@ class TC_00_DeviceCollection(qubesadmin.tests.QubesTestCase):
         self.assertAllCalled()
 
     def test_079_update_assignment_unsupported_mode_rejected(self):
-        self.app.expected_calls[
-            ('dom0', 'admin.deviceclass.List', 'details', None)] = (
-            b'0\x00test assignment_modes=ask-to-attach,auto-attach\n')
+        self.app._deviceclass_properties_cache = {
+            'test': {'assignment_modes': 'ask-to-attach,auto-attach'}}
         dev = DeviceAssignment.new(
             self.app.domains['test-vm2'], devclass='test', port_id='dev1')
         with self.assertRaises(qubesadmin.exc.QubesValueError) as exc:

--- a/qubesadmin/tests/devices.py
+++ b/qubesadmin/tests/devices.py
@@ -167,6 +167,16 @@ class TC_00_DeviceCollection(qubesadmin.tests.QubesTestCase):
         self.vm.devices['test'].attach(assign)
         self.assertAllCalled()
 
+    def test_024_attach_manual_not_supported(self):
+        self.app._deviceclass_properties_cache = {
+            'test': {'assignment_modes': 'required'}}
+        assign = DeviceAssignment.new(
+            self.app.domains['test-vm2'], 'dev1', devclass='test',
+            mode='required')
+        with self.assertRaises(qubesadmin.exc.QubesValueError) as exc:
+            self.vm.devices['test'].attach(assign)
+        self.assertIn('cannot be attached manually', str(exc.exception))
+
     def test_030_detach(self):
         self.app.expected_calls[
             ('test-vm', 'admin.vm.device.test.Detach', 'test-vm2+dev1+_',

--- a/qubesadmin/tests/devices.py
+++ b/qubesadmin/tests/devices.py
@@ -331,7 +331,13 @@ class TC_00_DeviceCollection(qubesadmin.tests.QubesTestCase):
         self.assertEqual(devs[1].port_id, 'dev2')
         self.assertAllCalled()
 
+    _test_class_details = (
+        b'0\x00test assignment_modes=ask-to-attach,auto-attach,required\n')
+
     def test_070_update_assignment_required(self):
+        self.app.expected_calls[
+            ('dom0', 'admin.deviceclass.List', 'details', None)] = \
+            self._test_class_details
         self.app.expected_calls[
             ('test-vm', 'admin.vm.device.test.Set.assignment',
              'test-vm2+dev1+_', b'required')] = b'0\0'
@@ -342,6 +348,9 @@ class TC_00_DeviceCollection(qubesadmin.tests.QubesTestCase):
 
     def test_071_update_assignment_ask(self):
         self.app.expected_calls[
+            ('dom0', 'admin.deviceclass.List', 'details', None)] = \
+            self._test_class_details
+        self.app.expected_calls[
             ('test-vm', 'admin.vm.device.test.Set.assignment',
              'test-vm2+dev1+_', b'ask-to-attach')] = b'0\0'
         dev = DeviceAssignment.new(
@@ -350,6 +359,9 @@ class TC_00_DeviceCollection(qubesadmin.tests.QubesTestCase):
         self.assertAllCalled()
 
     def test_072_update_assignment_auto(self):
+        self.app.expected_calls[
+            ('dom0', 'admin.deviceclass.List', 'details', None)] = \
+            self._test_class_details
         self.app.expected_calls[
             ('test-vm', 'admin.vm.device.test.Set.assignment',
              'test-vm2+dev1+_', b'auto-attach')] = b'0\0'
@@ -367,6 +379,90 @@ class TC_00_DeviceCollection(qubesadmin.tests.QubesTestCase):
             self.assertNotIn(devclass, seen)
             seen.add(devclass)
         self.assertEqual(seen, {'block', 'mic', 'usb'})
+
+    def test_074_deviceclass_properties(self):
+        self.app.expected_calls[
+            ('dom0', 'admin.deviceclass.List', 'details', None)] = (
+            b'0\x00pci assignment_modes=required\n'
+            b'block assignment_modes=ask-to-attach,auto-attach,required\n'
+            b'usb assignment_modes=ask-to-attach,auto-attach\n')
+        props = self.app.deviceclass_properties()
+        self.assertEqual(
+            props['pci'], {'assignment_modes': 'required'})
+        self.assertEqual(
+            props['usb'],
+            {'assignment_modes': 'ask-to-attach,auto-attach'})
+        self.assertEqual(
+            props['block'],
+            {'assignment_modes': 'ask-to-attach,auto-attach,required'})
+
+    def test_075_deviceclass_properties_none(self):
+        self.app.expected_calls[
+            ('dom0', 'admin.deviceclass.List', 'details', None)] = (
+            b"2\x00ProtocolError\x00\x00unexpected argument\x00\x00")
+        self.app.expected_calls[
+            ('dom0', 'admin.deviceclass.List', None, None)] = \
+            b'0\x00pci\nblock\nusb\n'
+        props = self.app.deviceclass_properties()
+        # deviceclasses are still listed
+        self.assertEqual(props, {'pci': {}, 'block': {}, 'usb': {}})
+
+    def test_076_assign_unsupported_mode_rejected(self):
+        self.app.expected_calls[
+            ('dom0', 'admin.deviceclass.List', 'details', None)] = (
+            b'0\x00test assignment_modes=ask-to-attach,auto-attach\n')
+        assign = DeviceAssignment.new(
+            self.app.domains['test-vm2'], 'dev1', devclass='test',
+            mode='required')
+        with self.assertRaises(qubesadmin.exc.QubesValueError) as exc:
+            self.vm.devices['test'].assign(assign)
+        self.assertIn('required', str(exc.exception))
+        self.assertIn('ask-to-attach, auto-attach', str(exc.exception))
+
+    def test_077_assign_supported_mode_passes(self):
+        self.app.expected_calls[
+            ('dom0', 'admin.deviceclass.List', 'details', None)] = (
+            b'0\x00test assignment_modes=ask-to-attach,auto-attach,required\n')
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.device.test.Assign', 'test-vm2+dev1+_',
+             b"device_id='*' port_id='dev1' devclass='test' "
+             b"backend_domain='test-vm2' mode='required' "
+             b"frontend_domain='test-vm'")] = b'0\0'
+        assign = DeviceAssignment.new(
+            self.app.domains['test-vm2'], 'dev1', devclass='test',
+            mode='required')
+        self.vm.devices['test'].assign(assign)
+        self.assertAllCalled()
+
+    def test_078_assign_old_backend_skips_validation(self):
+        self.app.expected_calls[
+            ('dom0', 'admin.deviceclass.List', 'details', None)] = (
+            b"2\x00ProtocolError\x00\x00unexpected argument\x00\x00")
+        self.app.expected_calls[
+            ('dom0', 'admin.deviceclass.List', None, None)] = \
+            b'0\x00test\n'
+        self.app.expected_calls[
+            ('test-vm', 'admin.vm.device.test.Assign', 'test-vm2+dev1+_',
+             b"device_id='*' port_id='dev1' devclass='test' "
+             b"backend_domain='test-vm2' mode='required' "
+             b"frontend_domain='test-vm'")] = b'0\0'
+        assign = DeviceAssignment.new(
+            self.app.domains['test-vm2'], 'dev1', devclass='test',
+            mode='required')
+        self.vm.devices['test'].assign(assign)
+        self.assertAllCalled()
+
+    def test_079_update_assignment_unsupported_mode_rejected(self):
+        self.app.expected_calls[
+            ('dom0', 'admin.deviceclass.List', 'details', None)] = (
+            b'0\x00test assignment_modes=ask-to-attach,auto-attach\n')
+        dev = DeviceAssignment.new(
+            self.app.domains['test-vm2'], devclass='test', port_id='dev1')
+        with self.assertRaises(qubesadmin.exc.QubesValueError) as exc:
+            self.vm.devices['test'].update_assignment(
+                dev, AssignmentMode.REQUIRED)
+        self.assertIn('required', str(exc.exception))
+        self.assertIn('ask-to-attach, auto-attach', str(exc.exception))
 
     def test_080_add_denied_device(self):
         self.app.expected_calls[

--- a/qubesadmin/tests/tools/qvm_device.py
+++ b/qubesadmin/tests/tools/qvm_device.py
@@ -54,6 +54,10 @@ class TC_00_qvm_device(qubesadmin.tests.QubesTestCase):
             b"interfaces='u012345' product='test-device' "
             b"backend_domain='test-vm1'"
         )
+        # preset so `assign` does not issue an extra qubesd call
+        self.app._deviceclass_properties_cache = {
+            'testclass': {
+                'assignment_modes': 'ask-to-attach,auto-attach,required'}}
         self.vm1 = self.app.domains['test-vm1']
         self.vm2 = self.app.domains['test-vm2']
         self.vm1_device = \

--- a/qubesadmin/tests/tools/qvm_device.py
+++ b/qubesadmin/tests/tools/qvm_device.py
@@ -54,10 +54,11 @@ class TC_00_qvm_device(qubesadmin.tests.QubesTestCase):
             b"interfaces='u012345' product='test-device' "
             b"backend_domain='test-vm1'"
         )
-        # preset so `assign` does not issue an extra qubesd call
+        # preset so `assign`/`attach` do not issue an extra qubesd call
         self.app._deviceclass_properties_cache = {
             'testclass': {
-                'assignment_modes': 'ask-to-attach,auto-attach,required'}}
+                'assignment_modes':
+                    'manual,ask-to-attach,auto-attach,required'}}
         self.vm1 = self.app.domains['test-vm1']
         self.vm2 = self.app.domains['test-vm2']
         self.vm1_device = \


### PR DESCRIPTION
Until now, the available assignment modes were hidden in code without an endpoint in the API.

requires: QubesOS/qubes-core-admin/pull/857