### PR TITLE
Fix validation typo on qvm_start_daemon.py

### DIFF
--- a/qubesadmin/tools/qvm_start_daemon.py
+++ b/qubesadmin/tools/qvm_start_daemon.py
@@ -111,7 +111,7 @@ def validator_color(color: str) -> bool:
 GUI_DAEMON_OPTIONS = [
     ("allow_fullscreen", "bool", (lambda x: isinstance(x, bool))),
     ("override_redirect_protection", "bool", (lambda x: isinstance(x, bool))),
-    ("override_redirect", "str", (lambda x: x in ["allow", "disable"])),
+    ("override_redirect", "str", (lambda x: x in ["allow", "disabled"])),
     ("allow_utf8_titles", "bool", (lambda x: isinstance(x, bool))),
     ("secure_copy_sequence", "str", validator_key_sequence),
     ("secure_paste_sequence", "str", validator_key_sequence),


### PR DESCRIPTION
Closes QubesOS/qubes-issues#11107

## Why I believe `disabled` is correct and `disable` is wrong

### `disabled` is hard coded in logic.

https://github.com/QubesOS/qubes-gui-daemon/blob/1fec627cf125f00d7fa31242895f98a87d31da7d/gui-daemon/xside.c#L4721

`disable` would cause `unsupported value 'disable' for override_redirect (must be 'disabled' or 'allow')` error

### documented in guid.conf

https://github.com/QubesOS/qubes-gui-daemon/blob/1fec627cf125f00d7fa31242895f98a87d31da7d/gui-daemon/guid.conf#L33

Therefore, I believe  `disable` is wrong.

## Use of AI

I used AI to investigate the cause of the problem I found on daily use of Qubes OS.
AI suggested me the fix, and I tried it myself on dom0.
Since this patch fixed my problem, I am submitting this.
None of the message nor the issue at https://github.com/QubesOS/qubes-issues/issues/11107 are written by AI.