### PR TITLE
Fix man page about qvm-run --gui and --no-gui

### DIFF
--- a/doc/manpages/qvm-run.rst
+++ b/doc/manpages/qvm-run.rst
@@ -80,13 +80,16 @@ Options
 
 .. option:: --gui
 
-   Run the command with GUI forwarding enabled, which is the default. This
-   switch can be used to counter :option:`--no-gui`.
+   Wait for the qube's GUI session to be ready before running the command.
+   This is the default when ``DISPLAY`` is set, the qube has a ``guivm``
+   property and its ``gui`` feature is enabled. For DisposableVMs, the
+   command is then started once the GUI session is ready. This switch can be
+   used to counter :option:`--no-gui`.
 
 .. option:: --no-gui, --nogui
 
-   Run the command without GUI forwarding enabled. Can be switched back with
-   :option:`--gui`.
+   Do not wait for the qube's GUI session to be ready; run the command
+   immediately. Can be switched back with :option:`--gui`.
 
 .. option:: --service
 


### PR DESCRIPTION
Per https://github.com/QubesOS/qubes-issues/issues/9181, --gui/--no-gui do not control GUI forwarding. They control whether qvm-run waits for the qube's GUI session to start before running the command (and which RPC service is used for DisposableVMs). Update the man page to describe the actual behavior. Still affects 4.3.