### PR TITLE
Don't let qvm-prefs access computed properties

### DIFF
--- a/qubesadmin/tests/tools/qvm_prefs.py
+++ b/qubesadmin/tests/tools/qvm_prefs.py
@@ -181,3 +181,18 @@ class TC_00_qvm_prefs(qubesadmin.tests.QubesTestCase):
                                             app=self.app)
         self.assertEqual('', stdout.getvalue())
         self.assertAllCalled()
+
+    def test_010_computed_property(self):
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.List', None, None)] = \
+            b'0\x00dom0 class=AdminVM state=Running\n'
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.property.List', None, None)] = \
+            b'0\x00prop1\nprop2\n'
+        with self.assertRaises(SystemExit):
+            with qubesadmin.tests.tools.StderrBuffer() as stderr:
+                qubesadmin.tools.qvm_prefs.main([
+                    'dom0', 'derived_vms'], app=self.app)
+        self.assertIn('no such property: \'derived_vms\'',
+            stderr.getvalue())
+        self.assertAllCalled()

--- a/qubesadmin/tools/qvm_prefs.py
+++ b/qubesadmin/tools/qvm_prefs.py
@@ -117,6 +117,12 @@ def process_actions(parser, args, target):
         return 0
     else:
         args.property = args.property.replace('-', '_')
+        # Some attributes are computed by this library instead of coming from
+        # the Admin API (derived_vms, appvms, methods...). Those are not
+        # properties, so reject them instead of letting getattr find them.
+        if hasattr(type(target), args.property) and \
+                args.property not in target.property_list():
+            parser.error('no such property: {!r}'.format(args.property))
 
     if args.value is not None:
         if str(args.value).lower() == "none":


### PR DESCRIPTION
`qvm-prefs somevm derived_vms` printed a list of raw QubesVM objects. `derived_vms` is computed in qubesadmin rather than being an Admin API property, so `getattr()` finds it on the class and `PropertyHolder.__getattr__` never gets a chance to reject it. Same story for `appvms`, `connected_vms` and the public methods.

Now a name that resolves to a class attribute is checked against `property_list()` and rejected with the usual "no such property" error if it is not in there. This covers get, set and `--default` in one place. `name` and other real properties that also live on the class still work, and ordinary properties never reach that branch, so there is no extra Admin API call in the common case.

Added `test_010_computed_property` to the existing qvm_prefs tests.

Fixes QubesOS/qubes-issues#10949