### PR TITLE
Fix ordering of dependent qube actions

### DIFF
--- a/qubesadmin/tests/tools/qvm_start.py
+++ b/qubesadmin/tests/tools/qvm_start.py
@@ -70,6 +70,64 @@ class TC_00_qvm_start(qubesadmin.tests.QubesTestCase):
             1)
         self.assertAllCalled()
 
+    def test_004_preflight_before_start(self):
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.List', None, None)] = \
+            b'0\x00some-vm class=AppVM state=Running\n' \
+            b'other-vm class=AppVM state=Running\n'
+        self.app.expected_calls[
+            ('some-vm', 'admin.vm.CurrentState', None, None)] = \
+            b'0\x00power_state=Running'
+        self.app.expected_calls[
+            ('other-vm', 'admin.vm.CurrentState', None, None)] = \
+            b'0\x00power_state=Halted'
+        self.app.expected_calls[
+            ('other-vm', 'admin.vm.Start', None, None)] = b'0\x00'
+
+        with qubesadmin.tests.tools.StderrBuffer() as stderr:
+            retcode = qubesadmin.tools.qvm_start.main(
+                ['some-vm', 'other-vm'], app=self.app
+            )
+
+        self.assertEqual(retcode, 1)
+        self.assertIn('some-vm: Domain is already running', stderr.getvalue())
+        start_indices = [
+            index for index, call in enumerate(self.app.actual_calls)
+            if call[1] == 'admin.vm.Start'
+        ]
+        self.assertEqual(len(start_indices), 1)
+        self.assertTrue(all(
+            call[1] == 'admin.vm.CurrentState'
+            for call in self.app.actual_calls[:start_indices[0]]
+            if call[0] in ('some-vm', 'other-vm')
+        ))
+        self.assertEqual(sum(
+            call[1] == 'admin.vm.CurrentState'
+            for call in self.app.actual_calls
+        ), 2)
+        self.assertAllCalled()
+
+    def test_005_skip_running_without_state_checks(self):
+        self.app.expected_calls[
+            ('dom0', 'admin.vm.List', None, None)] = \
+            b'0\x00some-vm class=AppVM state=Running\n' \
+            b'other-vm class=AppVM state=Running\n'
+        self.app.expected_calls[
+            ('some-vm', 'admin.vm.Start', None, None)] = b'0\x00'
+        self.app.expected_calls[
+            ('other-vm', 'admin.vm.Start', None, None)] = b'0\x00'
+
+        retcode = qubesadmin.tools.qvm_start.main(
+            ['--skip-if-running', 'some-vm', 'other-vm'], app=self.app
+        )
+
+        self.assertEqual(retcode, 0)
+        self.assertFalse(any(
+            call[1] == 'admin.vm.CurrentState'
+            for call in self.app.actual_calls
+        ))
+        self.assertAllCalled()
+
     def test_010_drive_cdrom(self):
         self.app.expected_calls[
             ('dom0', 'admin.vm.List', None, None)] = \

--- a/qubesadmin/tools/qvm_start.py
+++ b/qubesadmin/tools/qvm_start.py
@@ -77,22 +77,60 @@ parser_drive.add_argument(
 async def run_async(args=None, app=None):
     # pylint: disable=missing-function-docstring
     args = parser.parse_args(args, app=app)
+    exit_code = 0
+    preflight = len(args.domains) > 1 and not args.skip_if_running
+    if preflight:
+        check_tasks = [
+            asyncio.to_thread(qube.is_running) for qube in args.domains
+        ]
+        check_results = await asyncio.gather(
+            *check_tasks, return_exceptions=True
+        )
+        start_domains = []
+        for qube, is_running in zip(args.domains, check_results):
+            if isinstance(is_running, BaseException):
+                exit_code = 1
+                parser.print_error(
+                    "Starting qube failed: {}: {}".format(
+                        qube.name, str(is_running)
+                    )
+                )
+            elif is_running:
+                exit_code = 1
+                parser.print_error(
+                    "Starting qube failed: {}: Domain is already running"
+                    .format(qube.name)
+                )
+            else:
+                start_domains.append(qube)
+    else:
+        start_domains = args.domains
+
+    # The preflight above determines which qubes were running before this
+    # command. Without a drive, admin.vm.Start is a no-op if a dependency has
+    # started the qube in the meantime, so do not repeat the state request.
+    check_if_running = not (preflight or args.skip_if_running)
+    if args.drive:
+        # Avoid attaching a temporary drive to an already-running qube.
+        check_if_running = True
     tasks = [
         asyncio.to_thread(
             qubesadmin.utils.start_expert,
             domain=qube,
-            skip_if_running=args.skip_if_running,
+            skip_if_running=args.skip_if_running or preflight,
             drive=args.drive,
+            check_if_running=check_if_running,
         )
-        for qube in args.domains
+        for qube in start_domains
     ]
     results = await asyncio.gather(*tasks, return_exceptions=True)
-    exit_code = 0
-    for qube, res in zip(args.domains, results):
+    for qube, res in zip(start_domains, results):
         if isinstance(res, BaseException):
             exit_code = 1
             parser.print_error(
-                "Starting qube failed: {}: {}".format(qube.name, str(res))
+                "Starting qube failed: {}: {}".format(
+                    qube.name, str(res)
+                )
             )
     return exit_code
 

--- a/qubesadmin/utils/__init__.py
+++ b/qubesadmin/utils/__init__.py
@@ -488,12 +488,15 @@ def get_drive_assignment(app, drive_str):
 
 
 def start_expert(
-    domain, skip_if_running: bool = False, drive: str | None = None
+    domain,
+    skip_if_running: bool = False,
+    drive: str | None = None,
+    check_if_running: bool = True,
 ):
     """
-    Start the domain, optionally specifying a drive.
+    Start the domain, optionally specifying a drive and checking its state.
     """
-    if domain.is_running():
+    if check_if_running and domain.is_running():
         if skip_if_running:
             return
         raise QubesVMAlreadyStartedError("Domain is already running")


### PR DESCRIPTION
## Summary

Addresses the qvm-start portion of QubesOS/qubes-issues#10860.

When multiple qubes are requested, dependency auto-starts can change another requested qube's state before its concurrent start task checks it, causing a false "Domain is already running" error.

This change:

- preflights all requested qubes before starting any;
- reports already-running qubes unless `--skip-if-running` is used;
- starts only qubes halted during preflight;
- tolerates state changes caused by dependency auto-starts.

`qvm-shutdown` is intentionally unchanged. Its dependency checks occur server-side and cover audiovm, guivm, netvm, and assigned devices, so a client-side NetVM-only ordering fix would be incomplete.

## Testing

- 38 focused unit tests passed
- `python -m compileall -q qubesadmin`
- `git diff --check`

## AI assistance disclosure

This change was developed with assistance from OpenAI Codex. I reviewed and adapted the implementation and ran the test suite.