### PR TITLE
Reject usernames containing colon in run_service

### DIFF
--- a/qubesadmin/app.py
+++ b/qubesadmin/app.py
@@ -1016,6 +1016,8 @@ class QubesLocal(QubesBase):
             qrexec_opts.extend(["-l", localcmd])
         if user is None:
             user = "DEFAULT"
+        if ":" in user:
+            raise ValueError("Username in qrexec cannot contain a colon")
         if not wait:
             qrexec_opts.extend(["-e"])
         if prefix_data:

--- a/qubesadmin/tests/app.py
+++ b/qubesadmin/tests/app.py
@@ -1119,6 +1119,14 @@ class TC_20_QubesLocal(unittest.TestCase):
             self.get_request(), b"admin.vm.Start+ dom0 name some-vm\0"
         )
 
+    @mock.patch.object(sys, 'stderr')
+    @mock.patch('os.isatty', lambda fd: fd == 2)
+    def test_015_run_service_user_colon(self, mock_stderr):
+        mock_stderr.fileno.return_value = 2
+        self.listen_and_send(b'0\0')
+        with self.assertRaises(ValueError):
+            self.app.run_service('some-vm', 'service.name', user='a:b')
+
 
 class TC_30_QubesRemote(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#9154

## Problem
run_service() in qubesadmin/app.py builds the qrexec command as "{user}:QUBESRPC ..." without validating that user itself doesn't contain a ' : '. On the receiving end, parse_qubes_rpc_command() (qubes-core-qrexec/libqrexec/exec.c) splits on the first colon it finds, so a colon inside user gets misread as the delimiter silently truncating the username and misinterpreting the rest as part of the command.

## Fix
Added a check in run_service() that raises ValueError if user contains a ' : ' before user is used to build the command string.

## Testing
Added test_015_run_service_user_colon in qubesadmin/tests/app.py. Full suite: 63 passed, 1 pre-existing unrelated failure (test_014_run_service_prefix_data, fails identically on unmodified main appears to be an os.isatty mocking issue unrelated to this change).

### Notes 
I noticed parse_qubes_rpc_command() on the C side (qubes-core-qrexec) has no independent safeguard against this either. Happy to open that as a separate follow-up if useful, since fixing it here felt out of scope.

### Disclosure
This is my first contribution. I used Claude AI to help locate the relevant repositories and functions across qubes-core-admin-client and qubes-core-qrexec, and to review the fix and test before submitting. The fix, test, and verification are my own.