### PR TITLE
tools/qvm-device: fix listing assignments with --resolve-paths

### DIFF
--- a/qubesadmin/tests/tools/qvm_device.py
+++ b/qubesadmin/tests/tools/qvm_device.py
@@ -211,6 +211,55 @@ class TC_00_qvm_device(qubesadmin.tests.QubesTestCase):
                 ],
             )
 
+    def test_005_list_assignments_pci_with_sbdf(self):
+        """
+        List PCI devices with SBDF info.
+        """
+        self.app.expected_calls[("dom0", "admin.vm.List", None, None)] = (
+            b"0\0dom0 class=AdminVM state=Running\n"
+            b"test-vm1 class=AppVM state=Running\n"
+        )
+        self.app.domains.clear_cache()
+        self.expected_device_call(
+            "dom0",
+            "Available",
+            b"0\00000_14.0:0x8086:0xa0ed::p0c0330 "
+            b"device_id='0x8086:0xa0ed::p0c0330' port_id='00_14.0' "
+            b"devclass='pci' backend_domain='dom0' product='p1' vendor='v' "
+            b"interfaces='p0c0330' _sbdf='0000:00:14.0'\n"
+            b"00_1d.0-00_00.0:0x8086:0x2725::p028000 "
+            b"device_id='0x8086:0x2725::p028000' port_id='00_1d.0-00_00.0' "
+            b"devclass='pci' backend_domain='dom0' product='p2' vendor='v' "
+            b"interfaces='p028000' _sbdf='0000:aa:00.0'\n",
+            klass="pci",
+        )
+        self.expected_device_call("dom0", "Attached", b"0\0", klass="pci")
+        self.expected_device_call("dom0", "Assigned", b"0\0", klass="pci")
+        self.expected_device_call("test-vm1", "Attached", b"0\0", klass="pci")
+        self.expected_device_call(
+            "test-vm1",
+            "Assigned",
+            b"0\000dom0+00_1d.0-00_00.0:* device_id='*' "
+            b"port_id='00_1d.0-00_00.0' devclass='pci' backend_domain='dom0' "
+            b"mode='required' frontend_domain='test-vm1' "
+            b"_no-strict-reset='True'\n",
+            klass="pci",
+        )
+
+        with qubesadmin.tests.tools.StdoutBuffer() as buf:
+            qubesadmin.tools.qvm_device.main(
+                ["pci", "list", "-s", "--with-sbdf", "dom0"], app=self.app
+            )
+            self.assertEqual(
+                [x.rstrip() for x in buf.getvalue().splitlines()],
+                [
+                    "dom0:00_14.0          0000:00:14.0  PCI_USB: v p1",
+                    "dom0:00_1d.0-00_00.0                any device   "
+                    "  *test-vm1 (required: no-strict-reset=True)",
+                    "dom0:00_1d.0-00_00.0  0000:aa:00.0  Network: v p2",
+                ],
+            )
+
     def test_010_attach(self):
         """ Test attach action """
         self.app.expected_calls[(

--- a/qubesadmin/tools/qvm_device.py
+++ b/qubesadmin/tools/qvm_device.py
@@ -93,7 +93,7 @@ class Line:
         self.description = device.description
         self.assignment = assignment
         self.frontends = []
-        self.sbdf = getattr(device, "data", {}).get("sbdf")
+        self.sbdf = getattr(device, "data", {}).get("sbdf", "")
 
     @property
     def assignments(self):


### PR DESCRIPTION
Assignments use virtual_device, which does not have data -> sbdf
attribute. Put empty string in that place, instead of None, to avoid
TypeError while sorting entries.

Fixes QubesOS/qubes-issues#10980
