### PR TITLE
Optimize QubesVM._get_derived_vms()

### DIFF
--- a/qubesadmin/vm/__init__.py
+++ b/qubesadmin/vm/__init__.py
@@ -438,9 +438,28 @@ class QubesVM(qubesadmin.base.PropertyHolder):
         Return `set` of all domains based on the current TemplateVM
         at any level of inheritance.
         """
-        result = set(vm.appvms)
-        for appvm in vm.appvms:
-            result.update(QubesVM._get_derived_vms(appvm))
+        # first build a map of templates -> children
+        children = {}
+        for domain in vm.app.domains:
+            try:
+                template = domain.template
+            except AttributeError:
+                continue
+            if template in children:
+                children[template].append(domain)
+            else:
+                children[template] = [domain]
+
+        result = set()
+        pending = [vm]
+
+        # starting with this VM, go through its children and build out a list
+        while pending:
+            parent = pending.pop()
+            for child in children.get(parent, ()):
+                if child not in result:
+                    result.add(child)
+                    pending.append(child)
         return result
 
     @property


### PR DESCRIPTION
Instead of recursing in a way that effectively made it O(N^2), build the map of template -> children once, and then iterate over it, giving us effectively O(N) performance.

Fixes <https://github.com/QubesOS/qubes-issues/issues/11083>.

----

As mentioned in the issue, I used Claude Opus 5 to figure out this bug and then to write the initial patch, which I then cleaned up and rewrote the comments.