### PR TITLE
Execute backup even if summary is denied by qrexec

### DIFF
--- a/qubesadmin/tools/qvm_backup.py
+++ b/qubesadmin/tools/qvm_backup.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     have_events = False
 import qubesadmin.tools
-from qubesadmin.exc import QubesException
+from qubesadmin.exc import QubesException, QubesDaemonAccessError
 
 backup_profile_dir = '/etc/qubes/backup'
 
@@ -179,7 +179,9 @@ def main(args=None, app=None):
         print(backup_summary.decode())
     except QubesException as err:
         print('\nBackup preparation error: {}'.format(err), file=sys.stderr)
-        return 1
+        if not isinstance(err, QubesDaemonAccessError):
+            return 1
+        print('Skipping error as summary is not required to execute backup')
 
     if not args.yes:
         if input("Do you want to proceed? [y/N] ").upper() != "Y":


### PR DESCRIPTION
The summary might be denied in case the user didn't allow the call to avoid leaking more information about the backup than necessary. This can happen on non-dom0, where the caller doesn't have the backup passphrase or know about the included and excluded qubes, as some information can be only seen from dom0, such as the backup profile.

For: https://github.com/qubesos/qubes-issues/issues/11062